### PR TITLE
Issue #229 Support for non-aggregation ORDER BY with no LIMIT

### DIFF
--- a/src/main/java/com/salesforce/phoenix/compile/OrderByCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/OrderByCompiler.java
@@ -103,9 +103,6 @@ public class OrderByCompiler {
                             .setMessage(nonAggregateExpression.toString()).build().buildException();
                         }
                         ExpressionCompiler.throwNonAggExpressionInAggException(nonAggregateExpression.toString());
-                    } else if (limit == null && !context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) {
-                        // Throw if no limit unless hint indicates that all data is in single region
-                        throw new SQLExceptionInfo.Builder(SQLExceptionCode.UNSUPPORTED_ORDER_BY_QUERY).build().buildException();
                     }
                 }
                 OrderByExpression col = new OrderByExpression(expression, node.isNullsLast(), node.isAscending());

--- a/src/main/java/com/salesforce/phoenix/coprocessor/ScanRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/ScanRegionObserver.java
@@ -107,7 +107,7 @@ public class ScanRegionObserver extends BaseScannerRegionObserver {
                 orderByExpressions.add(orderByExpression);
             }
             ResultIterator inner = new RegionScannerResultIterator(s);
-            return new OrderedResultIterator(inner, orderByExpressions, limit, estimatedRowSize);
+            return new OrderedResultIterator(inner, orderByExpressions, limit >= 0 ? limit : null, estimatedRowSize);
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {

--- a/src/main/java/com/salesforce/phoenix/coprocessor/ScanRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/ScanRegionObserver.java
@@ -67,10 +67,11 @@ public class ScanRegionObserver extends BaseScannerRegionObserver {
     public static final String NON_AGGREGATE_QUERY = "NonAggregateQuery";
     private static final String TOPN = "TopN";
 
-    public static void serializeIntoScan(Scan scan, int limit, List<OrderByExpression> orderByExpressions, int estimatedRowSize) {
+    public static void serializeIntoScan(Scan scan, int thresholdBytes, int limit, List<OrderByExpression> orderByExpressions, int estimatedRowSize) {
         ByteArrayOutputStream stream = new ByteArrayOutputStream(); // TODO: size?
         try {
             DataOutputStream output = new DataOutputStream(stream);
+            WritableUtils.writeVInt(output, thresholdBytes);
             WritableUtils.writeVInt(output, limit);
             WritableUtils.writeVInt(output, estimatedRowSize);
             WritableUtils.writeVInt(output, orderByExpressions.size());
@@ -97,6 +98,7 @@ public class ScanRegionObserver extends BaseScannerRegionObserver {
         ByteArrayInputStream stream = new ByteArrayInputStream(topN); // TODO: size?
         try {
             DataInputStream input = new DataInputStream(stream);
+            int thresholdBytes = WritableUtils.readVInt(input);
             int limit = WritableUtils.readVInt(input);
             int estimatedRowSize = WritableUtils.readVInt(input);
             int size = WritableUtils.readVInt(input);
@@ -107,7 +109,7 @@ public class ScanRegionObserver extends BaseScannerRegionObserver {
                 orderByExpressions.add(orderByExpression);
             }
             ResultIterator inner = new RegionScannerResultIterator(s);
-            return new OrderedResultIterator(inner, orderByExpressions, limit >= 0 ? limit : null, estimatedRowSize);
+            return new OrderedResultIterator(inner, orderByExpressions, thresholdBytes, limit >= 0 ? limit : null, estimatedRowSize);
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {

--- a/src/main/java/com/salesforce/phoenix/execute/AggregatePlan.java
+++ b/src/main/java/com/salesforce/phoenix/execute/AggregatePlan.java
@@ -106,7 +106,9 @@ public class AggregatePlan extends BasicQueryPlan {
                 resultScanner = new LimitingResultIterator(aggResultIterator, limit);
             }
         } else {
-            resultScanner = new OrderedAggregatingResultIterator(aggResultIterator, orderBy.getOrderByExpressions(), limit);
+            int thresholdBytes = services.getConfig().getInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, 
+            		QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
+            resultScanner = new OrderedAggregatingResultIterator(aggResultIterator, orderBy.getOrderByExpressions(), thresholdBytes, limit);
         }
         
         return new WrappedScanner(resultScanner, getProjector());

--- a/src/main/java/com/salesforce/phoenix/execute/AggregatePlan.java
+++ b/src/main/java/com/salesforce/phoenix/execute/AggregatePlan.java
@@ -107,7 +107,7 @@ public class AggregatePlan extends BasicQueryPlan {
             }
         } else {
             int thresholdBytes = services.getConfig().getInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, 
-            		QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
+                    QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
             resultScanner = new OrderedAggregatingResultIterator(aggResultIterator, orderBy.getOrderByExpressions(), thresholdBytes, limit);
         }
         

--- a/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
+++ b/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
@@ -56,7 +56,7 @@ public class ScanPlan extends BasicQueryPlan {
         super(context, table, projector, context.getBindManager().getParameterMetaData(), limit, orderBy);
         if (!orderBy.getOrderByExpressions().isEmpty() && !context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) { // TopN
             int thresholdBytes = context.getConnection().getQueryServices().getConfig().getInt(
-            		QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
+                    QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
             ScanRegionObserver.serializeIntoScan(context.getScan(), thresholdBytes, limit == null ? -1 : limit, orderBy.getOrderByExpressions(), projector.getEstimatedByteSize());
         }
     }
@@ -99,7 +99,7 @@ public class ScanPlan extends BasicQueryPlan {
                 // do the sort on the client side
                 if (context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) {
                     int thresholdBytes = services.getConfig().getInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, 
-                    		QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
+                            QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
                     scanner = new ConcatResultIterator(iterators);
                     scanner = new OrderedResultIterator(scanner, orderBy.getOrderByExpressions(), thresholdBytes, limit);
                 } else {

--- a/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
+++ b/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
@@ -55,7 +55,9 @@ public class ScanPlan extends BasicQueryPlan {
     public ScanPlan(StatementContext context, TableRef table, RowProjector projector, Integer limit, OrderBy orderBy) {
         super(context, table, projector, context.getBindManager().getParameterMetaData(), limit, orderBy);
         if (!orderBy.getOrderByExpressions().isEmpty() && !context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) { // TopN
-            ScanRegionObserver.serializeIntoScan(context.getScan(), limit == null ? -1 : limit, orderBy.getOrderByExpressions(), projector.getEstimatedByteSize());
+            int thresholdBytes = context.getConnection().getQueryServices().getConfig().getInt(
+            		QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
+            ScanRegionObserver.serializeIntoScan(context.getScan(), thresholdBytes, limit == null ? -1 : limit, orderBy.getOrderByExpressions(), projector.getEstimatedByteSize());
         }
     }
     
@@ -96,8 +98,10 @@ public class ScanPlan extends BasicQueryPlan {
                 // If we expect to have a small amount of data in a single region
                 // do the sort on the client side
                 if (context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) {
+                    int thresholdBytes = services.getConfig().getInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, 
+                    		QueryServicesOptions.DEFAULT_SPOOL_THRESHOLD_BYTES);
                     scanner = new ConcatResultIterator(iterators);
-                    scanner = new OrderedResultIterator(scanner, orderBy.getOrderByExpressions(), limit);
+                    scanner = new OrderedResultIterator(scanner, orderBy.getOrderByExpressions(), thresholdBytes, limit);
                 } else {
                     scanner = new MergeSortTopNResultIterator(iterators, limit, orderBy.getOrderByExpressions());
                 }

--- a/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
+++ b/src/main/java/com/salesforce/phoenix/execute/ScanPlan.java
@@ -54,8 +54,8 @@ public class ScanPlan extends BasicQueryPlan {
     
     public ScanPlan(StatementContext context, TableRef table, RowProjector projector, Integer limit, OrderBy orderBy) {
         super(context, table, projector, context.getBindManager().getParameterMetaData(), limit, orderBy);
-        if (limit != null && !orderBy.getOrderByExpressions().isEmpty() && !context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) { // TopN
-            ScanRegionObserver.serializeIntoScan(context.getScan(), limit, orderBy.getOrderByExpressions(), projector.getEstimatedByteSize());
+        if (!orderBy.getOrderByExpressions().isEmpty() && !context.hasHint(Hint.NO_INTRA_REGION_PARALLELIZATION)) { // TopN
+            ScanRegionObserver.serializeIntoScan(context.getScan(), limit == null ? -1 : limit, orderBy.getOrderByExpressions(), projector.getEstimatedByteSize());
         }
     }
     

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -24,305 +24,320 @@ import com.salesforce.phoenix.schema.tuple.ResultTuple;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 
 public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
-  private int flushSize = 10000; //TODO make this number configurable.
-  private Comparator<ResultEntry> comparator;
-  private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
-  private MappedByteBufferPriorityQueue currentQueue = null;
-  private int currentIndex = 0;
-  MinMaxPriorityQueue<IndexedResultEntry> mergedQueue = null;
-  
-  public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator) throws IOException {
-    this.comparator = comparator;
-    this.currentQueue = new MappedByteBufferPriorityQueue(0, flushSize, comparator);
-  }
-  
-  @Override
-  public boolean offer(ResultEntry e) {
-    try {
-      boolean isFlush = this.currentQueue.writeResult(e);
-      if(isFlush) {
-        queues.add(currentQueue);
-        currentIndex++;
-        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, flushSize, comparator);
-        currentQueue.writeResult(e);
-      }
-    } catch (IOException e1) {
-      return false;
-    }
-    
-    return true;
-  }
+	private Comparator<ResultEntry> comparator;
+	private final int thresholdBytes;
+	private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
+	private MappedByteBufferPriorityQueue currentQueue = null;
+	private int currentIndex = 0;
+	MinMaxPriorityQueue<IndexedResultEntry> mergedQueue = null;
 
-  @Override
-  public ResultEntry poll() {
-    if(mergedQueue==null) {
-      mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
-          .maximumSize(queues.size()).create();
-      for(MappedByteBufferPriorityQueue queue: queues) {
-        try {
-          mergedQueue.add(queue.getNextResult());
-        } catch (IOException e) {
-          return null;
-        }
-      }
-    }
-    if(!mergedQueue.isEmpty()) {
-      IndexedResultEntry re = mergedQueue.pollFirst();
-      if(re!=null) {
-        IndexedResultEntry next = null;
-        try {
-          next = queues.get(re.getIndex()).getNextResult();
-        } catch (IOException e) {
-          return null;
-        }
-         if(next != null) {
-           mergedQueue.add(next);
-         }
-         return re;
-      }
-    }
-    return null;
-  }
+	public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator, int thresholdBytes)
+			throws IOException {
+		this.comparator = comparator;
+		this.thresholdBytes = thresholdBytes;
+		this.currentQueue = new MappedByteBufferPriorityQueue(0, thresholdBytes,
+				comparator);
+	}
 
-  @Override
-  public ResultEntry peek() {
-    if(mergedQueue==null) {
-      mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
-          .maximumSize(queues.size()).create();
-      for(MappedByteBufferPriorityQueue queue: queues) {
-        try {
-          mergedQueue.add(queue.getNextResult());
-        } catch (IOException e) {
-          return null;
-        }
-      }
-    }
-    if(!mergedQueue.isEmpty()) {
-      IndexedResultEntry re = mergedQueue.peekFirst();
-      if(re!=null) {
-         return re;
-      }
-    }
-    return null;
-  }
+	@Override
+	public boolean offer(ResultEntry e) {
+		try {
+			boolean isFlush = this.currentQueue.writeResult(e);
+			if (isFlush) {
+				queues.add(currentQueue);
+				currentIndex++;
+				currentQueue = new MappedByteBufferPriorityQueue(currentIndex,
+						thresholdBytes, comparator);
+				currentQueue.writeResult(e);
+			}
+		} catch (IOException e1) {
+			return false;
+		}
 
-  @Override
-  public Iterator<ResultEntry> iterator() {
-    // TODO Auto-generated method stub
-    return null;
-  }
+		return true;
+	}
 
-  @Override
-  public int size() {
-    int size = 0;
-    for(MappedByteBufferPriorityQueue queue : queues) {
-      size += queue.results.size();
-    }
-    return size;
-  }
-  
-  public void close() {
-    if (queues != null) {
-      for (MappedByteBufferPriorityQueue queue : queues) {
-        queue.close();
-      }
-    }
-  }
-  
-  private static class IndexedResultEntry extends ResultEntry{
-    private ResultEntry resultEntry;
-    private int index;
-    
-    public IndexedResultEntry(int index, ResultEntry resultEntry) {
-      super(resultEntry.sortKeys, resultEntry.result);
-      this.index = index;
-      this.resultEntry = resultEntry;
-    }
-    
-    @SuppressWarnings("unused")
-    public ResultEntry getResultEntry(){
-      return this.resultEntry;
-    }
-    public int getIndex(){
-      return this.index;
-    }
-  }
+	@Override
+	public ResultEntry poll() {
+		if (mergedQueue == null) {
+			mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
+					comparator).maximumSize(queues.size()).create();
+			for (MappedByteBufferPriorityQueue queue : queues) {
+				try {
+					mergedQueue.add(queue.getNextResult());
+				} catch (IOException e) {
+					return null;
+				}
+			}
+		}
+		if (!mergedQueue.isEmpty()) {
+			IndexedResultEntry re = mergedQueue.pollFirst();
+			if (re != null) {
+				IndexedResultEntry next = null;
+				try {
+					next = queues.get(re.getIndex()).getNextResult();
+				} catch (IOException e) {
+					return null;
+				}
+				if (next != null) {
+					mergedQueue.add(next);
+				}
+				return re;
+			}
+		}
+		return null;
+	}
 
-  private static class MappedByteBufferPriorityQueue {
-    int mappingSize;
-    long allReadSize = 0;
-    long allWriteSize = 0;
-    long writeIndex = 0, readIndex = 0;
-    private MappedByteBuffer writeBuffer, readBuffer;
-    private FileChannel fc;
-    private RandomAccessFile af;
-    private File file;
-    private boolean stop = false;
-    MinMaxPriorityQueue<ResultEntry> results = null;
-    private boolean flushBuffer = false;
-//    private ImmutableBytesWritable[] sortKeys;
-    private int index;
+	@Override
+	public ResultEntry peek() {
+		if (mergedQueue == null) {
+			mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
+					comparator).maximumSize(queues.size()).create();
+			for (MappedByteBufferPriorityQueue queue : queues) {
+				try {
+					mergedQueue.add(queue.getNextResult());
+				} catch (IOException e) {
+					return null;
+				}
+			}
+		}
+		if (!mergedQueue.isEmpty()) {
+			IndexedResultEntry re = mergedQueue.peekFirst();
+			if (re != null) {
+				return re;
+			}
+		}
+		return null;
+	}
 
-    public MappedByteBufferPriorityQueue(int index, int resultMappingSize, Comparator<ResultEntry> comparator) throws IOException {
-      this.index = index;
-      this.file = File.createTempFile(UUID.randomUUID().toString(), null);
-      this.af = new RandomAccessFile(file, "rw");
-      this.fc = af.getChannel();
-      this.mappingSize = resultMappingSize;
-      results = MinMaxPriorityQueue.<ResultEntry>orderedBy(comparator).create();
-      writeBuffer = fc.map(MapMode.READ_WRITE, this.writeIndex,
-          this.mappingSize);
-      readBuffer = fc.map(MapMode.READ_ONLY, this.readIndex, this.mappingSize);
-    }
-    
-    private List<KeyValue> toKeyValues(ResultEntry entry) {
-      Tuple result = entry.getResult();
-      int size = result.size();
-      List<KeyValue> kvs = new ArrayList<KeyValue>(size);
-      for (int i = 0; i < size; i++) {
-        kvs.add(result.getValue(i));
-      }
-      return kvs;
-    }
-    
-    private int sizeof(List<KeyValue> kvs) {
-      int size = Bytes.SIZEOF_INT; // totalLen
+	@Override
+	public Iterator<ResultEntry> iterator() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 
-      for (KeyValue kv : kvs) {
-        size += kv.getLength();
-        size += Bytes.SIZEOF_INT; // kv.getLength
-      }
+	@Override
+	public int size() {
+		int size = 0;
+		for (MappedByteBufferPriorityQueue queue : queues) {
+			size += queue.results.size();
+		}
+		return size;
+	}
 
-      return size;
-    }
-    
-    private int sizeof(ImmutableBytesWritable[]sortKeys) {
-      int size = Bytes.SIZEOF_INT;
-      if(sortKeys!=null) {
-        for(ImmutableBytesWritable sortKey: sortKeys) {
-          size += sortKey.getLength();
-          size += Bytes.SIZEOF_INT;
-        }
-      }
-      return size;
-    }
-    
-    public boolean writeResult(ResultEntry entry) throws IOException {
-      int sortKeySize = sizeof(entry.sortKeys);
-      int resultSize = sizeof(toKeyValues(entry)) + sortKeySize;
-      if (resultSize >= mappingSize) {
-        throw new IOException("Result is too large, buffer size is["
-            + mappingSize + "], and result size is[" + resultSize + "].");
-      }
-      if (allWriteSize + resultSize >= writeIndex + mappingSize) {
-        writeBuffer.force();
-        writeIndex = allWriteSize;
-        writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex, mappingSize);
-        for(int i=0;i<results.size();i++) {
-          int totalLen = 0;
-          ResultEntry re = results.pollFirst();
-          List<KeyValue> keyValues = toKeyValues(re);
-          for (KeyValue kv : keyValues) {
-            totalLen = kv.getLength() + Bytes.SIZEOF_INT;
-          }
-          writeBuffer.putInt(totalLen);
-          allWriteSize += Bytes.SIZEOF_INT;
-          for (KeyValue kv : keyValues) {
-            writeBuffer.putInt(kv.getLength());
-            allWriteSize += Bytes.SIZEOF_INT;
-            writeBuffer.put(kv.getBuffer(), kv.getOffset(), kv.getLength());
-            allWriteSize += kv.getLength();
-          }
-          ImmutableBytesWritable[] sortKeys = re.sortKeys;
-          writeBuffer.putInt(sortKeySize);
-          allWriteSize += Bytes.SIZEOF_INT;
-          for(ImmutableBytesWritable sortKey: sortKeys){
-            writeBuffer.putInt(sortKey.getLength());
-            allWriteSize += Bytes.SIZEOF_INT;
-            writeBuffer.put(sortKey.get(), sortKey.getOffset(), sortKey.getLength());
-            allWriteSize += sortKey.getLength();
-          }
-        }
-        flushBuffer = true;
-      } else {
-        results.add(entry);
-      }
-      return flushBuffer;
-    }
+	public void close() {
+		if (queues != null) {
+			for (MappedByteBufferPriorityQueue queue : queues) {
+				queue.close();
+			}
+		}
+	}
 
-    public IndexedResultEntry getNextResult() throws IOException {
-      if (allReadSize != 0 && allReadSize == allWriteSize && stop) {
-        return null;
-      }
-      if(flushBuffer) {
-        if (readBuffer == null
-            || allReadSize + Bytes.SIZEOF_INT >= readIndex + mappingSize) {
-          readIndex = allReadSize;
-          readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
-              mappingSize);
-        }
-        int length = readBuffer.getInt();
-        allReadSize += Bytes.SIZEOF_INT;
-        long nextResultIndex = allReadSize + length;
-        if (nextResultIndex >= readIndex + mappingSize) {
-          readIndex = allReadSize;
-          readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
-              mappingSize);
-        }
-        byte[] rb = new byte[length];
-        readBuffer.get(rb);
-        this.allReadSize += length;
-        Result result = new Result(new ImmutableBytesWritable(rb));
-        ResultTuple rt = new ResultTuple(result);
-        int sortKeySize = readBuffer.getInt();
-        allReadSize += Bytes.SIZEOF_INT;
-        ImmutableBytesWritable[]sortKeys = new ImmutableBytesWritable[sortKeySize];
-        for (int i = 0; i < sortKeySize; i++) {
-          int contentLength = readBuffer.getInt();
-          allReadSize += Bytes.SIZEOF_INT;
-          byte[]sortKeyContent = new byte[contentLength];
-          allReadSize += contentLength;
-          readBuffer.get(sortKeyContent);
-          sortKeys[i] = new ImmutableBytesWritable(sortKeyContent);
-        }
-        ResultEntry re = new ResultEntry(sortKeys, rt);
-        return new IndexedResultEntry(index, re);
-      } else {
-        ResultEntry re = results.poll();
-        return new IndexedResultEntry(index, re);
-      }
-    }
+	private static class IndexedResultEntry extends ResultEntry {
+		private ResultEntry resultEntry;
+		private int index;
 
-    public void stop() {
-      this.stop = true;
-    }
+		public IndexedResultEntry(int index, ResultEntry resultEntry) {
+			super(resultEntry.sortKeys, resultEntry.result);
+			this.index = index;
+			this.resultEntry = resultEntry;
+		}
 
-    public void close() {
-      this.stop();
-      if (this.fc != null) {
-        try {
-          this.fc.close();
-        } catch (IOException e) {
-//          logger.debug("Failed to close FileChannel:" + this.fc);
-        }
-      }
-      if (this.af != null) {
-        try {
-          this.af.close();
-        } catch (IOException e) {
+		@SuppressWarnings("unused")
+		public ResultEntry getResultEntry() {
+			return this.resultEntry;
+		}
 
-        }
-      }
-      if (this.file != null) {
-        if (file.isFile()) {
-          boolean result = file.delete();
-          if (!result) {
-//            logger.warn("Failed to delete buffer file[" + file + "]");
-          } else {
-//            logger.debug("Has deleted buffer file[" + file + "]");
-          }
-        }
-      }
-    }
-  }
+		public int getIndex() {
+			return this.index;
+		}
+	}
+
+	private static class MappedByteBufferPriorityQueue {
+		int mappingSize;
+		long allReadSize = 0;
+		long allWriteSize = 0;
+		long writeIndex = 0, readIndex = 0;
+		private MappedByteBuffer writeBuffer, readBuffer;
+		private FileChannel fc;
+		private RandomAccessFile af;
+		private File file;
+		private boolean stop = false;
+		MinMaxPriorityQueue<ResultEntry> results = null;
+		private boolean flushBuffer = false;
+		// private ImmutableBytesWritable[] sortKeys;
+		private int index;
+
+		public MappedByteBufferPriorityQueue(int index, int resultMappingSize,
+				Comparator<ResultEntry> comparator) throws IOException {
+			this.index = index;
+			this.file = File.createTempFile(UUID.randomUUID().toString(), null);
+			this.af = new RandomAccessFile(file, "rw");
+			this.fc = af.getChannel();
+			this.mappingSize = resultMappingSize;
+			results = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
+					.create();
+			writeBuffer = fc.map(MapMode.READ_WRITE, this.writeIndex,
+					this.mappingSize);
+			readBuffer = fc.map(MapMode.READ_ONLY, this.readIndex,
+					this.mappingSize);
+		}
+
+		private List<KeyValue> toKeyValues(ResultEntry entry) {
+			Tuple result = entry.getResult();
+			int size = result.size();
+			List<KeyValue> kvs = new ArrayList<KeyValue>(size);
+			for (int i = 0; i < size; i++) {
+				kvs.add(result.getValue(i));
+			}
+			return kvs;
+		}
+
+		private int sizeof(List<KeyValue> kvs) {
+			int size = Bytes.SIZEOF_INT; // totalLen
+
+			for (KeyValue kv : kvs) {
+				size += kv.getLength();
+				size += Bytes.SIZEOF_INT; // kv.getLength
+			}
+
+			return size;
+		}
+
+		private int sizeof(ImmutableBytesWritable[] sortKeys) {
+			int size = Bytes.SIZEOF_INT;
+			if (sortKeys != null) {
+				for (ImmutableBytesWritable sortKey : sortKeys) {
+					size += sortKey.getLength();
+					size += Bytes.SIZEOF_INT;
+				}
+			}
+			return size;
+		}
+
+		public boolean writeResult(ResultEntry entry) throws IOException {
+			int sortKeySize = sizeof(entry.sortKeys);
+			int resultSize = sizeof(toKeyValues(entry)) + sortKeySize;
+			if (resultSize >= mappingSize) {
+				throw new IOException("Result is too large, buffer size is["
+						+ mappingSize + "], and result size is[" + resultSize
+						+ "].");
+			}
+			if (allWriteSize + resultSize >= writeIndex + mappingSize) {
+				writeBuffer.force();
+				writeIndex = allWriteSize;
+				writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex,
+						mappingSize);
+				for (int i = 0; i < results.size(); i++) {
+					int totalLen = 0;
+					ResultEntry re = results.pollFirst();
+					List<KeyValue> keyValues = toKeyValues(re);
+					for (KeyValue kv : keyValues) {
+						totalLen = kv.getLength() + Bytes.SIZEOF_INT;
+					}
+					writeBuffer.putInt(totalLen);
+					allWriteSize += Bytes.SIZEOF_INT;
+					for (KeyValue kv : keyValues) {
+						writeBuffer.putInt(kv.getLength());
+						allWriteSize += Bytes.SIZEOF_INT;
+						writeBuffer.put(kv.getBuffer(), kv.getOffset(), kv
+								.getLength());
+						allWriteSize += kv.getLength();
+					}
+					ImmutableBytesWritable[] sortKeys = re.sortKeys;
+					writeBuffer.putInt(sortKeySize);
+					allWriteSize += Bytes.SIZEOF_INT;
+					for (ImmutableBytesWritable sortKey : sortKeys) {
+						writeBuffer.putInt(sortKey.getLength());
+						allWriteSize += Bytes.SIZEOF_INT;
+						writeBuffer.put(sortKey.get(), sortKey.getOffset(),
+								sortKey.getLength());
+						allWriteSize += sortKey.getLength();
+					}
+				}
+				flushBuffer = true;
+			} else {
+				results.add(entry);
+			}
+			return flushBuffer;
+		}
+
+		public IndexedResultEntry getNextResult() throws IOException {
+			if (allReadSize != 0 && allReadSize == allWriteSize && stop) {
+				return null;
+			}
+			if (flushBuffer) {
+				if (readBuffer == null
+						|| allReadSize + Bytes.SIZEOF_INT >= readIndex
+								+ mappingSize) {
+					readIndex = allReadSize;
+					readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+							mappingSize);
+				}
+				int length = readBuffer.getInt();
+				allReadSize += Bytes.SIZEOF_INT;
+				long nextResultIndex = allReadSize + length;
+				if (nextResultIndex >= readIndex + mappingSize) {
+					readIndex = allReadSize;
+					readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+							mappingSize);
+				}
+				byte[] rb = new byte[length];
+				readBuffer.get(rb);
+				this.allReadSize += length;
+				Result result = new Result(new ImmutableBytesWritable(rb));
+				ResultTuple rt = new ResultTuple(result);
+				int sortKeySize = readBuffer.getInt();
+				allReadSize += Bytes.SIZEOF_INT;
+				ImmutableBytesWritable[] sortKeys = new ImmutableBytesWritable[sortKeySize];
+				for (int i = 0; i < sortKeySize; i++) {
+					int contentLength = readBuffer.getInt();
+					allReadSize += Bytes.SIZEOF_INT;
+					byte[] sortKeyContent = new byte[contentLength];
+					allReadSize += contentLength;
+					readBuffer.get(sortKeyContent);
+					sortKeys[i] = new ImmutableBytesWritable(sortKeyContent);
+				}
+				ResultEntry re = new ResultEntry(sortKeys, rt);
+				return new IndexedResultEntry(index, re);
+			} else {
+				ResultEntry re = results.poll();
+				return new IndexedResultEntry(index, re);
+			}
+		}
+
+		public void stop() {
+			this.stop = true;
+		}
+
+		public void close() {
+			this.stop();
+			if (this.fc != null) {
+				try {
+					this.fc.close();
+				} catch (IOException e) {
+					// logger.debug("Failed to close FileChannel:" + this.fc);
+				}
+			}
+			if (this.af != null) {
+				try {
+					this.af.close();
+				} catch (IOException e) {
+
+				}
+			}
+			if (this.file != null) {
+				if (file.isFile()) {
+					boolean result = file.delete();
+					if (!result) {
+						// logger.warn("Failed to delete buffer file[" + file +
+						// "]");
+					} else {
+						// logger.debug("Has deleted buffer file[" + file +
+						// "]");
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -24,320 +24,320 @@ import com.salesforce.phoenix.schema.tuple.ResultTuple;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 
 public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
-	private Comparator<ResultEntry> comparator;
-	private final int thresholdBytes;
-	private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
-	private MappedByteBufferPriorityQueue currentQueue = null;
-	private int currentIndex = 0;
-	MinMaxPriorityQueue<IndexedResultEntry> mergedQueue = null;
+    private Comparator<ResultEntry> comparator;
+    private final int thresholdBytes;
+    private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
+    private MappedByteBufferPriorityQueue currentQueue = null;
+    private int currentIndex = 0;
+    MinMaxPriorityQueue<IndexedResultEntry> mergedQueue = null;
 
-	public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator, int thresholdBytes)
-			throws IOException {
-		this.comparator = comparator;
-		this.thresholdBytes = thresholdBytes;
-		this.currentQueue = new MappedByteBufferPriorityQueue(0, thresholdBytes,
-				comparator);
-	}
+    public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator,
+            int thresholdBytes) throws IOException {
+        this.comparator = comparator;
+        this.thresholdBytes = thresholdBytes;
+        this.currentQueue = new MappedByteBufferPriorityQueue(0,
+                thresholdBytes, comparator);
+    }
 
-	@Override
-	public boolean offer(ResultEntry e) {
-		try {
-			boolean isFlush = this.currentQueue.writeResult(e);
-			if (isFlush) {
-				queues.add(currentQueue);
-				currentIndex++;
-				currentQueue = new MappedByteBufferPriorityQueue(currentIndex,
-						thresholdBytes, comparator);
-				currentQueue.writeResult(e);
-			}
-		} catch (IOException e1) {
-			return false;
-		}
+    @Override
+    public boolean offer(ResultEntry e) {
+        try {
+            boolean isFlush = this.currentQueue.writeResult(e);
+            if (isFlush) {
+                queues.add(currentQueue);
+                currentIndex++;
+                currentQueue = new MappedByteBufferPriorityQueue(currentIndex,
+                        thresholdBytes, comparator);
+                currentQueue.writeResult(e);
+            }
+        } catch (IOException e1) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	@Override
-	public ResultEntry poll() {
-		if (mergedQueue == null) {
-			mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
-					comparator).maximumSize(queues.size()).create();
-			for (MappedByteBufferPriorityQueue queue : queues) {
-				try {
-					mergedQueue.add(queue.getNextResult());
-				} catch (IOException e) {
-					return null;
-				}
-			}
-		}
-		if (!mergedQueue.isEmpty()) {
-			IndexedResultEntry re = mergedQueue.pollFirst();
-			if (re != null) {
-				IndexedResultEntry next = null;
-				try {
-					next = queues.get(re.getIndex()).getNextResult();
-				} catch (IOException e) {
-					return null;
-				}
-				if (next != null) {
-					mergedQueue.add(next);
-				}
-				return re;
-			}
-		}
-		return null;
-	}
+    @Override
+    public ResultEntry poll() {
+        if (mergedQueue == null) {
+            mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
+                    comparator).maximumSize(queues.size()).create();
+            for (MappedByteBufferPriorityQueue queue : queues) {
+                try {
+                    mergedQueue.add(queue.getNextResult());
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+        }
+        if (!mergedQueue.isEmpty()) {
+            IndexedResultEntry re = mergedQueue.pollFirst();
+            if (re != null) {
+                IndexedResultEntry next = null;
+                try {
+                    next = queues.get(re.getIndex()).getNextResult();
+                } catch (IOException e) {
+                    return null;
+                }
+                if (next != null) {
+                    mergedQueue.add(next);
+                }
+                return re;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public ResultEntry peek() {
-		if (mergedQueue == null) {
-			mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
-					comparator).maximumSize(queues.size()).create();
-			for (MappedByteBufferPriorityQueue queue : queues) {
-				try {
-					mergedQueue.add(queue.getNextResult());
-				} catch (IOException e) {
-					return null;
-				}
-			}
-		}
-		if (!mergedQueue.isEmpty()) {
-			IndexedResultEntry re = mergedQueue.peekFirst();
-			if (re != null) {
-				return re;
-			}
-		}
-		return null;
-	}
+    @Override
+    public ResultEntry peek() {
+        if (mergedQueue == null) {
+            mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(
+                    comparator).maximumSize(queues.size()).create();
+            for (MappedByteBufferPriorityQueue queue : queues) {
+                try {
+                    mergedQueue.add(queue.getNextResult());
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+        }
+        if (!mergedQueue.isEmpty()) {
+            IndexedResultEntry re = mergedQueue.peekFirst();
+            if (re != null) {
+                return re;
+            }
+        }
+        return null;
+    }
 
-	@Override
-	public Iterator<ResultEntry> iterator() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Iterator<ResultEntry> iterator() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public int size() {
-		int size = 0;
-		for (MappedByteBufferPriorityQueue queue : queues) {
-			size += queue.results.size();
-		}
-		return size;
-	}
+    @Override
+    public int size() {
+        int size = 0;
+        for (MappedByteBufferPriorityQueue queue : queues) {
+            size += queue.results.size();
+        }
+        return size;
+    }
 
-	public void close() {
-		if (queues != null) {
-			for (MappedByteBufferPriorityQueue queue : queues) {
-				queue.close();
-			}
-		}
-	}
+    public void close() {
+        if (queues != null) {
+            for (MappedByteBufferPriorityQueue queue : queues) {
+                queue.close();
+            }
+        }
+    }
 
-	private static class IndexedResultEntry extends ResultEntry {
-		private ResultEntry resultEntry;
-		private int index;
+    private static class IndexedResultEntry extends ResultEntry {
+        private ResultEntry resultEntry;
+        private int index;
 
-		public IndexedResultEntry(int index, ResultEntry resultEntry) {
-			super(resultEntry.sortKeys, resultEntry.result);
-			this.index = index;
-			this.resultEntry = resultEntry;
-		}
+        public IndexedResultEntry(int index, ResultEntry resultEntry) {
+            super(resultEntry.sortKeys, resultEntry.result);
+            this.index = index;
+            this.resultEntry = resultEntry;
+        }
 
-		@SuppressWarnings("unused")
-		public ResultEntry getResultEntry() {
-			return this.resultEntry;
-		}
+        @SuppressWarnings("unused")
+        public ResultEntry getResultEntry() {
+            return this.resultEntry;
+        }
 
-		public int getIndex() {
-			return this.index;
-		}
-	}
+        public int getIndex() {
+            return this.index;
+        }
+    }
 
-	private static class MappedByteBufferPriorityQueue {
-		int mappingSize;
-		long allReadSize = 0;
-		long allWriteSize = 0;
-		long writeIndex = 0, readIndex = 0;
-		private MappedByteBuffer writeBuffer, readBuffer;
-		private FileChannel fc;
-		private RandomAccessFile af;
-		private File file;
-		private boolean stop = false;
-		MinMaxPriorityQueue<ResultEntry> results = null;
-		private boolean flushBuffer = false;
-		// private ImmutableBytesWritable[] sortKeys;
-		private int index;
+    private static class MappedByteBufferPriorityQueue {
+        int mappingSize;
+        long allReadSize = 0;
+        long allWriteSize = 0;
+        long writeIndex = 0, readIndex = 0;
+        private MappedByteBuffer writeBuffer, readBuffer;
+        private FileChannel fc;
+        private RandomAccessFile af;
+        private File file;
+        private boolean stop = false;
+        MinMaxPriorityQueue<ResultEntry> results = null;
+        private boolean flushBuffer = false;
+        // private ImmutableBytesWritable[] sortKeys;
+        private int index;
 
-		public MappedByteBufferPriorityQueue(int index, int resultMappingSize,
-				Comparator<ResultEntry> comparator) throws IOException {
-			this.index = index;
-			this.file = File.createTempFile(UUID.randomUUID().toString(), null);
-			this.af = new RandomAccessFile(file, "rw");
-			this.fc = af.getChannel();
-			this.mappingSize = resultMappingSize;
-			results = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
-					.create();
-			writeBuffer = fc.map(MapMode.READ_WRITE, this.writeIndex,
-					this.mappingSize);
-			readBuffer = fc.map(MapMode.READ_ONLY, this.readIndex,
-					this.mappingSize);
-		}
+        public MappedByteBufferPriorityQueue(int index, int resultMappingSize,
+                Comparator<ResultEntry> comparator) throws IOException {
+            this.index = index;
+            this.file = File.createTempFile(UUID.randomUUID().toString(), null);
+            this.af = new RandomAccessFile(file, "rw");
+            this.fc = af.getChannel();
+            this.mappingSize = resultMappingSize;
+            results = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
+                    .create();
+            writeBuffer = fc.map(MapMode.READ_WRITE, this.writeIndex,
+                    this.mappingSize);
+            readBuffer = fc.map(MapMode.READ_ONLY, this.readIndex,
+                    this.mappingSize);
+        }
 
-		private List<KeyValue> toKeyValues(ResultEntry entry) {
-			Tuple result = entry.getResult();
-			int size = result.size();
-			List<KeyValue> kvs = new ArrayList<KeyValue>(size);
-			for (int i = 0; i < size; i++) {
-				kvs.add(result.getValue(i));
-			}
-			return kvs;
-		}
+        private List<KeyValue> toKeyValues(ResultEntry entry) {
+            Tuple result = entry.getResult();
+            int size = result.size();
+            List<KeyValue> kvs = new ArrayList<KeyValue>(size);
+            for (int i = 0; i < size; i++) {
+                kvs.add(result.getValue(i));
+            }
+            return kvs;
+        }
 
-		private int sizeof(List<KeyValue> kvs) {
-			int size = Bytes.SIZEOF_INT; // totalLen
+        private int sizeof(List<KeyValue> kvs) {
+            int size = Bytes.SIZEOF_INT; // totalLen
 
-			for (KeyValue kv : kvs) {
-				size += kv.getLength();
-				size += Bytes.SIZEOF_INT; // kv.getLength
-			}
+            for (KeyValue kv : kvs) {
+                size += kv.getLength();
+                size += Bytes.SIZEOF_INT; // kv.getLength
+            }
 
-			return size;
-		}
+            return size;
+        }
 
-		private int sizeof(ImmutableBytesWritable[] sortKeys) {
-			int size = Bytes.SIZEOF_INT;
-			if (sortKeys != null) {
-				for (ImmutableBytesWritable sortKey : sortKeys) {
-					size += sortKey.getLength();
-					size += Bytes.SIZEOF_INT;
-				}
-			}
-			return size;
-		}
+        private int sizeof(ImmutableBytesWritable[] sortKeys) {
+            int size = Bytes.SIZEOF_INT;
+            if (sortKeys != null) {
+                for (ImmutableBytesWritable sortKey : sortKeys) {
+                    size += sortKey.getLength();
+                    size += Bytes.SIZEOF_INT;
+                }
+            }
+            return size;
+        }
 
-		public boolean writeResult(ResultEntry entry) throws IOException {
-			int sortKeySize = sizeof(entry.sortKeys);
-			int resultSize = sizeof(toKeyValues(entry)) + sortKeySize;
-			if (resultSize >= mappingSize) {
-				throw new IOException("Result is too large, buffer size is["
-						+ mappingSize + "], and result size is[" + resultSize
-						+ "].");
-			}
-			if (allWriteSize + resultSize >= writeIndex + mappingSize) {
-				writeBuffer.force();
-				writeIndex = allWriteSize;
-				writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex,
-						mappingSize);
-				for (int i = 0; i < results.size(); i++) {
-					int totalLen = 0;
-					ResultEntry re = results.pollFirst();
-					List<KeyValue> keyValues = toKeyValues(re);
-					for (KeyValue kv : keyValues) {
-						totalLen = kv.getLength() + Bytes.SIZEOF_INT;
-					}
-					writeBuffer.putInt(totalLen);
-					allWriteSize += Bytes.SIZEOF_INT;
-					for (KeyValue kv : keyValues) {
-						writeBuffer.putInt(kv.getLength());
-						allWriteSize += Bytes.SIZEOF_INT;
-						writeBuffer.put(kv.getBuffer(), kv.getOffset(), kv
-								.getLength());
-						allWriteSize += kv.getLength();
-					}
-					ImmutableBytesWritable[] sortKeys = re.sortKeys;
-					writeBuffer.putInt(sortKeySize);
-					allWriteSize += Bytes.SIZEOF_INT;
-					for (ImmutableBytesWritable sortKey : sortKeys) {
-						writeBuffer.putInt(sortKey.getLength());
-						allWriteSize += Bytes.SIZEOF_INT;
-						writeBuffer.put(sortKey.get(), sortKey.getOffset(),
-								sortKey.getLength());
-						allWriteSize += sortKey.getLength();
-					}
-				}
-				flushBuffer = true;
-			} else {
-				results.add(entry);
-			}
-			return flushBuffer;
-		}
+        public boolean writeResult(ResultEntry entry) throws IOException {
+            int sortKeySize = sizeof(entry.sortKeys);
+            int resultSize = sizeof(toKeyValues(entry)) + sortKeySize;
+            if (resultSize >= mappingSize) {
+                throw new IOException("Result is too large, buffer size is["
+                        + mappingSize + "], and result size is[" + resultSize
+                        + "].");
+            }
+            if (allWriteSize + resultSize >= writeIndex + mappingSize) {
+                writeBuffer.force();
+                writeIndex = allWriteSize;
+                writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex,
+                        mappingSize);
+                for (int i = 0; i < results.size(); i++) {
+                    int totalLen = 0;
+                    ResultEntry re = results.pollFirst();
+                    List<KeyValue> keyValues = toKeyValues(re);
+                    for (KeyValue kv : keyValues) {
+                        totalLen = kv.getLength() + Bytes.SIZEOF_INT;
+                    }
+                    writeBuffer.putInt(totalLen);
+                    allWriteSize += Bytes.SIZEOF_INT;
+                    for (KeyValue kv : keyValues) {
+                        writeBuffer.putInt(kv.getLength());
+                        allWriteSize += Bytes.SIZEOF_INT;
+                        writeBuffer.put(kv.getBuffer(), kv.getOffset(), kv
+                                .getLength());
+                        allWriteSize += kv.getLength();
+                    }
+                    ImmutableBytesWritable[] sortKeys = re.sortKeys;
+                    writeBuffer.putInt(sortKeySize);
+                    allWriteSize += Bytes.SIZEOF_INT;
+                    for (ImmutableBytesWritable sortKey : sortKeys) {
+                        writeBuffer.putInt(sortKey.getLength());
+                        allWriteSize += Bytes.SIZEOF_INT;
+                        writeBuffer.put(sortKey.get(), sortKey.getOffset(),
+                                sortKey.getLength());
+                        allWriteSize += sortKey.getLength();
+                    }
+                }
+                flushBuffer = true;
+            } else {
+                results.add(entry);
+            }
+            return flushBuffer;
+        }
 
-		public IndexedResultEntry getNextResult() throws IOException {
-			if (allReadSize != 0 && allReadSize == allWriteSize && stop) {
-				return null;
-			}
-			if (flushBuffer) {
-				if (readBuffer == null
-						|| allReadSize + Bytes.SIZEOF_INT >= readIndex
-								+ mappingSize) {
-					readIndex = allReadSize;
-					readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
-							mappingSize);
-				}
-				int length = readBuffer.getInt();
-				allReadSize += Bytes.SIZEOF_INT;
-				long nextResultIndex = allReadSize + length;
-				if (nextResultIndex >= readIndex + mappingSize) {
-					readIndex = allReadSize;
-					readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
-							mappingSize);
-				}
-				byte[] rb = new byte[length];
-				readBuffer.get(rb);
-				this.allReadSize += length;
-				Result result = new Result(new ImmutableBytesWritable(rb));
-				ResultTuple rt = new ResultTuple(result);
-				int sortKeySize = readBuffer.getInt();
-				allReadSize += Bytes.SIZEOF_INT;
-				ImmutableBytesWritable[] sortKeys = new ImmutableBytesWritable[sortKeySize];
-				for (int i = 0; i < sortKeySize; i++) {
-					int contentLength = readBuffer.getInt();
-					allReadSize += Bytes.SIZEOF_INT;
-					byte[] sortKeyContent = new byte[contentLength];
-					allReadSize += contentLength;
-					readBuffer.get(sortKeyContent);
-					sortKeys[i] = new ImmutableBytesWritable(sortKeyContent);
-				}
-				ResultEntry re = new ResultEntry(sortKeys, rt);
-				return new IndexedResultEntry(index, re);
-			} else {
-				ResultEntry re = results.poll();
-				return new IndexedResultEntry(index, re);
-			}
-		}
+        public IndexedResultEntry getNextResult() throws IOException {
+            if (allReadSize != 0 && allReadSize == allWriteSize && stop) {
+                return null;
+            }
+            if (flushBuffer) {
+                if (readBuffer == null
+                        || allReadSize + Bytes.SIZEOF_INT >= readIndex
+                                + mappingSize) {
+                    readIndex = allReadSize;
+                    readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+                            mappingSize);
+                }
+                int length = readBuffer.getInt();
+                allReadSize += Bytes.SIZEOF_INT;
+                long nextResultIndex = allReadSize + length;
+                if (nextResultIndex >= readIndex + mappingSize) {
+                    readIndex = allReadSize;
+                    readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+                            mappingSize);
+                }
+                byte[] rb = new byte[length];
+                readBuffer.get(rb);
+                this.allReadSize += length;
+                Result result = new Result(new ImmutableBytesWritable(rb));
+                ResultTuple rt = new ResultTuple(result);
+                int sortKeySize = readBuffer.getInt();
+                allReadSize += Bytes.SIZEOF_INT;
+                ImmutableBytesWritable[] sortKeys = new ImmutableBytesWritable[sortKeySize];
+                for (int i = 0; i < sortKeySize; i++) {
+                    int contentLength = readBuffer.getInt();
+                    allReadSize += Bytes.SIZEOF_INT;
+                    byte[] sortKeyContent = new byte[contentLength];
+                    allReadSize += contentLength;
+                    readBuffer.get(sortKeyContent);
+                    sortKeys[i] = new ImmutableBytesWritable(sortKeyContent);
+                }
+                ResultEntry re = new ResultEntry(sortKeys, rt);
+                return new IndexedResultEntry(index, re);
+            } else {
+                ResultEntry re = results.poll();
+                return new IndexedResultEntry(index, re);
+            }
+        }
 
-		public void stop() {
-			this.stop = true;
-		}
+        public void stop() {
+            this.stop = true;
+        }
 
-		public void close() {
-			this.stop();
-			if (this.fc != null) {
-				try {
-					this.fc.close();
-				} catch (IOException e) {
-					// logger.debug("Failed to close FileChannel:" + this.fc);
-				}
-			}
-			if (this.af != null) {
-				try {
-					this.af.close();
-				} catch (IOException e) {
+        public void close() {
+            this.stop();
+            if (this.fc != null) {
+                try {
+                    this.fc.close();
+                } catch (IOException e) {
+                    // logger.debug("Failed to close FileChannel:" + this.fc);
+                }
+            }
+            if (this.af != null) {
+                try {
+                    this.af.close();
+                } catch (IOException e) {
 
-				}
-			}
-			if (this.file != null) {
-				if (file.isFile()) {
-					boolean result = file.delete();
-					if (!result) {
-						// logger.warn("Failed to delete buffer file[" + file +
-						// "]");
-					} else {
-						// logger.debug("Has deleted buffer file[" + file +
-						// "]");
-					}
-				}
-			}
-		}
-	}
+                }
+            }
+            if (this.file != null) {
+                if (file.isFile()) {
+                    boolean result = file.delete();
+                    if (!result) {
+                        // logger.warn("Failed to delete buffer file[" + file +
+                        // "]");
+                    } else {
+                        // logger.debug("Has deleted buffer file[" + file +
+                        // "]");
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -1,0 +1,331 @@
+package com.salesforce.phoenix.iterate;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.AbstractQueue;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.salesforce.phoenix.iterate.OrderedResultIterator.ResultEntry;
+import com.salesforce.phoenix.schema.tuple.ResultTuple;
+import com.salesforce.phoenix.schema.tuple.Tuple;
+
+public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
+  private Comparator<ResultEntry> comparator;
+  private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
+  private MappedByteBufferPriorityQueue currentQueue = null;
+  private int currentIndex = 0;
+  MinMaxPriorityQueue<IndexedResultEntry> mergedQueue = null;
+  
+  public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator) throws IOException {
+    this.comparator = comparator;
+    this.currentQueue = new MappedByteBufferPriorityQueue(0, getFileName(), 100, comparator); //TODO decide the 100 as a condifugrable one.
+  }
+
+  private String getFileName(){
+    return "/tmp/" + UUID.randomUUID().toString();
+  }
+  
+  @Override
+  public boolean offer(ResultEntry e) {
+    try {
+      boolean isFlush = this.currentQueue.writeResult(e);
+      if(isFlush) {
+        queues.add(currentQueue);
+        currentIndex++;
+        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, getFileName(), 100, comparator); //TODO decide the 100 as a condifugrable one.
+        currentQueue.writeResult(e);
+      }
+    } catch (IOException e1) {
+      return false;
+    }
+    
+    return true;
+  }
+
+  @Override
+  public ResultEntry poll() {
+    if(mergedQueue==null) {
+      mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
+          .maximumSize(queues.size()).create();
+      for(MappedByteBufferPriorityQueue queue: queues) {
+        try {
+          mergedQueue.add(queue.getNextResult());
+        } catch (IOException e) {
+          return null;
+        }
+      }
+    }
+    if(!mergedQueue.isEmpty()) {
+      IndexedResultEntry re = mergedQueue.pollFirst();
+      if(re!=null) {
+        IndexedResultEntry next = null;
+        try {
+          next = queues.get(re.getIndex()).getNextResult();
+        } catch (IOException e) {
+          return null;
+        }
+         if(next != null) {
+           mergedQueue.add(next);
+         }
+         return re;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public ResultEntry peek() {
+    if(mergedQueue==null) {
+      mergedQueue = MinMaxPriorityQueue.<ResultEntry> orderedBy(comparator)
+          .maximumSize(queues.size()).create();
+      for(MappedByteBufferPriorityQueue queue: queues) {
+        try {
+          mergedQueue.add(queue.getNextResult());
+        } catch (IOException e) {
+          return null;
+        }
+      }
+    }
+    if(!mergedQueue.isEmpty()) {
+      IndexedResultEntry re = mergedQueue.peekFirst();
+      if(re!=null) {
+         return re;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Iterator<ResultEntry> iterator() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int size() {
+    int size = 0;
+    for(MappedByteBufferPriorityQueue queue : queues) {
+      size += queue.results.size();
+    }
+    return size;
+  }
+  
+  public void close() {
+    if (queues != null) {
+      for (MappedByteBufferPriorityQueue queue : queues) {
+        queue.close();
+      }
+    }
+  }
+  
+  private static class IndexedResultEntry extends ResultEntry{
+    private ResultEntry resultEntry;
+    private int index;
+    
+    public IndexedResultEntry(int index, ResultEntry resultEntry) {
+      super(resultEntry.sortKeys, resultEntry.result);
+      this.index = index;
+      this.resultEntry = resultEntry;
+    }
+    
+    @SuppressWarnings("unused")
+    public ResultEntry getResultEntry(){
+      return this.resultEntry;
+    }
+    public int getIndex(){
+      return this.index;
+    }
+  }
+
+  private static class MappedByteBufferPriorityQueue {
+    int mappingSize;
+    long allReadSize = 0;
+    long allWriteSize = 0;
+    long writeIndex = 0, readIndex = 0;
+    private MappedByteBuffer writeBuffer, readBuffer;
+    private FileChannel fc;
+    private RandomAccessFile af;
+    private File file;
+    private boolean stop = false;
+    MinMaxPriorityQueue<ResultEntry> results = null;
+    private boolean flushBuffer = false;
+//    private ImmutableBytesWritable[] sortKeys;
+    private int index;
+
+    public MappedByteBufferPriorityQueue(int index, String fileName, int resultMappingSize, Comparator<ResultEntry> comparator) throws IOException {
+      this.index = index;
+      this.file = new File(fileName);
+      this.af = new RandomAccessFile(file, "rw");
+      this.fc = af.getChannel();
+      this.mappingSize = resultMappingSize;
+      results = MinMaxPriorityQueue.<ResultEntry>orderedBy(comparator).create();
+      writeBuffer = fc.map(MapMode.READ_WRITE, this.writeIndex,
+          this.mappingSize);
+      readBuffer = fc.map(MapMode.READ_ONLY, this.readIndex, this.mappingSize);
+    }
+    
+    private List<KeyValue> toKeyValues(ResultEntry entry) {
+      Tuple result = entry.getResult();
+      int size = result.size();
+      List<KeyValue> kvs = new ArrayList<KeyValue>(size);
+      for (int i = 0; i < size; i++) {
+        kvs.add(result.getValue(i));
+      }
+      return kvs;
+    }
+    
+    private int sizeof(List<KeyValue> kvs) {
+      int size = Bytes.SIZEOF_INT; // totalLen
+
+      for (KeyValue kv : kvs) {
+        size += kv.getLength();
+        size += Bytes.SIZEOF_INT; // kv.getLength
+      }
+
+      return size;
+    }
+    
+    private int sizeof(ImmutableBytesWritable[]sortKeys) {
+      int size = Bytes.SIZEOF_INT;
+      if(sortKeys!=null) {
+        for(ImmutableBytesWritable sortKey: sortKeys) {
+          size += sortKey.getLength();
+          size += Bytes.SIZEOF_INT;
+        }
+      }
+      return size;
+    }
+    
+    public boolean writeResult(ResultEntry entry) throws IOException {
+      int sortKeySize = sizeof(entry.sortKeys);
+      int resultSize = sizeof(toKeyValues(entry)) + sortKeySize;
+      if (resultSize >= mappingSize) {
+        throw new IOException("Result is too large, buffer size is["
+            + mappingSize + "], and result size is[" + resultSize + "].");
+      }
+      if (allWriteSize + resultSize >= writeIndex + mappingSize) {
+        writeBuffer.force();
+        writeIndex = allWriteSize;
+        writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex, mappingSize);
+        for(int i=0;i<results.size();i++) {
+          int totalLen = 0;
+          ResultEntry re = results.pollFirst();
+          List<KeyValue> keyValues = toKeyValues(re);
+          for (KeyValue kv : keyValues) {
+            totalLen = kv.getLength() + Bytes.SIZEOF_INT;
+          }
+          writeBuffer.putInt(totalLen);
+          allWriteSize += Bytes.SIZEOF_INT;
+          for (KeyValue kv : keyValues) {
+            writeBuffer.putInt(kv.getLength());
+            allWriteSize += Bytes.SIZEOF_INT;
+            writeBuffer.put(kv.getBuffer(), kv.getOffset(), kv.getLength());
+            allWriteSize += kv.getLength();
+          }
+          ImmutableBytesWritable[] sortKeys = re.sortKeys;
+          writeBuffer.putInt(sortKeySize);
+          allWriteSize += Bytes.SIZEOF_INT;
+          for(ImmutableBytesWritable sortKey: sortKeys){
+            writeBuffer.putInt(sortKey.getLength());
+            allWriteSize += Bytes.SIZEOF_INT;
+            writeBuffer.put(sortKey.get(), sortKey.getOffset(), sortKey.getLength());
+            allWriteSize += sortKey.getLength();
+          }
+        }
+        flushBuffer = true;
+      } else {
+        results.add(entry);
+      }
+      return flushBuffer;
+    }
+
+    public IndexedResultEntry getNextResult() throws IOException {
+      if (allReadSize != 0 && allReadSize == allWriteSize && stop) {
+        return null;
+      }
+      if(flushBuffer) {
+        if (readBuffer == null
+            || allReadSize + Bytes.SIZEOF_INT >= readIndex + mappingSize) {
+          readIndex = allReadSize;
+          readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+              mappingSize);
+        }
+        int length = readBuffer.getInt();
+        allReadSize += Bytes.SIZEOF_INT;
+        long nextResultIndex = allReadSize + length;
+        if (nextResultIndex >= readIndex + mappingSize) {
+          readIndex = allReadSize;
+          readBuffer = this.fc.map(MapMode.READ_WRITE, readIndex,
+              mappingSize);
+        }
+        byte[] rb = new byte[length];
+        readBuffer.get(rb);
+        this.allReadSize += length;
+        Result result = new Result(new ImmutableBytesWritable(rb));
+        ResultTuple rt = new ResultTuple(result);
+        int sortKeySize = readBuffer.getInt();
+        allReadSize += Bytes.SIZEOF_INT;
+        ImmutableBytesWritable[]sortKeys = new ImmutableBytesWritable[sortKeySize];
+        for (int i = 0; i < sortKeySize; i++) {
+          int contentLength = readBuffer.getInt();
+          allReadSize += Bytes.SIZEOF_INT;
+          byte[]sortKeyContent = new byte[contentLength];
+          allReadSize += contentLength;
+          readBuffer.get(sortKeyContent);
+          sortKeys[i] = new ImmutableBytesWritable(sortKeyContent);
+        }
+        ResultEntry re = new ResultEntry(sortKeys, rt);
+        return new IndexedResultEntry(index, re);
+      } else {
+        ResultEntry re = results.poll();
+        return new IndexedResultEntry(index, re);
+      }
+    }
+
+    public void stop() {
+      this.stop = true;
+    }
+
+    public void close() {
+      this.stop();
+      if (this.fc != null) {
+        try {
+          this.fc.close();
+        } catch (IOException e) {
+//          logger.debug("Failed to close FileChannel:" + this.fc);
+        }
+      }
+      if (this.af != null) {
+        try {
+          this.af.close();
+        } catch (IOException e) {
+
+        }
+      }
+      if (this.file != null) {
+        if (file.isFile()) {
+          boolean result = file.delete();
+          if (!result) {
+//            logger.warn("Failed to delete buffer file[" + file + "]");
+          } else {
+//            logger.debug("Has deleted buffer file[" + file + "]");
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -33,11 +33,7 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
   
   public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator) throws IOException {
     this.comparator = comparator;
-    this.currentQueue = new MappedByteBufferPriorityQueue(0, getFileName(), flushSize, comparator);
-  }
-
-  private String getFileName(){
-    return "/tmp/" + UUID.randomUUID().toString();
+    this.currentQueue = new MappedByteBufferPriorityQueue(0, flushSize, comparator);
   }
   
   @Override
@@ -47,7 +43,7 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
       if(isFlush) {
         queues.add(currentQueue);
         currentIndex++;
-        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, getFileName(), flushSize, comparator);
+        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, flushSize, comparator);
         currentQueue.writeResult(e);
       }
     } catch (IOException e1) {
@@ -167,9 +163,9 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
 //    private ImmutableBytesWritable[] sortKeys;
     private int index;
 
-    public MappedByteBufferPriorityQueue(int index, String fileName, int resultMappingSize, Comparator<ResultEntry> comparator) throws IOException {
+    public MappedByteBufferPriorityQueue(int index, int resultMappingSize, Comparator<ResultEntry> comparator) throws IOException {
       this.index = index;
-      this.file = new File(fileName);
+      this.file = File.createTempFile(UUID.randomUUID().toString(), null);
       this.af = new RandomAccessFile(file, "rw");
       this.fc = af.getChannel();
       this.mappingSize = resultMappingSize;

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -24,6 +24,7 @@ import com.salesforce.phoenix.schema.tuple.ResultTuple;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 
 public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
+  private int flushSize = 10000; //TODO make this number configurable.
   private Comparator<ResultEntry> comparator;
   private List<MappedByteBufferPriorityQueue> queues = new ArrayList<MappedByteBufferPriorityQueue>();
   private MappedByteBufferPriorityQueue currentQueue = null;
@@ -32,7 +33,7 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
   
   public MappedByteBufferSortedQueue(Comparator<ResultEntry> comparator) throws IOException {
     this.comparator = comparator;
-    this.currentQueue = new MappedByteBufferPriorityQueue(0, getFileName(), 100, comparator); //TODO decide the 100 as a condifugrable one.
+    this.currentQueue = new MappedByteBufferPriorityQueue(0, getFileName(), flushSize, comparator);
   }
 
   private String getFileName(){
@@ -46,7 +47,7 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
       if(isFlush) {
         queues.add(currentQueue);
         currentIndex++;
-        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, getFileName(), 100, comparator); //TODO decide the 100 as a condifugrable one.
+        currentQueue = new MappedByteBufferPriorityQueue(currentIndex, getFileName(), flushSize, comparator);
         currentQueue.writeResult(e);
       }
     } catch (IOException e1) {

--- a/src/main/java/com/salesforce/phoenix/iterate/MergeSortTopNResultIterator.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MergeSortTopNResultIterator.java
@@ -57,8 +57,7 @@ public class MergeSortTopNResultIterator extends MergeSortResultIterator {
     
     public MergeSortTopNResultIterator(ResultIterators iterators, Integer limit, List<OrderByExpression> orderByColumns) {
         super(iterators);
-        checkNotNull(limit);
-        this.limit = limit;
+        this.limit = limit == null ? -1 : limit;
         this.orderByColumns = orderByColumns;
     }
 
@@ -87,7 +86,7 @@ public class MergeSortTopNResultIterator extends MergeSortResultIterator {
 
     @Override
     public Tuple peek() throws SQLException {
-        if (count >= limit) {
+        if (limit >= 0 && count >= limit) {
             return null;
         }
         return super.peek();
@@ -95,7 +94,7 @@ public class MergeSortTopNResultIterator extends MergeSortResultIterator {
 
     @Override
     public Tuple next() throws SQLException {
-        if (count++ >= limit) {
+        if (limit >= 0 && count++ >= limit) {
             return null;
         }
         return super.next();

--- a/src/main/java/com/salesforce/phoenix/iterate/OrderedAggregatingResultIterator.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/OrderedAggregatingResultIterator.java
@@ -46,8 +46,8 @@ public class OrderedAggregatingResultIterator extends OrderedResultIterator impl
 
     public OrderedAggregatingResultIterator(AggregatingResultIterator delegate,
                                 List<OrderByExpression> orderByExpressions,
-                                Integer limit) throws SQLException {
-        super (delegate, orderByExpressions, limit);
+                                int thresholdBytes, Integer limit) throws SQLException {
+        super (delegate, orderByExpressions, thresholdBytes, limit);
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/iterate/OrderedResultIterator.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/OrderedResultIterator.java
@@ -121,7 +121,7 @@ public class OrderedResultIterator implements ResultIterator {
     }
 
     public OrderedResultIterator(ResultIterator delegate, List<OrderByExpression> orderByExpressions, 
-    		int thresholdBytes, Integer limit, int estimatedRowSize) {
+            int thresholdBytes, Integer limit, int estimatedRowSize) {
         checkArgument(!orderByExpressions.isEmpty());
         this.delegate = delegate;
         this.orderByExpressions = orderByExpressions;
@@ -188,29 +188,28 @@ public class OrderedResultIterator implements ResultIterator {
         Collection<ResultEntry> entries;
         if (limit == null) {
           try{
-            final MappedByteBufferSortedQueue queueEntries = new MappedByteBufferSortedQueue(comparator, thresholdBytes);
-            entries = queueEntries;
-            
-            resultIterator = new BaseResultIterator() {
+                final MappedByteBufferSortedQueue queueEntries = new MappedByteBufferSortedQueue(comparator, thresholdBytes);
+                entries = queueEntries;
+                resultIterator = new BaseResultIterator() {
 
-                @Override
-                public Tuple next() throws SQLException {
-                  ResultEntry entry = queueEntries.poll();
-                  if (entry == null) {
-                      resultIterator = ResultIterator.EMPTY_ITERATOR;
-                      return null;
-                  }
-                  return entry.getResult();
-                }
-                
-                @Override
-                public void close() throws SQLException {
-                  queueEntries.close();
-                }
-            };
-          } catch (IOException e) {
-            throw new SQLException("", e);
-          }
+                    @Override
+                    public Tuple next() throws SQLException {
+                        ResultEntry entry = queueEntries.poll();
+                        if (entry == null) {
+                            resultIterator = ResultIterator.EMPTY_ITERATOR;
+                            return null;
+                        }
+                        return entry.getResult();
+                    }
+
+                    @Override
+                    public void close() throws SQLException {
+                        queueEntries.close();
+                    }
+                };
+            } catch (IOException e) {
+                throw new SQLException("", e);
+            }
         } else {
             final MinMaxPriorityQueue<ResultEntry> queueEntries = MinMaxPriorityQueue.<ResultEntry>orderedBy(comparator).maximumSize(limit).create();
             entries = queueEntries;

--- a/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
@@ -16,17 +16,17 @@ public class OrderByTest extends BaseClientMangedTimeTest {
 
     @Test
     public void testMultiOrderByExprNoSpool() throws Exception {
-    	testMultiOrderByExpr(1024 * 1024);
+        testMultiOrderByExpr(1024 * 1024);
     }
     
     @Test
     public void testMultiOrderByExprWithSpool() throws Exception {
-    	testMultiOrderByExpr(100);
+        testMultiOrderByExpr(100);
     }
 
     private void testMultiOrderByExpr(int thresholdBytes) throws Exception {
-    	Configuration config = driver.getQueryServices().getConfig();
-    	config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
+        Configuration config = driver.getQueryServices().getConfig();
+        config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
         long ts = nextTimestamp();
         String tenantId = getOrganizationId();
         initATableValues(tenantId, getDefaultSplits(tenantId), null, ts);
@@ -65,17 +65,17 @@ public class OrderByTest extends BaseClientMangedTimeTest {
 
     @Test
     public void testDescMultiOrderByExprNoSpool() throws Exception {
-    	testDescMultiOrderByExpr(1024 * 1024);
+        testDescMultiOrderByExpr(1024 * 1024);
     }
 
     @Test
     public void testDescMultiOrderByExprWithSpool() throws Exception {
-    	testDescMultiOrderByExpr(100);
+        testDescMultiOrderByExpr(100);
     }
 
     private void testDescMultiOrderByExpr(int thresholdBytes) throws Exception {
-    	Configuration config = driver.getQueryServices().getConfig();
-    	config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
+        Configuration config = driver.getQueryServices().getConfig();
+        config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
         long ts = nextTimestamp();
         String tenantId = getOrganizationId();
         initATableValues(tenantId, getDefaultSplits(tenantId), null, ts);

--- a/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
 package com.salesforce.phoenix.end2end;
 
 import static com.salesforce.phoenix.util.TestUtil.*;
@@ -79,7 +106,7 @@ public class OrderByTest extends BaseClientMangedTimeTest {
         long ts = nextTimestamp();
         String tenantId = getOrganizationId();
         initATableValues(tenantId, getDefaultSplits(tenantId), null, ts);
-        String query = "SELECT entity_id FROM aTable ORDER BY b_string || entity_id desc LIMIT 5";
+        String query = "SELECT entity_id FROM aTable ORDER BY b_string || entity_id desc";
         Properties props = new Properties(TEST_PROPERTIES);
         props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB, Long.toString(ts + 2)); // Execute at timestamp 2
         Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);

--- a/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/OrderByTest.java
@@ -1,0 +1,115 @@
+package com.salesforce.phoenix.end2end;
+
+import static com.salesforce.phoenix.util.TestUtil.*;
+import static org.junit.Assert.*;
+
+import java.sql.*;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+import com.salesforce.phoenix.query.QueryServices;
+import com.salesforce.phoenix.util.PhoenixRuntime;
+
+public class OrderByTest extends BaseClientMangedTimeTest {
+
+    @Test
+    public void testMultiOrderByExprNoSpool() throws Exception {
+    	testMultiOrderByExpr(1024 * 1024);
+    }
+    
+    @Test
+    public void testMultiOrderByExprWithSpool() throws Exception {
+    	testMultiOrderByExpr(100);
+    }
+
+    private void testMultiOrderByExpr(int thresholdBytes) throws Exception {
+    	Configuration config = driver.getQueryServices().getConfig();
+    	config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
+        long ts = nextTimestamp();
+        String tenantId = getOrganizationId();
+        initATableValues(tenantId, getDefaultSplits(tenantId), null, ts);
+        String query = "SELECT entity_id FROM aTable ORDER BY b_string, entity_id";
+        Properties props = new Properties(TEST_PROPERTIES);
+        props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB, Long.toString(ts + 2)); // Execute at timestamp 2
+        Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(query);
+            ResultSet rs = statement.executeQuery();
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW1);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW4);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW7);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW2);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW5);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW8);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW3);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW6);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW9);
+
+            assertFalse(rs.next());
+        } finally {
+            conn.close();
+        }
+    }
+    
+
+    @Test
+    public void testDescMultiOrderByExprNoSpool() throws Exception {
+    	testDescMultiOrderByExpr(1024 * 1024);
+    }
+
+    @Test
+    public void testDescMultiOrderByExprWithSpool() throws Exception {
+    	testDescMultiOrderByExpr(100);
+    }
+
+    private void testDescMultiOrderByExpr(int thresholdBytes) throws Exception {
+    	Configuration config = driver.getQueryServices().getConfig();
+    	config.setInt(QueryServices.SPOOL_THRESHOLD_BYTES_ATTRIB, thresholdBytes);
+        long ts = nextTimestamp();
+        String tenantId = getOrganizationId();
+        initATableValues(tenantId, getDefaultSplits(tenantId), null, ts);
+        String query = "SELECT entity_id FROM aTable ORDER BY b_string || entity_id desc LIMIT 5";
+        Properties props = new Properties(TEST_PROPERTIES);
+        props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB, Long.toString(ts + 2)); // Execute at timestamp 2
+        Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(query);
+            ResultSet rs = statement.executeQuery();
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW9);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW6);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW3);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW8);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW5);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW2);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW7);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW4);
+            assertTrue (rs.next());
+            assertEquals(rs.getString(1), ROW1);
+
+            assertFalse(rs.next());
+        } finally {
+            conn.close();
+        }
+    }
+        
+
+}


### PR DESCRIPTION
For OrderedResultIterator, use MappedByteBufferSorted to spool sorted result to disk once the current buffer reaches the threshold.
Also thinking to replace TopN implementation with this unlimited order-by implementation.
