### PR TITLE
Fix a bug in DefaultParallelIteratorRegionSplitter.genKeyRanges

### DIFF
--- a/src/main/java/com/salesforce/phoenix/iterate/DefaultParallelIteratorRegionSplitter.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/DefaultParallelIteratorRegionSplitter.java
@@ -136,13 +136,11 @@ public class DefaultParallelIteratorRegionSplitter implements ParallelIteratorRe
         // Create a multi-map of ServerName to List<KeyRange> which we'll use to round robin from to ensure
         // that we keep each region server busy for each query.
         ListMultimap<ServerName,KeyRange> keyRangesPerRegion = ArrayListMultimap.create(regions.size(),regions.size() * splitsPerRegion);;
-        if (regions.size() >= targetConcurrency) {
+        if (splitsPerRegion == 1) {
             for (Map.Entry<HRegionInfo, ServerName> region : regions) {
                 keyRangesPerRegion.put(region.getValue(), ParallelIterators.TO_KEY_RANGE.apply(region));
             }
         } else {
-            assert splitsPerRegion >= 2 : "Splits per region has to be greater than 2";
-            
             // Maintain bucket for each server and then returns KeyRanges in round-robin
             // order to ensure all servers are utilized.
             for (Map.Entry<HRegionInfo, ServerName> region : regions) {


### PR DESCRIPTION
In the case of r > t/2, but m / r = 1 (e.g. round down from 1.8), the splitsPerRegion is actually 1, but code will go to split branch. which will lead to IllegalArgumentException in Bytes.
