### PR TITLE
for hbase 0.94.4 compile-time compatibility

### DIFF
--- a/src/main/java/com/salesforce/phoenix/filter/MultiCFCQKeyValueComparisonFilter.java
+++ b/src/main/java/com/salesforce/phoenix/filter/MultiCFCQKeyValueComparisonFilter.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
  * Copyright (c) 2013, Salesforce.com, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
  *     Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
+ *     Neither the name of Salesforce.com nor the names of its contributors may
+ *     be used to endorse or promote products derived from this software without
  *     specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.filter;
@@ -35,7 +35,7 @@ import com.salesforce.phoenix.expression.Expression;
 
 
 /**
- * 
+ *
  * Filter that evaluates WHERE clause expression, used in the case where there
  * are references to multiple column qualifiers over multiple column families.
  *
@@ -45,7 +45,7 @@ import com.salesforce.phoenix.expression.Expression;
 public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFilter {
     private final ImmutablePairBytesPtr ptr = new ImmutablePairBytesPtr();
     private TreeSet<byte[]> cfSet;
-    
+
     public MultiCFCQKeyValueComparisonFilter() {
     }
 
@@ -58,7 +58,7 @@ public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFi
         cfSet = new TreeSet<byte[]>(Bytes.BYTES_COMPARATOR);
         super.init();
     }
-    
+
     @Override
     protected Object setColumnKey(byte[] cf, int cfOffset, int cfLength,
             byte[] cq, int cqOffset, int cqLength) {
@@ -67,7 +67,7 @@ public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFi
     }
 
     @Override
-    protected Object newColumnKey(byte[] cf, int cfOffset, int cfLength, 
+    protected Object newColumnKey(byte[] cf, int cfOffset, int cfLength,
             byte[] cq, int cqOffset, int cqLength) {
 
         byte[] cfKey;
@@ -91,7 +91,7 @@ public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFi
         private int offset2;
         private int length2;
         private int hashCode;
-        
+
         private ImmutablePairBytesPtr() {
         }
 
@@ -118,7 +118,7 @@ public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFi
                 hash = (31 * hash) + bytes2[i];
             hashCode = hash;
         }
-        
+
         @Override
         public boolean equals(Object obj) {
             if (this == obj) return true;
@@ -132,8 +132,8 @@ public class MultiCFCQKeyValueComparisonFilter extends MultiKeyValueComparisonFi
         }
     }
 
-    
-    @Override
+
+    //@Override
     public boolean isFamilyEssential(byte[] name) {
         // Only the column families involved in the expression are essential.
         // The others are for columns projected in the select expression.

--- a/src/main/java/com/salesforce/phoenix/filter/MultiCQKeyValueComparisonFilter.java
+++ b/src/main/java/com/salesforce/phoenix/filter/MultiCQKeyValueComparisonFilter.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
  * Copyright (c) 2013, Salesforce.com, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
  *     Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
+ *     Neither the name of Salesforce.com nor the names of its contributors may
+ *     be used to endorse or promote products derived from this software without
  *     specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.filter;
@@ -33,7 +33,7 @@ import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.util.ImmutableBytesPtr;
 
 /**
- * 
+ *
  * Filter that evaluates WHERE clause expression, used in the case where there
  * are references to multiple column qualifiers over a single column family.
  *
@@ -43,7 +43,7 @@ import com.salesforce.phoenix.util.ImmutableBytesPtr;
 public class MultiCQKeyValueComparisonFilter extends MultiKeyValueComparisonFilter {
     private ImmutableBytesPtr ptr = new ImmutableBytesPtr();
     private byte[] cf;
-    
+
     public MultiCQKeyValueComparisonFilter() {
     }
 
@@ -70,8 +70,8 @@ public class MultiCQKeyValueComparisonFilter extends MultiKeyValueComparisonFilt
         return new ImmutableBytesPtr(cq, cqOffset, cqLength);
     }
 
-    
-    @Override
+
+    //@Override
     public boolean isFamilyEssential(byte[] name) {
         return Bytes.compareTo(cf, name) == 0;
     }

--- a/src/main/java/com/salesforce/phoenix/filter/RowKeyComparisonFilter.java
+++ b/src/main/java/com/salesforce/phoenix/filter/RowKeyComparisonFilter.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
  * Copyright (c) 2013, Salesforce.com, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
  *     Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
+ *     Neither the name of Salesforce.com nor the names of its contributors may
+ *     be used to endorse or promote products derived from this software without
  *     specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.filter;
@@ -41,7 +41,7 @@ import com.salesforce.phoenix.schema.tuple.Tuple;
 
 
 /**
- * 
+ *
  * Filter for use when expressions only reference row key columns
  *
  * @author jtaylor
@@ -49,7 +49,7 @@ import com.salesforce.phoenix.schema.tuple.Tuple;
  */
 public class RowKeyComparisonFilter extends BooleanExpressionFilter {
     private static final Logger logger = LoggerFactory.getLogger(RowKeyComparisonFilter.class);
-    
+
     private boolean keepRow = false;
     private RowKeyTuple inputTuple = new RowKeyTuple();
     private byte[] essentialCF;
@@ -66,7 +66,7 @@ public class RowKeyComparisonFilter extends BooleanExpressionFilter {
     public void reset() {
         this.keepRow = false;
     }
-    
+
     @Override
     public ReturnCode filterKeyValue(KeyValue v) {
         if(this.keepRow) {
@@ -79,18 +79,18 @@ public class RowKeyComparisonFilter extends BooleanExpressionFilter {
         private byte[] buf;
         private int offset;
         private int length;
-        
+
         public void setKey(byte[] buf, int offset, int length) {
             this.buf = buf;
             this.offset = offset;
             this.length = length;
         }
-        
+
         @Override
         public void getKey(ImmutableBytesWritable ptr) {
             ptr.set(buf, offset, length);
         }
-        
+
         @Override
         public KeyValue getValue(byte[] cf, byte[] cq) {
             return null;
@@ -116,7 +116,7 @@ public class RowKeyComparisonFilter extends BooleanExpressionFilter {
             throw new IndexOutOfBoundsException(Integer.toString(index));
         }
     }
-    
+
     @Override
     public boolean filterRowKey(final byte[] data, int offset, int length) {
         inputTuple.setKey(data, offset, length);
@@ -131,15 +131,15 @@ public class RowKeyComparisonFilter extends BooleanExpressionFilter {
     public boolean filterRow() {
         return !this.keepRow;
     }
-    
-    @Override
+
+    //@Override
     public boolean isFamilyEssential(byte[] name) {
         // We only need our "guaranteed to have a key value" column family,
         // which we pass in and serialize through. In the case of a VIEW where
         // we don't have this, we have to say that all families are essential.
         return this.essentialCF.length == 0 ? true : Bytes.compareTo(this.essentialCF, name) == 0;
     }
-    
+
     @Override
     public void readFields(DataInput input) throws IOException {
         super.readFields(input);

--- a/src/main/java/com/salesforce/phoenix/filter/SingleKeyValueComparisonFilter.java
+++ b/src/main/java/com/salesforce/phoenix/filter/SingleKeyValueComparisonFilter.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
  * Copyright (c) 2013, Salesforce.com, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
  *     Redistributions in binary form must reproduce the above copyright notice,
  *     this list of conditions and the following disclaimer in the documentation
  *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
+ *     Neither the name of Salesforce.com nor the names of its contributors may
+ *     be used to endorse or promote products derived from this software without
  *     specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.filter;
@@ -40,7 +40,7 @@ import com.salesforce.phoenix.schema.tuple.SingleKeyValueTuple;
 
 
 /**
- * 
+ *
  * Modeled after {@link org.apache.hadoop.hbase.filter.SingleColumnValueFilter},
  * but for general expression evaluation in the case where only a single KeyValue
  * column is referenced in the expression.
@@ -76,11 +76,11 @@ public abstract class SingleKeyValueComparisonFilter extends BooleanExpressionFi
         expression.accept(visitor);
         this.evaluateOnCompletion = visitor.evaluateOnCompletion();
     }
-    
+
     private boolean foundColumn() {
         return inputTuple.size() > 0;
     }
-    
+
     @Override
     public ReturnCode filterKeyValue(KeyValue keyValue) {
         if (this.matchedColumn) {
@@ -102,7 +102,7 @@ public abstract class SingleKeyValueComparisonFilter extends BooleanExpressionFi
             return ReturnCode.INCLUDE;
         }
         inputTuple.setKeyValue(keyValue);
-        
+
         // We have the columns, so evaluate here
         if (!Boolean.TRUE.equals(evaluate(inputTuple))) {
             return ReturnCode.NEXT_ROW;
@@ -144,8 +144,8 @@ public abstract class SingleKeyValueComparisonFilter extends BooleanExpressionFi
         super.readFields(input);
         init();
     }
-    
-    @Override
+
+    //@Override
     public boolean isFamilyEssential(byte[] name) {
         // Only the column families involved in the expression are essential.
         // The others are for columns projected in the select expression


### PR DESCRIPTION
The @Override annotations only make sense when compiling against 0.94.5, and prevent compilation against 0.94.4
