### PR TITLE
fix regression if first operand of inlist is a function

### DIFF
--- a/src/main/java/com/salesforce/phoenix/compile/WhereOptimizer.java
+++ b/src/main/java/com/salesforce/phoenix/compile/WhereOptimizer.java
@@ -568,13 +568,17 @@ public class WhereOptimizer {
             if (childKeyExprs.isEmpty()) {
                 return null;
             }
-
             List<byte[]> keys = node.getKeys();
             List<KeyRange> ranges = KeyRange.of(keys);
             KeyPart colKeyExpr = childKeyExprs.get(0).iterator().next().getKeyPart();
+
             if (ranges.size() > 0) {
-                if (ranges.get(0).lowerUnbound() || ranges.get(ranges.size() - 1).upperUnbound()) {
+                if (ranges.get(0).lowerUnbound()
+                    || ranges.get(ranges.size() - 1).upperUnbound()
+                    || !(node.getChild() instanceof RowKeyColumnExpression))
+                {
                     // unbound?  punt.  TODO optimize SkipScanFilter
+                    // TODO: nothing fancy on the left side of the IN operator
                     ImmutableBytesWritable minKey = node.getMinKey();
                     ImmutableBytesWritable maxKey = node.getMaxKey();
                     // TODO: make key range backed by ImmutableBytesWritable to prevent copy?

--- a/src/test/java/com/salesforce/phoenix/end2end/QueryPlanTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/QueryPlanTest.java
@@ -56,7 +56,8 @@ public class QueryPlanTest extends BaseConnectedQueryTest {
                 "CLIENT SERIAL FULL SCAN OVER ATABLE",
 
                 "SELECT inst,host FROM PTSDB WHERE regexp_substr(inst, '[^-]+') IN ('na1', 'na2','na3')",
-                "CLIENT SERIAL RANGE SCAN OVER PTSDB FROM ('na1') INCLUSIVE TO ('na3') INCLUSIVE",
+                "CLIENT SERIAL RANGE SCAN OVER PTSDB FROM ('na1') INCLUSIVE TO ('na3') INCLUSIVE\n" +
+                "    SERVER FILTER BY REGEXP_SUBSTR(INST, '[^-]+', 1) IN ('na2','na3','na1')",
 
                 "SELECT count(*) FROM atable",
                 "CLIENT PARALLEL 4-WAY FULL SCAN OVER ATABLE\n" +

--- a/src/test/java/com/salesforce/phoenix/util/TestUtil.java
+++ b/src/test/java/com/salesforce/phoenix/util/TestUtil.java
@@ -1,63 +1,69 @@
 /*******************************************************************************
  * Copyright (c) 2013, Salesforce.com, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
  *     Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
+ *     Neither the name of Salesforce.com nor the names of its contributors may
+ *     be used to endorse or promote products derived from this software without
  *     specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.util;
 
-import static org.junit.Assert.*;
-
 import java.io.File;
 import java.math.BigDecimal;
 import java.sql.SQLException;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.util.Bytes;
-
 import com.salesforce.phoenix.compile.StatementContext;
 import com.salesforce.phoenix.expression.*;
+import com.salesforce.phoenix.expression.function.RegexpSubstrFunction;
 import com.salesforce.phoenix.filter.*;
 import com.salesforce.phoenix.query.KeyRange;
-import com.salesforce.phoenix.schema.*;
+import com.salesforce.phoenix.schema.PColumn;
+import com.salesforce.phoenix.schema.PDataType;
+import com.salesforce.phoenix.schema.RowKeyValueAccessor;
 import com.salesforce.phoenix.schema.tuple.Tuple;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 
 
 public class TestUtil {
     private TestUtil() {
     }
-    
+
     public static final String CF_NAME = "a";
     public static final byte[] CF = Bytes.toBytes(CF_NAME);
-    
+
     public static final String CF2_NAME = "b";
-    
+
     public final static String A_VALUE = "a";
     public final static byte[] A = Bytes.toBytes(A_VALUE);
     public final static String B_VALUE = "b";
@@ -68,7 +74,7 @@ public class TestUtil {
     public final static byte[] D = Bytes.toBytes(D_VALUE);
     public final static String E_VALUE = "e";
     public final static byte[] E = Bytes.toBytes(E_VALUE);
-    
+
     public final static String ROW1 = "00A123122312312";
     public final static String ROW2 = "00A223122312312";
     public final static String ROW3 = "00A323122312312";
@@ -82,7 +88,7 @@ public class TestUtil {
     public static final long MILLIS_IN_DAY = 1000 * 60 * 60 * 24;
     public static final String PHOENIX_JDBC_URL = "jdbc:phoenix:localhost;test=true";
     public static final String PHOENIX_CONNECTIONLESS_JDBC_URL = PhoenixRuntime.JDBC_PROTOCOL + PhoenixRuntime.JDBC_PROTOCOL_SEPARATOR + PhoenixRuntime.CONNECTIONLESS  + ";test=true";
-    
+
     public static final String TEST_SCHEMA_FILE_NAME = "config" + File.separator + "test-schema.xml";
     public static final String CED_SCHEMA_FILE_NAME = "config" + File.separator + "schema.xml";
     public static final String ATABLE_NAME = "ATABLE";
@@ -102,18 +108,18 @@ public class TestUtil {
     public static final String MULTI_CF_NAME = "MULTI_CF";
     public static final String MDTEST_NAME = "MDTEST";
     public static final String KEYONLY_NAME = "KEYONLY";
-    
+
     public static final Properties TEST_PROPERTIES = new Properties();
-    
+
     public static byte[][] getSplits(String tenantId) {
-        return new byte[][] { 
+        return new byte[][] {
             HConstants.EMPTY_BYTE_ARRAY,
             Bytes.toBytes(tenantId + "00A"),
             Bytes.toBytes(tenantId + "00B"),
             Bytes.toBytes(tenantId + "00C"),
             };
     }
-    
+
     public static void assertRoundEquals(BigDecimal bd1, BigDecimal bd2) {
         bd1 = bd1.round(PDataType.DEFAULT_MATH_CONTEXT);
         bd2 = bd2.round(PDataType.DEFAULT_MATH_CONTEXT);
@@ -121,7 +127,7 @@ public class TestUtil {
             fail("expected:<" + bd1 + "> but was:<" + bd2 + ">");
         }
     }
-    
+
     public static BigDecimal computeAverage(double sum, long count) {
         return BigDecimal.valueOf(sum).divide(BigDecimal.valueOf(count), PDataType.DEFAULT_MATH_CONTEXT);
     }
@@ -133,23 +139,27 @@ public class TestUtil {
     public static Expression constantComparison(CompareOp op, PColumn c, Object o) {
         return  new ComparisonExpression(op, Arrays.<Expression>asList(new KeyValueColumnExpression(c), LiteralExpression.newConstant(o)));
     }
-    
+
     public static Expression kvColumn(PColumn c) {
         return new KeyValueColumnExpression(c);
     }
-    
+
     public static Expression pkColumn(PColumn c, List<PColumn> columns) {
         return new RowKeyColumnExpression(c, new RowKeyValueAccessor(columns, columns.indexOf(c)));
     }
-    
+
     public static Expression constantComparison(CompareOp op, Expression e, Object o) {
         return  new ComparisonExpression(op, Arrays.asList(e, LiteralExpression.newConstant(o)));
     }
-    
+
     public static Expression columnComparison(CompareOp op, PColumn c1, PColumn c2) {
         return  new ComparisonExpression(op, Arrays.<Expression>asList(new KeyValueColumnExpression(c1), new KeyValueColumnExpression(c2)));
     }
-    
+
+    public static Expression regexpSubstr(Expression... exprs) {
+        return new RegexpSubstrFunction(Arrays.asList(exprs));
+    }
+
     public static SingleKeyValueComparisonFilter singleKVFilter(Expression e) {
         return  new SingleCQKeyValueComparisonFilter(e);
     }
@@ -161,19 +171,19 @@ public class TestUtil {
     public static MultiKeyValueComparisonFilter multiKVFilter(Expression e) {
         return  new MultiCQKeyValueComparisonFilter(e);
     }
-    
+
     public static Expression and(Expression... expressions) {
         return new AndExpression(Arrays.asList(expressions));
     }
-    
+
     public static Expression or(Expression... expressions) {
         return new OrExpression(Arrays.asList(expressions));
     }
-        
+
     public static Expression in(Expression... expressions) throws SQLException {
         return new InListExpression(Arrays.asList(expressions));
     }
-        
+
     public static Expression in(Expression e, PDataType childType, Object... literals) throws SQLException {
         List<Expression> expressions = new ArrayList<Expression>(literals.length + 1);
         expressions.add(e);
@@ -182,26 +192,26 @@ public class TestUtil {
         }
         return new InListExpression(expressions);
     }
-        
+
     public static void assertDegenerate(StatementContext context) {
         Scan scan = context.getScan();
         assertDegenerate(scan);
     }
-    
+
     public static void assertDegenerate(Scan scan) {
         assertNull(scan.getFilter());
         assertArrayEquals(KeyRange.EMPTY_RANGE.getLowerRange(), scan.getStartRow());
         assertArrayEquals(KeyRange.EMPTY_RANGE.getLowerRange(), scan.getStopRow());
         assertEquals(null,scan.getFilter());
     }
-    
+
     public static void assertEmptyScanKey(Scan scan) {
         assertNull(scan.getFilter());
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, scan.getStartRow());
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, scan.getStopRow());
         assertEquals(null,scan.getFilter());
     }
-    
+
     /**
      * Does a deep comparison of two Results, down to the byte arrays.
      * @param res1 first result to compare


### PR DESCRIPTION
The server filter was incorrectly being removed for queries such as:
SELECT ... FROM ... WHERE regexp_substr(inst, '[^-]+') IN ('inst1', 'inst2')

The fix is to apply the new inlist optimization less aggressively.
