### PR TITLE
Fixing bug with toObject methods on DATE, TIME and TIMESTAMP PData types...

### DIFF
--- a/src/main/java/com/salesforce/phoenix/schema/PDataType.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PDataType.java
@@ -779,8 +779,9 @@ public enum PDataType {
             }
             switch (actualType) {
             case DATE:
-            case TIME:
                 return new Timestamp(((Date)object).getTime());
+            case TIME:
+                return new Timestamp(((Time)object).getTime());
             case TIMESTAMP:
                 return object;
             default:
@@ -804,6 +805,11 @@ public enum PDataType {
             default:
                 throw new ConstraintViolationException(actualType + " cannot be coerced to " + this);
             }
+        }
+        
+        @Override
+        public boolean isCoercibleTo(PDataType targetType) {
+            return this == targetType || targetType == DATE || targetType == TIME || targetType == BINARY;
         }
 
         @Override
@@ -875,8 +881,9 @@ public enum PDataType {
             }
             switch (actualType) {
             case DATE:
-            case TIMESTAMP:
                 return new Time(((Date)object).getTime());
+            case TIMESTAMP:
+                return new Time(((Timestamp)object).getTime());
             case TIME:
                 return object;
             default:
@@ -946,8 +953,9 @@ public enum PDataType {
             }
             switch (actualType) {
             case TIME:
+                return new Date(((Time)object).getTime());
             case TIMESTAMP:
-                return new Time(((Date)object).getTime());
+                return new Date(((Timestamp)object).getTime());
             case DATE:
                 return object;
             default:

--- a/src/test/java/com/salesforce/phoenix/schema/PDataTypeTest.java
+++ b/src/test/java/com/salesforce/phoenix/schema/PDataTypeTest.java
@@ -27,11 +27,21 @@
  ******************************************************************************/
 package com.salesforce.phoenix.schema;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
@@ -327,6 +337,14 @@ public class PDataTypeTest {
         assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.INTEGER, 0L));
         assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.LONG));
         assertFalse(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.UNSIGNED_INT));
+        
+        // Testing coercing Date types
+        assertTrue(PDataType.DATE.isCoercibleTo(PDataType.TIMESTAMP));
+        assertTrue(PDataType.DATE.isCoercibleTo(PDataType.TIME));
+        assertTrue(PDataType.TIMESTAMP.isCoercibleTo(PDataType.DATE));
+        assertTrue(PDataType.TIMESTAMP.isCoercibleTo(PDataType.TIME));
+        assertTrue(PDataType.TIME.isCoercibleTo(PDataType.TIMESTAMP));
+        assertTrue(PDataType.TIME.isCoercibleTo(PDataType.DATE));
     }
 
     @Test
@@ -372,6 +390,29 @@ public class PDataTypeTest {
             testReadDecimalPrecisionAndScaleFromRawBytes(bds[i]);
             testReadDecimalPrecisionAndScaleFromRawBytes(bds[i].negate());
         }
+    }
+    
+    @Test
+    public void testDateConversions() {
+        long now = System.currentTimeMillis();
+        Date date = new Date(now);
+        Time t = new Time(now);
+        Timestamp ts = new Timestamp(now);
+        
+        Object o = PDataType.DATE.toObject(ts, PDataType.TIMESTAMP);
+        assertEquals(o.getClass(), java.sql.Date.class);
+        o = PDataType.DATE.toObject(t, PDataType.TIME);
+        assertEquals(o.getClass(), java.sql.Date.class);
+        
+        o = PDataType.TIME.toObject(date, PDataType.DATE);
+        assertEquals(o.getClass(), java.sql.Time.class);
+        o = PDataType.TIME.toObject(ts, PDataType.TIMESTAMP);
+        assertEquals(o.getClass(), java.sql.Time.class);
+                
+        o = PDataType.TIMESTAMP.toObject(date, PDataType.DATE);
+        assertEquals(o.getClass(), java.sql.Timestamp.class);
+        o = PDataType.TIMESTAMP.toObject(t, PDataType.TIME);
+        assertEquals(o.getClass(), java.sql.Timestamp.class); 
     }
 
     private void testReadDecimalPrecisionAndScaleFromRawBytes(BigDecimal bd) {


### PR DESCRIPTION
.... Adding test case for the same
