### PR TITLE
Fix test failures.

### DIFF
--- a/java/src/phoenix/compile/ScanKey.java
+++ b/java/src/phoenix/compile/ScanKey.java
@@ -85,9 +85,11 @@ public class ScanKey {
         if (upperRange.length > 0) {
             byte[] stopKey = upperRange;
             if (upperInclusive) { 
-                // Adjust stop key since hbase is always non inclusive for stop key
+                // Adjust stop key since HBase is always non inclusive for stop key
                 try {
-                    stopKey = ByteUtil.nextKey(stopKey);
+                    if (upperInclusive) { 
+                        stopKey = ByteUtil.nextKey(stopKey);
+                    }
                     scan.setStopRow(stopKey);
                 } catch (ScanKeyOverflowException e) {
                     // We do not need to set stop key since the stop key already hits

--- a/java/src/phoenix/schema/ScanKeyOverflowException.java
+++ b/java/src/phoenix/schema/ScanKeyOverflowException.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
 package phoenix.schema;
 
 /**
@@ -21,6 +48,6 @@ public class ScanKeyOverflowException extends RuntimeException {
     }
 
     public ScanKeyOverflowException(String message, Throwable cause) {
-        super( message, cause);
+        super(message, cause);
     }
 }

--- a/test/unit/java/src/phoenix/util/ByteUtilTest.java
+++ b/test/unit/java/src/phoenix/util/ByteUtilTest.java
@@ -64,7 +64,7 @@ public class ByteUtilTest {
             key = new byte[] {(byte)255};
             ByteUtil.nextKey(key);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (ScanKeyOverflowException e) {
             assertTrue(e.getMessage().contains("Overflow trying to get next key"));
         }
     }


### PR DESCRIPTION
Fix test failures due to setScanKey not setting end key when comparison is not inclusive and some test not catching the right exception.
