### PR TITLE
use assertArrayEquals(expected, actual) instead of assertTrue(Bytes.compareTo(actual, expected) == 0)

### DIFF
--- a/src/test/java/com/salesforce/phoenix/compile/LimitClauseTest.java
+++ b/src/test/java/com/salesforce/phoenix/compile/LimitClauseTest.java
@@ -74,8 +74,8 @@ public class LimitClauseTest extends BaseConnectionlessQueryTest {
         List<Object> binds = Collections.emptyList();
         Integer limit = compileStatement(query, binds, scan);
 
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
         assertEquals(limit,Integer.valueOf(5));
     }
 
@@ -88,8 +88,8 @@ public class LimitClauseTest extends BaseConnectionlessQueryTest {
         Integer limit = compileStatement(query, binds, scan);
 
         assertNull(limit);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
     }
     
     @Test
@@ -100,8 +100,8 @@ public class LimitClauseTest extends BaseConnectionlessQueryTest {
         List<Object> binds = Arrays.<Object>asList(5);
         Integer limit = compileStatement(query, binds, scan);
 
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
         assertEquals(limit,Integer.valueOf(5));
     }
 

--- a/src/test/java/com/salesforce/phoenix/compile/QueryCompileTest.java
+++ b/src/test/java/com/salesforce/phoenix/compile/QueryCompileTest.java
@@ -369,7 +369,7 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         Set<byte[]> projectedFamilies = scan.getFamilyMap().keySet();
         assertEquals(1, scan.getFamilyMap().values().size());
         // Empty column name
-        assertTrue(Bytes.compareTo(scan.getFamilyMap().values().iterator().next().iterator().next(), QueryConstants.EMPTY_COLUMN_BYTES) == 0);
+        assertArrayEquals(QueryConstants.EMPTY_COLUMN_BYTES, scan.getFamilyMap().values().iterator().next().iterator().next());
         assertEquals(1,projectedFamilies.size());
         // Empty column name should be in first column family
         assertTrue(projectedFamilies.contains(Bytes.toBytes(SchemaUtil.normalizeIdentifier("a"))));
@@ -386,7 +386,7 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         // Projects column family with not null column
         assertNull(scan.getFilter());
         assertEquals(1,scan.getFamilyMap().keySet().size());
-        assertTrue(Bytes.compareTo(Bytes.toBytes(SchemaUtil.normalizeIdentifier(QueryConstants.DEFAULT_COLUMN_FAMILY)),scan.getFamilyMap().keySet().iterator().next()) == 0);
+        assertArrayEquals(Bytes.toBytes(SchemaUtil.normalizeIdentifier(QueryConstants.DEFAULT_COLUMN_FAMILY)), scan.getFamilyMap().keySet().iterator().next());
     }
 
     @Test
@@ -398,7 +398,7 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         compileQuery(query, binds, scan);
         // Projects column family with not null column
         assertEquals(1,scan.getFamilyMap().keySet().size());
-        assertTrue(Bytes.compareTo(Bytes.toBytes(SchemaUtil.normalizeIdentifier(QueryConstants.DEFAULT_COLUMN_FAMILY)),scan.getFamilyMap().keySet().iterator().next()) == 0);
+        assertArrayEquals(Bytes.toBytes(SchemaUtil.normalizeIdentifier(QueryConstants.DEFAULT_COLUMN_FAMILY)), scan.getFamilyMap().keySet().iterator().next());
     }
 
     @Test
@@ -750,16 +750,16 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         List<Object> binds = Collections.emptyList();
         Scan scan = new Scan();
         compileQuery(query, binds, scan);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abc"), scan.getStartRow()) == 0);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abd"), scan.getStopRow()) == 0);
+        assertArrayEquals(Bytes.toBytes("abc"), scan.getStartRow());
+        assertArrayEquals(Bytes.toBytes("abd"), scan.getStopRow());
         assertTrue(scan.getFilter() != null);
 
         query = "SELECT host FROM ptsdb WHERE regexp_substr(inst, '[a-zA-Z]+', 0) = 'abc'";
         binds = Collections.emptyList();
         scan = new Scan();
         compileQuery(query, binds, scan);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abc"), scan.getStartRow()) == 0);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abd"), scan.getStopRow()) == 0);
+        assertArrayEquals(Bytes.toBytes("abc"), scan.getStartRow());
+        assertArrayEquals(Bytes.toBytes("abd"), scan.getStopRow());
         assertTrue(scan.getFilter() != null);
 
         // Test scan keys are not set when the offset is not 0 or 1.
@@ -847,8 +847,8 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         List<Object> binds = Collections.emptyList();
         Scan scan = new Scan();
         compileQuery(query, binds, scan);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abc"), scan.getStartRow()) == 0);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abd"), scan.getStopRow()) == 0);
+        assertArrayEquals(Bytes.toBytes("abc"), scan.getStartRow());
+        assertArrayEquals(Bytes.toBytes("abd"), scan.getStopRow());
         assertTrue(scan.getFilter() == null); // Extracted.
     }
 
@@ -858,8 +858,8 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
         List<Object> binds = Collections.emptyList();
         Scan scan = new Scan();
         compileQuery(query, binds, scan);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abc"), scan.getStartRow()) == 0);
-        assertTrue(Bytes.compareTo(Bytes.toBytes("abd"), scan.getStopRow()) == 0);
+        assertArrayEquals(Bytes.toBytes("abc"), scan.getStartRow());
+        assertArrayEquals(Bytes.toBytes("abd"), scan.getStopRow());
         assertTrue(scan.getFilter() != null);
     }
 }

--- a/src/test/java/com/salesforce/phoenix/compile/WhereClauseFilterTest.java
+++ b/src/test/java/com/salesforce/phoenix/compile/WhereClauseFilterTest.java
@@ -368,9 +368,9 @@ public class WhereClauseFilterTest extends BaseConnectionlessQueryTest {
         Filter filter = scan.getFilter();
         assertNull(filter);
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
     
     @Test
@@ -388,9 +388,9 @@ public class WhereClauseFilterTest extends BaseConnectionlessQueryTest {
         Filter filter = scan.getFilter();
         assertEquals(singleKVFilter(constantComparison(CompareOp.EQUAL, BaseConnectionlessQueryTest.A_INTEGER, 0)),filter);
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
     
     @Test
@@ -408,9 +408,9 @@ public class WhereClauseFilterTest extends BaseConnectionlessQueryTest {
         Filter filter = scan.getFilter();
         assertEquals(singleKVFilter(constantComparison(CompareOp.EQUAL, BaseConnectionlessQueryTest.A_INTEGER, 0)),filter);
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
     
     @Test
@@ -428,9 +428,9 @@ public class WhereClauseFilterTest extends BaseConnectionlessQueryTest {
         Filter filter = scan.getFilter();
         assertEquals(null,filter);
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
     
     @Test
@@ -446,9 +446,9 @@ public class WhereClauseFilterTest extends BaseConnectionlessQueryTest {
         StatementContext context = new StatementContext(pconn, resolver, binds, statement.getBindCount(), scan);
         statement = compileStatement(context, statement, resolver, binds, scan, 1, null);
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
 
         Filter filter = scan.getFilter();
         assertNotNull(filter);

--- a/src/test/java/com/salesforce/phoenix/compile/WhereClauseScanKeyTest.java
+++ b/src/test/java/com/salesforce/phoenix/compile/WhereClauseScanKeyTest.java
@@ -87,8 +87,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         compileStatement(query, scan, binds);
         
         assertNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
     }
 
     @Test
@@ -103,8 +103,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         compileStatement(query, scan, binds);
         
         assertNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes("EA")) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), PDataType.VARCHAR.toBytes("EZ")) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes("EA"), scan.getStartRow());
+        assertArrayEquals(PDataType.VARCHAR.toBytes("EZ"), scan.getStopRow());
     }
 
     @Test
@@ -157,8 +157,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         
         assertNull(scan.getFilter());
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -172,8 +172,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
         
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -188,8 +188,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
         
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(entityId));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -203,9 +203,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNotNull(scan.getFilter());
 
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId.substring(0,3));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = startRow;
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
 
     @Test
@@ -220,9 +220,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix1));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix2));
-        assertTrue(Bytes.compareTo(scan.getStopRow(), stopRow) == 0);
+        assertArrayEquals(stopRow, scan.getStopRow());
     }
 
     @Test
@@ -237,9 +237,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix1));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix2));
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
 
     @Test
@@ -254,9 +254,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix1));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix2));
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
 
     @Test
@@ -283,9 +283,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(entityId));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(entityId));
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
 
     @Test
@@ -312,9 +312,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix1),new byte[entityId.length() - keyPrefix1.length()]);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), stopRow) == 0);
+        assertArrayEquals(stopRow, scan.getStopRow());
     }
 
     @Test
@@ -329,9 +329,9 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNull(scan.getFilter());
 
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(entityId));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
         byte[] stopRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(entityId));
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(stopRow)) == 0);
+        assertArrayEquals(ByteUtil.nextKey(stopRow), scan.getStopRow());
     }
 
     /**
@@ -372,8 +372,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         compileStatement(query, scan, binds);
         
         assertNotNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
     }
 
     @Test
@@ -413,8 +413,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         compileStatement(query, scan, binds);
         
         assertNotNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), HConstants.EMPTY_END_ROW) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(HConstants.EMPTY_END_ROW, scan.getStopRow());
     }
 
     @Test
@@ -426,8 +426,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         compileStatement(query, scan, binds, 1000);
         
         assertNotNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(), PDataType.VARCHAR.toBytes(tenantId)) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId))) == 0);
+        assertArrayEquals(PDataType.VARCHAR.toBytes(tenantId), scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(PDataType.VARCHAR.toBytes(tenantId)), scan.getStopRow());
     }
     
 
@@ -455,8 +455,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         
         assertNull(scan.getFilter());
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -470,8 +470,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         
         assertNull(scan.getFilter());
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -498,8 +498,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNotNull(scan.getFilter());
         
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -516,8 +516,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertEquals(1, extractedNodes.size());
         
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -535,8 +535,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         
         
         byte[] startRow = ByteUtil.concat(PDataType.VARCHAR.toBytes(tenantId),PDataType.VARCHAR.toBytes(keyPrefix));
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -552,8 +552,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNotNull(scan.getFilter());
         assertEquals(1, extractedNodes.size());
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -669,8 +669,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNotNull(scan.getFilter());
         assertEquals(1, extractedNodes.size());
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
 
     @Test
@@ -686,8 +686,8 @@ public class WhereClauseScanKeyTest extends BaseConnectionlessQueryTest {
         assertNotNull(scan.getFilter());
         assertEquals(1, extractedNodes.size());
         byte[] startRow = PDataType.VARCHAR.toBytes(tenantId);
-        assertTrue(Bytes.compareTo(scan.getStartRow(), startRow) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(), ByteUtil.nextKey(startRow)) == 0);
+        assertArrayEquals(startRow, scan.getStartRow());
+        assertArrayEquals(ByteUtil.nextKey(startRow), scan.getStopRow());
     }
     /*
      * The following 5 tests are testing the comparison in where clauses under the case when the rhs

--- a/src/test/java/com/salesforce/phoenix/end2end/ParallelIteratorsTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/ParallelIteratorsTest.java
@@ -253,8 +253,8 @@ public class ParallelIteratorsTest extends BaseClientMangedTimeTest {
         byte[] minKey = stats.getMinKey(table);
         assertTrue(minKey == null);
         assertTrue(waitForAsyncChange(minKeyChange,waitTime));
-        assertTrue(Bytes.compareTo(KMIN, stats.getMinKey(table)) == 0);
-        assertTrue(Bytes.compareTo(KMAX, stats.getMaxKey(table)) == 0);
+        assertArrayEquals(KMIN, stats.getMinKey(table));
+        assertArrayEquals(KMAX, stats.getMaxKey(table));
         minKeyChange = new MinKeyChange(stats, table);
         
         String url = PHOENIX_JDBC_URL + ";" + PhoenixRuntime.CURRENT_SCN_ATTRIB + "=" + ts + 2;
@@ -272,18 +272,18 @@ public class ParallelIteratorsTest extends BaseClientMangedTimeTest {
         assertFalse(waitForAsyncChange(minKeyChange,waitTime)); // Stats won't change until they're attempted to be retrieved again
         timeKeeper.setCurrentTimeMillis(timeKeeper.currentTimeMillis() + updateFreq);
         minKeyChange = new MinKeyChange(stats, table); // Will kick off change, but will upate asynchronously
-        assertTrue(Bytes.compareTo(KMIN, minKeyChange.value) == 0);
+        assertArrayEquals(KMIN, minKeyChange.value);
         assertTrue(waitForAsyncChange(minKeyChange,waitTime));
-        assertTrue(Bytes.compareTo(KMIN2, stats.getMinKey(table)) == 0);
-        assertTrue(Bytes.compareTo(KMAX, stats.getMaxKey(table)) == 0);
+        assertArrayEquals(KMIN2, stats.getMinKey(table));
+        assertArrayEquals(KMAX, stats.getMaxKey(table));
         minKeyChange = new MinKeyChange(stats, table);
         
         timeKeeper.setCurrentTimeMillis(timeKeeper.currentTimeMillis() + maxAge);
         minKeyChange = new MinKeyChange(stats, table); // Will kick off change, but will upate asynchronously
         assertTrue(null == minKeyChange.value);
         assertTrue(waitForAsyncChange(minKeyChange,waitTime));
-        assertTrue(Bytes.compareTo(KMIN2, stats.getMinKey(table)) == 0);
-        assertTrue(Bytes.compareTo(KMAX, stats.getMaxKey(table)) == 0);
+        assertArrayEquals(KMIN2, stats.getMinKey(table));
+        assertArrayEquals(KMAX, stats.getMaxKey(table));
         minKeyChange = new MinKeyChange(stats, table);
         maxKeyChange = new MaxKeyChange(stats, table);
         
@@ -298,18 +298,18 @@ public class ParallelIteratorsTest extends BaseClientMangedTimeTest {
         assertFalse(waitForAsyncChange(maxKeyChange,waitTime)); // Stats won't change until they're attempted to be retrieved again
         timeKeeper.setCurrentTimeMillis(timeKeeper.currentTimeMillis() + updateFreq);
         maxKeyChange = new MaxKeyChange(stats, table); // Will kick off change, but will upate asynchronously
-        assertTrue(Bytes.compareTo(KMAX, maxKeyChange.value) == 0);
+        assertArrayEquals(KMAX, maxKeyChange.value);
         assertTrue(waitForAsyncChange(maxKeyChange,waitTime));
-        assertTrue(Bytes.compareTo(KMAX2, stats.getMaxKey(table)) == 0);
-        assertTrue(Bytes.compareTo(KMIN2, stats.getMinKey(table)) == 0);
+        assertArrayEquals(KMAX2, stats.getMaxKey(table));
+        assertArrayEquals(KMIN2, stats.getMinKey(table));
         maxKeyChange = new MaxKeyChange(stats, table);
         
         timeKeeper.setCurrentTimeMillis(timeKeeper.currentTimeMillis() + maxAge);
         maxKeyChange = new MaxKeyChange(stats, table); // Will kick off change, but will upate asynchronously
         assertTrue(null == maxKeyChange.value);
         assertTrue(waitForAsyncChange(maxKeyChange,waitTime));
-        assertTrue(Bytes.compareTo(KMIN2, stats.getMinKey(table)) == 0);
-        assertTrue(Bytes.compareTo(KMAX2, stats.getMaxKey(table)) == 0);
+        assertArrayEquals(KMIN2, stats.getMinKey(table));
+        assertArrayEquals(KMAX2, stats.getMaxKey(table));
     }
 
     private static KeyRange newKeyRange(byte[] lowerRange, byte[] upperRange) {

--- a/src/test/java/com/salesforce/phoenix/util/ByteUtilTest.java
+++ b/src/test/java/com/salesforce/phoenix/util/ByteUtilTest.java
@@ -67,11 +67,11 @@ public class ByteUtilTest {
         key = new byte[] {1, (byte)255};
         byte[] nextKey = ByteUtil.nextKey(key);
         byte[] expectedKey = new byte[] {2,(byte)0};
-        assertTrue(Bytes.compareTo(expectedKey, nextKey) == 0); 
+        assertArrayEquals(expectedKey, nextKey); 
         key = ByteUtil.concat(Bytes.toBytes("00D300000000XHP"), PDataType.INTEGER.toBytes(Integer.MAX_VALUE));
         nextKey = ByteUtil.nextKey(key);
         expectedKey = ByteUtil.concat(Bytes.toBytes("00D300000000XHQ"), PDataType.INTEGER.toBytes(Integer.MIN_VALUE));
-        assertTrue(Bytes.compareTo(expectedKey, nextKey) == 0);
+        assertArrayEquals(expectedKey, nextKey);
         
         try {
             key = new byte[] {(byte)255};

--- a/src/test/java/com/salesforce/phoenix/util/TestUtil.java
+++ b/src/test/java/com/salesforce/phoenix/util/TestUtil.java
@@ -185,15 +185,15 @@ public class TestUtil {
     
     public static void assertDegenerate(Scan scan) {
         assertNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(),KeyRange.EMPTY_RANGE.getLowerRange()) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(),KeyRange.EMPTY_RANGE.getLowerRange()) == 0);
+        assertArrayEquals(KeyRange.EMPTY_RANGE.getLowerRange(), scan.getStartRow());
+        assertArrayEquals(KeyRange.EMPTY_RANGE.getLowerRange(), scan.getStopRow());
         assertEquals(null,scan.getFilter());
     }
     
     public static void assertEmptyScanKey(Scan scan) {
         assertNull(scan.getFilter());
-        assertTrue(Bytes.compareTo(scan.getStartRow(),ByteUtil.EMPTY_BYTE_ARRAY) == 0);
-        assertTrue(Bytes.compareTo(scan.getStopRow(),ByteUtil.EMPTY_BYTE_ARRAY) == 0);
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, scan.getStartRow());
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, scan.getStopRow());
         assertEquals(null,scan.getFilter());
     }
     


### PR DESCRIPTION
I did the change using regex search and replace, and tests pass.

My hope is that tests will be easier to read, assuming you weren't calling Bytes.compareTo for some special magic.
