### PR TITLE
Change parser to throw PhoenixParserException for all RuntimeException.

### DIFF
--- a/src/main/java/com/salesforce/phoenix/parse/SQLParser.java
+++ b/src/main/java/com/salesforce/phoenix/parse/SQLParser.java
@@ -92,7 +92,7 @@ public class SQLParser {
         } catch (UnsupportedOperationException e) {
             throw new SQLFeatureNotSupportedException(e);
         } catch (RuntimeException e) {
-            throw new SQLException(e);
+            throw new PhoenixParserException(e, parser);
         }
     }
 
@@ -108,10 +108,8 @@ public class SQLParser {
             throw new PhoenixParserException(e, parser);
         } catch (UnsupportedOperationException e) {
             throw new SQLFeatureNotSupportedException(e);
-        } catch (UnknownFunctionException e) {
-            throw new PhoenixParserException(e, parser);
         } catch (RuntimeException e) {
-            throw new SQLException(e);
+            throw new PhoenixParserException(e, parser);
         }
     }
 


### PR DESCRIPTION
Should be the last in the story. It occurs to me that the new ParserException can accept any RuntimeException. Change to use that class as the wrapper for all runtime exception caught during parse time.
