### PR TITLE
Increment show case.

### DIFF
--- a/src/main/antlr3/PhoenixSQL.g
+++ b/src/main/antlr3/PhoenixSQL.g
@@ -71,6 +71,7 @@ tokens
     UPSERT='upsert';
     INTO='into';
     VALUES='values';
+    INCREASE='increase';
     DELETE='delete';
     CREATE='create';
     DROP='drop';
@@ -437,8 +438,8 @@ select_node returns [SelectStatement ret]
 upsert_node returns [UpsertStatement ret]
     :   UPSERT INTO t=from_table_name
         (LPAREN c=column_refs RPAREN)?
-        ((VALUES LPAREN v=expression_terms RPAREN) | s=select_node)
-        {ret = factory.upsert(t, c, v, s, getBindCount()); }
+        (((i=INCREASE)? VALUES LPAREN v=expression_terms RPAREN) | s=select_node)
+        {ret = factory.upsert(t, c, i!=null, v, s, getBindCount()); }
     ;
 
 // Parses a select statement which must be the only statement (expects an EOF after the statement).

--- a/src/main/java/com/salesforce/phoenix/compile/DeleteCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/DeleteCompiler.java
@@ -87,7 +87,7 @@ public class DeleteCompiler {
 
                 @Override
                 public MutationState execute() {
-                    Map<ImmutableBytesPtr,Map<PColumn,byte[]>> mutation = Maps.newHashMapWithExpectedSize(1);
+                    Map<ImmutableBytesPtr,Map<PColumn,MutationValue>> mutation = Maps.newHashMapWithExpectedSize(1);
                     mutation.put(key, null);
                     return new MutationState(tableRef, mutation, 0, maxSize, connection);
                 }
@@ -176,7 +176,7 @@ public class DeleteCompiler {
                     Scanner scanner = plan.getScanner();
                     ResultIterator iterator = scanner.iterator();
                     int estSize = scanner.getEstimatedSize();
-                    Map<ImmutableBytesPtr,Map<PColumn,byte[]>> mutations = Maps.newHashMapWithExpectedSize(estSize);
+                    Map<ImmutableBytesPtr,Map<PColumn,MutationValue>> mutations = Maps.newHashMapWithExpectedSize(estSize);
                     try {
                         Tuple row;
                         int rowCount = 0;

--- a/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
@@ -32,6 +32,7 @@ import java.util.*;
 
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -42,6 +43,7 @@ import com.salesforce.phoenix.exception.SQLExceptionCode;
 import com.salesforce.phoenix.exception.SQLExceptionInfo;
 import com.salesforce.phoenix.execute.AggregatePlan;
 import com.salesforce.phoenix.execute.MutationState;
+import com.salesforce.phoenix.execute.MutationValue;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
 import com.salesforce.phoenix.expression.function.CountAggregateFunction;
@@ -63,8 +65,8 @@ public class UpsertCompiler {
         this.statement = statement;
     }
     
-    private static void setValues(byte[][] values, int[] pkSlotIndex, int[] columnIndexes, PTable table, Map<ImmutableBytesPtr,Map<PColumn,byte[]>> mutation) {
-        Map<PColumn,byte[]> columnValues = Maps.newHashMapWithExpectedSize(columnIndexes.length);
+    private static void setValues(byte[][] values, boolean isIncrease, int[] pkSlotIndex, int[] columnIndexes, PTable table, Map<ImmutableBytesPtr,Map<PColumn,MutationValue>> mutation) {
+        Map<PColumn,MutationValue> columnValues = Maps.newHashMapWithExpectedSize(columnIndexes.length);
         byte[][] pkValues = new byte[table.getPKColumns().size()][];
         // If the table uses salting, the first byte is the salting byte, set to an empty arrary
         // here and we will fill in the byte later in PRowImpl.
@@ -77,7 +79,11 @@ public class UpsertCompiler {
             if (SchemaUtil.isPKColumn(column)) {
                 pkValues[pkSlotIndex[i]] = value;
             } else {
-                columnValues.put(column, value);
+                if (isIncrease) {
+                    columnValues.put(column, new MutationValue(null, column.getDataType().getCodec().decodeLong(value, 0, null)));
+                } else {
+                    columnValues.put(column, new MutationValue(value));
+                }
             }
         }
         ImmutableBytesPtr ptr = new ImmutableBytesPtr();
@@ -180,6 +186,7 @@ public class UpsertCompiler {
         
         final int[] columnIndexes = columnIndexesToBe;
         final int[] pkSlotIndexes = pkSlotIndexesToBe;
+        final boolean isIncrease = upsert.isIncrease();
         
         // TODO: break this up into multiple functions
         ////////////////////////////////////////////////////////////////////
@@ -350,7 +357,7 @@ public class UpsertCompiler {
                     Scanner scanner = queryPlan.getScanner();
                     int estSize = scanner.getEstimatedSize();
                     int rowCount = 0;
-                    Map<ImmutableBytesPtr,Map<PColumn,byte[]>> mutation = Maps.newHashMapWithExpectedSize(estSize);
+                    Map<ImmutableBytesPtr,Map<PColumn,MutationValue>> mutation = Maps.newHashMapWithExpectedSize(estSize);
                     ResultSet rs = new PhoenixResultSet(scanner, statement);
                     PTable table = tableRef.getTable();
                     PColumn column;
@@ -368,7 +375,7 @@ public class UpsertCompiler {
                             values[i] = column.getDataType().coerceBytes(rs.getBytes(i+1), null, column.getDataType(),
                                     null, null, column.getMaxLength(), column.getScale());
                         }
-                        setValues(values, pkSlotIndexes, columnIndexes, table, mutation);
+                        setValues(values, isIncrease, pkSlotIndexes, columnIndexes, table, mutation);
                         rowCount++;
                         // Commit a batch if auto commit is true and we're at our batch size
                         if (isAutoCommit && rowCount % batchSize == 0) {
@@ -441,8 +448,8 @@ public class UpsertCompiler {
     
                 @Override
                 public MutationState execute() {
-                    Map<ImmutableBytesPtr,Map<PColumn,byte[]>> mutation = Maps.newHashMapWithExpectedSize(1);
-                    setValues(values, pkSlotIndexes, columnIndexes, tableRef.getTable(), mutation);
+                    Map<ImmutableBytesPtr,Map<PColumn,MutationValue>> mutation = Maps.newHashMapWithExpectedSize(1);
+                    setValues(values, isIncrease, pkSlotIndexes, columnIndexes, tableRef.getTable(), mutation);
                     return new MutationState(tableRef, mutation, 0, maxSize, connection);
                 }
     

--- a/src/main/java/com/salesforce/phoenix/coprocessor/MetaDataEndpointImpl.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/MetaDataEndpointImpl.java
@@ -202,7 +202,7 @@ public class MetaDataEndpointImpl extends BaseEndpointCoprocessor implements Met
         KeyValue tableTypeKv = tableKeyValues[TABLE_TYPE_INDEX];
         PTableType tableType = PTableType.fromSerializedValue(tableTypeKv.getBuffer()[tableTypeKv.getValueOffset()]);
         KeyValue tableSeqNumKv = tableKeyValues[TABLE_SEQ_NUM_INDEX];
-        long tableSeqNum = PDataType.LONG.getCodec().decodeLong(tableSeqNumKv.getBuffer(), tableSeqNumKv.getValueOffset(), null);
+        long tableSeqNum = PDataType.RAW_LONG.getCodec().decodeLong(tableSeqNumKv.getBuffer(), tableSeqNumKv.getValueOffset(), null);
         KeyValue columnCountKv = tableKeyValues[COLUMN_COUNT_INDEX];
         int columnCount = PDataType.INTEGER.getCodec().decodeInt(columnCountKv.getBuffer(), columnCountKv.getValueOffset(), null);
         KeyValue pkNameKv = tableKeyValues[PK_NAME_INDEX];
@@ -450,7 +450,7 @@ public class MetaDataEndpointImpl extends BaseEndpointCoprocessor implements Met
         if (kvs != null) {
             for (KeyValue kv : kvs) { // list is not ordered, so search. TODO: we could potentially assume the position
                 if (Bytes.compareTo(kv.getBuffer(), kv.getQualifierOffset(), kv.getQualifierLength(), PhoenixDatabaseMetaData.TABLE_SEQ_NUM_BYTES, 0, PhoenixDatabaseMetaData.TABLE_SEQ_NUM_BYTES.length) == 0) {
-                    return PDataType.LONG.getCodec().decodeLong(kv.getBuffer(), kv.getValueOffset(), null);
+                    return PDataType.RAW_LONG.getCodec().decodeLong(kv.getBuffer(), kv.getValueOffset(), null);
                 }
             }
         }

--- a/src/main/java/com/salesforce/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.salesforce.phoenix.exception.ValueTypeIncompatibleException;
+import com.salesforce.phoenix.execute.MutationValue;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.ExpressionType;
 import com.salesforce.phoenix.expression.aggregator.*;
@@ -181,7 +182,7 @@ public class UngroupedAggregateRegionObserver extends BaseScannerRegionObserver 
                                     }
                                     bytes = column.getDataType().coerceBytes(bytes, null, column.getDataType(),
                                             null, null, column.getMaxLength(), column.getScale());
-                                    row.setValue(projectedTable.getColumns().get(i), bytes);
+                                    row.setValue(projectedTable.getColumns().get(i), new MutationValue(bytes));
                                 }
                             }
                             for (Mutation mutation : row.toRowMutations()) {

--- a/src/main/java/com/salesforce/phoenix/execute/MutationValue.java
+++ b/src/main/java/com/salesforce/phoenix/execute/MutationValue.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.execute;
+
+/**
+ * Store values for column Mutation.
+ * there are two type of values could be saved in a single MutationValue instance.
+ * putValue for put mutaion, and incValue for a HTable.increment.
+ * Upon mutation, putValue should be applied before incValue.
+ * 
+ * @author Raymond
+ */
+
+public class MutationValue {
+    private byte[] putValue = null;
+    private long incValue = 0;
+
+    public MutationValue() {
+        this.putValue = null;
+        this.incValue = 0;
+    }
+
+    public MutationValue(byte[] putValue) {
+        this.putValue = putValue;
+        this.incValue = 0;
+    }
+
+    public MutationValue(byte[] putValue, long incValue) {
+        this.putValue = putValue;
+        this.incValue = incValue;
+    }
+
+    public byte[] getPutValue() {
+        return putValue;
+    }
+
+    public long getIncValue() {
+        return incValue;
+    }
+
+    public void setPutValue(byte[] value) {
+        putValue = value;
+    }
+
+    public void setIncValue(long value) {
+        incValue = value;
+    }
+
+    public boolean hasPutValue() {
+        return !(putValue == null || putValue.length == 0);
+    }
+    
+    public boolean hasIncValue() {
+        return incValue != 0;
+    }
+
+    public boolean isEmpty() {
+        return ((putValue == null || putValue.length == 0) &&
+                (incValue == 0));
+    }
+
+    public void merge(MutationValue m) {
+        
+        if (m == null)
+            return;
+
+        // When merging new MutationValue, new putValue always reset current putValue and incValue at the same time.
+        // While if only incValue is available in new MutaionValue, then it should accumulate with current one.
+        if (m.hasPutValue()) {
+            putValue = m.getPutValue();
+            incValue = 0;
+        }
+        
+        incValue += m.getIncValue();
+    }
+}

--- a/src/main/java/com/salesforce/phoenix/iterate/OrderedResultIterator.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/OrderedResultIterator.java
@@ -36,11 +36,14 @@ import java.util.*;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.WritableComparator;
 
 import com.google.common.base.Function;
 import com.google.common.collect.*;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.OrderByExpression;
+import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 import com.salesforce.phoenix.util.SizedUtil;
 
@@ -84,6 +87,20 @@ public class OrderedResultIterator implements ResultIterator {
         @Override
         public ImmutableBytesWritable apply(ResultEntry entry) {
             return entry.getSortKey(index);
+        }
+    }
+
+    /** A function that returns Nth key as LONGWritable for a given {@link ResultEntry}. */
+    private static class NthKeyLongWritable implements Function<ResultEntry, LongWritable> {
+        private final int index;
+
+        NthKeyLongWritable(int index) {
+            this.index = index;
+        }
+        @Override
+        public LongWritable apply(ResultEntry entry) {
+            ImmutableBytesWritable key = entry.getSortKey(index);
+            return new LongWritable(WritableComparator.readLong(key.get(), key.getOffset()));
         }
     }
 
@@ -155,10 +172,20 @@ public class OrderedResultIterator implements ResultIterator {
         Ordering<ResultEntry> ordering = null;
         int pos = 0;
         for (OrderByExpression col : orderByExpressions) {
-            Ordering<ImmutableBytesWritable> o = Ordering.from(new ImmutableBytesWritable.Comparator());
-            if(!col.isAscending()) o = o.reverse();
-            o = col.isNullsLast() ? o.nullsLast() : o.nullsFirst();
-            Ordering<ResultEntry> entryOrdering = o.onResultOf(new NthKey(pos++));
+            Ordering<ResultEntry> entryOrdering = null;
+            if (col.getExpression().getDataType() == PDataType.RAW_LONG) {
+                // LONG type data won't be able to be compared by bytes directly. 
+                Ordering<LongWritable> o = Ordering.from(new LongWritable.Comparator());
+                if(!col.isAscending()) o = o.reverse();
+                o = col.isNullsLast() ? o.nullsLast() : o.nullsFirst();
+                entryOrdering = o.onResultOf(new NthKeyLongWritable(pos++));
+            } else {
+                Ordering<ImmutableBytesWritable> o = Ordering.from(new ImmutableBytesWritable.Comparator());
+                if(!col.isAscending()) o = o.reverse();
+                o = col.isNullsLast() ? o.nullsLast() : o.nullsFirst();
+                entryOrdering = o.onResultOf(new NthKey(pos++));
+            }
+
             ordering = ordering == null ? entryOrdering : ordering.compound(entryOrdering);
         }
         return ordering;

--- a/src/main/java/com/salesforce/phoenix/jdbc/PhoenixStatement.java
+++ b/src/main/java/com/salesforce/phoenix/jdbc/PhoenixStatement.java
@@ -189,8 +189,8 @@ public class PhoenixStatement implements Statement, SQLCloseable, com.salesforce
     }
     
     private class ExecutableUpsertStatement extends UpsertStatement implements MutatableStatement {
-        private ExecutableUpsertStatement(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
-            super(table, columns, values, select, bindCount);
+        private ExecutableUpsertStatement(TableName table, List<ParseNode> columns, boolean isIncrease, List<ParseNode> values, SelectStatement select, int bindCount) {
+            super(table, columns, isIncrease, values, select, bindCount);
         }
 
         @Override
@@ -595,8 +595,8 @@ public class PhoenixStatement implements Statement, SQLCloseable, com.salesforce
         }
         
         @Override
-        public ExecutableUpsertStatement upsert(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
-            return new ExecutableUpsertStatement(table, columns, values, select, bindCount);
+        public ExecutableUpsertStatement upsert(TableName table, List<ParseNode> columns, boolean isIncrease, List<ParseNode> values, SelectStatement select, int bindCount) {
+            return new ExecutableUpsertStatement(table, columns, isIncrease, values, select, bindCount);
         }
         
         @Override

--- a/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
@@ -121,6 +121,15 @@ public class ColumnDef {
         return dataType;
     }
 
+    public PDataType getNonPKDataType() {
+        switch (dataType) {
+        case LONG:
+            return PDataType.RAW_LONG;
+        default:
+            return dataType;
+        }
+    }
+
     public boolean isNull() {
         return isNull;
     }

--- a/src/main/java/com/salesforce/phoenix/parse/ParseNodeFactory.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ParseNodeFactory.java
@@ -434,8 +434,8 @@ public class ParseNodeFactory {
         return new SelectStatement(from, hint, isDistinct, select, where, groupBy == null ? Collections.<ParseNode>emptyList() : groupBy, having, orderBy == null ? Collections.<OrderByNode>emptyList() : orderBy, limit, bindCount);
     }
     
-    public UpsertStatement upsert(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
-        return new UpsertStatement(table, columns, values, select, bindCount);
+    public UpsertStatement upsert(TableName table, List<ParseNode> columns, boolean isIncrease, List<ParseNode> values, SelectStatement select, int bindCount) {
+        return new UpsertStatement(table, columns, isIncrease, values, select, bindCount);
     }
     
     public DeleteStatement delete(TableName table, HintNode hint, ParseNode node, List<OrderByNode> orderBy, LimitNode limit, int bindCount) {

--- a/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
+++ b/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
@@ -32,12 +32,14 @@ import java.util.List;
 
 public class UpsertStatement extends MutationStatement {
     private final List<ParseNode> columns;
+    private final boolean isIncrease;
     private final List<ParseNode> values;
     private final SelectStatement select;
     
-    public UpsertStatement(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
+    public UpsertStatement(TableName table, List<ParseNode> columns, boolean isIncrease, List<ParseNode> values, SelectStatement select, int bindCount) {
         super(table, bindCount);
         this.columns = columns == null ? Collections.<ParseNode>emptyList() : columns;
+        this.isIncrease = isIncrease;
         this.values = values;
         this.select = select;
     }
@@ -46,6 +48,9 @@ public class UpsertStatement extends MutationStatement {
         return columns;
     }
 
+    public boolean isIncrease() {
+        return isIncrease;
+    }
     public List<ParseNode> getValues() {
         return values;
     }

--- a/src/main/java/com/salesforce/phoenix/schema/MetaDataClient.java
+++ b/src/main/java/com/salesforce/phoenix/schema/MetaDataClient.java
@@ -206,7 +206,8 @@ public class MetaDataClient {
             	columnModifier = pkConstraint.getColumnModifier(columnName);
             }            
             
-            PColumn column = new PColumnImpl(new PNameImpl(columnName), familyName, def.getDataType(),
+            PDataType realDataType = isPK ? def.getDataType() : def.getNonPKDataType();
+            PColumn column = new PColumnImpl(new PNameImpl(columnName), familyName, realDataType,
                     def.getMaxLength(), def.getScale(), def.isNull(), position, columnModifier);
             return column;
         } catch (IllegalArgumentException e) { // Based on precondition check in constructor

--- a/src/main/java/com/salesforce/phoenix/schema/PRow.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PRow.java
@@ -29,7 +29,10 @@ package com.salesforce.phoenix.schema;
 
 import java.util.List;
 
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Mutation;
+
+import com.salesforce.phoenix.execute.MutationValue;
 
 /**
  * 
@@ -51,7 +54,17 @@ public interface PRow {
      * constraint
      */
     public List<Mutation> toRowMutations();
-    
+
+    /**
+     * Get the Increment {@link org.apache.hadoop.hbase.client.Increment} used to
+     * update an HTable after all mutations through calls to
+     * {@link #setValue(PColumn, Object)} or {@link #delete()}.
+     * @return the Increment representing the Increment made to a row
+     * @throws ConstraintViolationException if row data violates schema
+     * constraint
+     */
+    public Increment toIncrement();
+
     /**
      * Set a column value in the row
      * @param col the column for which the value is being set
@@ -68,7 +81,7 @@ public interface PRow {
      * @throws ConstraintViolationException if row data violates schema
      * constraint
      */
-    public void setValue(PColumn col, byte[] value);
+    public void setValue(PColumn col, MutationValue value);
     
     /**
      * Delete the row. Note that a delete take precedence over any

--- a/src/test/java/com/salesforce/phoenix/end2end/QueryDatabaseMetaDataTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/QueryDatabaseMetaDataTest.java
@@ -181,7 +181,7 @@ public class QueryDatabaseMetaDataTest extends BaseClientMangedTimeTest {
         assertEquals(SchemaUtil.normalizeIdentifier("b"), rs.getString("TABLE_CAT"));
         assertEquals(SchemaUtil.normalizeIdentifier("col2"), rs.getString("COLUMN_NAME"));
         assertEquals(DatabaseMetaData.attributeNullable, rs.getShort("NULLABLE"));
-        assertEquals(PDataType.LONG.getSqlType(), rs.getInt("DATA_TYPE"));
+        assertEquals(PDataType.RAW_LONG.getSqlType(), rs.getInt("DATA_TYPE"));
         assertEquals(3, rs.getInt("ORDINAL_POSITION"));
         assertEquals(19, rs.getInt("COLUMN_SIZE"));
         assertEquals(0, rs.getInt("DECIMAL_DIGITS"));
@@ -255,7 +255,7 @@ public class QueryDatabaseMetaDataTest extends BaseClientMangedTimeTest {
         assertEquals(SchemaUtil.normalizeIdentifier("b"), rs.getString("TABLE_CAT"));
         assertEquals(SchemaUtil.normalizeIdentifier("col2"), rs.getString("COLUMN_NAME"));
         assertEquals(DatabaseMetaData.attributeNullable, rs.getShort("NULLABLE"));
-        assertEquals(PDataType.LONG.getSqlType(), rs.getInt("DATA_TYPE"));
+        assertEquals(PDataType.RAW_LONG.getSqlType(), rs.getInt("DATA_TYPE"));
         assertEquals(3, rs.getInt("ORDINAL_POSITION"));
         assertEquals(19, rs.getInt("COLUMN_SIZE"));
         assertEquals(0, rs.getInt("DECIMAL_DIGITS"));
@@ -641,7 +641,7 @@ public class QueryDatabaseMetaDataTest extends BaseClientMangedTimeTest {
             HTableInterface htable = conn2.getQueryServices().getTable(SchemaUtil.getTableName(MDTEST_NAME));
             Put put = new Put(Bytes.toBytes("0"));
             put.add(cfB, Bytes.toBytes("COL1"), ts+6, PDataType.INTEGER.toBytes(1));
-            put.add(cfC, Bytes.toBytes("COL2"), ts+6, PDataType.LONG.toBytes(2));
+            put.add(cfC, Bytes.toBytes("COL2"), ts+6, PDataType.RAW_LONG.toBytes(2));
             htable.put(put);
             conn2.close();
             

--- a/src/test/java/com/salesforce/phoenix/schema/PDataTypeTest.java
+++ b/src/test/java/com/salesforce/phoenix/schema/PDataTypeTest.java
@@ -62,8 +62,36 @@ public class PDataTypeTest {
         byte[] ba = PDataType.LONG.toBytes(na);
         byte[] bb = PDataType.LONG.toBytes(nb);
         assertTrue(Bytes.compareTo(ba, bb) > 0);
+        
+        assertEquals(1, PDataType.LONG.compareTo(1L, -1L, PDataType.LONG));
     }
 
+    @Test
+    public void testRawLong() {
+        Long la = 4L;
+        byte[] b = PDataType.RAW_LONG.toBytes(la);
+        Long lb = (Long)PDataType.RAW_LONG.toObject(b);
+        assertEquals(la,lb);
+
+        Long na = 1L;
+        Long nb = -1L;
+        byte[] ba = PDataType.RAW_LONG.toBytes(na);
+        byte[] bb = PDataType.RAW_LONG.toBytes(nb);
+        assertTrue(Bytes.compareTo(ba, bb) < 0);
+
+        assertEquals(PDataType.RAW_LONG.compareTo(1L, -1L, PDataType.LONG),1);
+    
+        byte[] bRAW_LONG_M = PDataType.RAW_LONG.toBytes(-1L);
+        byte[] bRAW_LONG_P = PDataType.RAW_LONG.toBytes(1L);
+        byte[] bLONG_M = PDataType.LONG.toBytes(-1L);
+        byte[] bLONG_P = PDataType.LONG.toBytes(1L);
+        assertEquals(0, PDataType.RAW_LONG.compareTo(bRAW_LONG_P, 0, 8, null, bLONG_P, 0, 8, null, PDataType.LONG));
+        assertEquals(1, PDataType.RAW_LONG.compareTo(bRAW_LONG_P, 0, 8, null, bLONG_M, 0, 8, null, PDataType.LONG));
+        assertEquals(-1, PDataType.RAW_LONG.compareTo(bRAW_LONG_M, 0, 8, null, bLONG_P, 0, 8, null, PDataType.LONG));
+        assertEquals(0, PDataType.RAW_LONG.compareTo(bRAW_LONG_M, 0, 8, null, bLONG_M, 0, 8, null, PDataType.LONG));
+
+    }
+    
     @Test
     public void testInt() {
         Integer na = 4;
@@ -293,6 +321,10 @@ public class PDataTypeTest {
         assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.LONG, 10));
         assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.LONG, 0));
         assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.LONG, -10));
+        assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.RAW_LONG));
+        assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.RAW_LONG, 10));
+        assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.RAW_LONG, 0));
+        assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.RAW_LONG, -10));
         assertFalse(PDataType.INTEGER.isCoercibleTo(PDataType.UNSIGNED_INT));
         assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.UNSIGNED_INT, 10));
         assertTrue(PDataType.INTEGER.isCoercibleTo(PDataType.UNSIGNED_INT, 0));
@@ -325,6 +357,38 @@ public class PDataTypeTest {
         assertTrue(PDataType.LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, 0L));
         assertFalse(PDataType.LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, -10L));
         assertFalse(PDataType.LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, Long.MIN_VALUE));
+        assertTrue(PDataType.LONG.isCoercibleTo(PDataType.RAW_LONG));
+        assertTrue(PDataType.LONG.isCoercibleTo(PDataType.RAW_LONG, 10L));
+        assertTrue(PDataType.LONG.isCoercibleTo(PDataType.RAW_LONG, 0L));
+        assertTrue(PDataType.LONG.isCoercibleTo(PDataType.RAW_LONG, -10L));
+
+        // Testing coercing raw long to other values.
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Long.MAX_VALUE));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Integer.MAX_VALUE + 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, (long)Integer.MAX_VALUE));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Integer.MAX_VALUE - 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, 0L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, -10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Integer.MIN_VALUE + 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, (long)Integer.MIN_VALUE));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Integer.MIN_VALUE - 10L));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.INTEGER, Long.MIN_VALUE));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_INT));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_INT, 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_INT, 0L));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_INT, -10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, Long.MAX_VALUE));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, 0L));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, -10L));
+        assertFalse(PDataType.RAW_LONG.isCoercibleTo(PDataType.UNSIGNED_LONG, Long.MIN_VALUE));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.LONG));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.LONG, 10L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.LONG, 0L));
+        assertTrue(PDataType.RAW_LONG.isCoercibleTo(PDataType.LONG, -10L));
 
         // Testing coercing unsigned_int to other values.
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.INTEGER));
@@ -333,6 +397,9 @@ public class PDataTypeTest {
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.LONG));
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.LONG, 10));
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.LONG, 0));
+        assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.RAW_LONG));
+        assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.RAW_LONG, 10));
+        assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.RAW_LONG, 0));
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.UNSIGNED_LONG));
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.UNSIGNED_LONG, 10));
         assertTrue(PDataType.UNSIGNED_INT.isCoercibleTo(PDataType.UNSIGNED_LONG, 0));
@@ -342,6 +409,7 @@ public class PDataTypeTest {
         assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.INTEGER, 10L));
         assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.INTEGER, 0L));
         assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.LONG));
+        assertTrue(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.RAW_LONG));
         assertFalse(PDataType.UNSIGNED_LONG.isCoercibleTo(PDataType.UNSIGNED_INT));
         
         // Testing coercing Date types


### PR DESCRIPTION
this is just for anyone who is interested to check out mu tweak on UPSERT to support atomic INCREASE

A few usage show case :

```
    CREATE TABLE test_table 
(row varchar not null, col_int integer, col_long bigint, col_long2 bigint
CONSTRAINT pk PRIMARY KEY (row));

    // increase on existing row.
UPSERT INTO test_table(row, col_int, col_long, col_long2) VALUES('row1', 1, 1, 1);
UPSERT INTO test_table(row, col_long, col_long2) INCREASE VALUES('row1', -100, 1000);

    // increase on non existing row.
UPSERT INTO test_table(row, col_long, col_long2) INCREASE VALUES('row2', 100, 1000);
```
