### PR TITLE
First Shot at dynamic Upsert

### DIFF
--- a/src/main/antlr3/PhoenixSQL.g
+++ b/src/main/antlr3/PhoenixSQL.g
@@ -643,8 +643,10 @@ expression_terms returns [List<ParseNode> ret]
 
 column_refs returns [List<ParseNode> ret]
 @init{ret = new ArrayList<ParseNode>(); }
-    :  v = column_ref {$ret.add(v);}  (COMMA v = column_ref {$ret.add(v);} )*
+     :  (d = column_def {$ret.add(factory.dynColumn(d));}|v = column_ref {$ret.add(v);})  (COMMA (d = column_def {$ret.add(factory.dynColumn(d));}|v = column_ref {$ret.add(v);}) )*
 ;
+catch[SQLException e]{throw  new RecognitionException();}
+
 column_ref returns [ParseNode ret]
     :   field=identifier {$ret = factory.column(field); }
     |   tableName=column_table_name DOT field=identifier {$ret = factory.column(tableName, field); }

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -181,7 +181,7 @@ public class FromCompiler {
                     PSchema theSchema = connection.getPMetaData().getSchema(schemaName);
                     PTable theTable = theSchema.getTable(tableName);
                     // If dynamic columns have been specified add them to the table declaration
-                    if (dynamicColumnDefs.isEmpty()) {
+                    if (!dynamicColumnDefs.isEmpty()) {
                         theTable = this.addDynamicColumns(dynamicColumnDefs, theTable);
                     }
                     TableRef tableRef = new TableRef(alias, theTable, theSchema, timeStamp);

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -262,7 +262,6 @@ public class FromCompiler {
         protected PTable addDynamicColumns(List<ColumnDef> dynColumns, PTable theTable)
                 throws AmbiguousColumnException, ColumnFamilyNotFoundException {
             List<ColumnDef> acceptedColumns = new ArrayList<ColumnDef>(); 
-            System.out.println("i#### addDynamicColumns  "+dynColumns.size());
             if (!dynColumns.isEmpty()) {
                 List<PColumn> allcolumns = new ArrayList<PColumn>();
                 allcolumns.addAll(theTable.getColumns());
@@ -275,8 +274,7 @@ public class FromCompiler {
                             throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
                         }
                     } catch (ColumnNotFoundException e) {
-                        //Only if th column is previously unknown will we add it to the table
-                        e.printStackTrace();
+                        //Only if the column is previously unknown will we add it to the table
 			acceptedColumns.add(cdef);
                    }  
                 }

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -270,13 +270,14 @@ public class FromCompiler {
                 for (ColumnDef cdef : dynColumns) {
                     try {
                         column = theTable.getColumn(cdef.getColumnDefName().getColumnName().getName());
+                        if (!column.getDataType().equals(cdef.getDataType())) {
+                            throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
+                        }
                     } catch (ColumnNotFoundException e) {
                         //Only if th column is previously unknown will we add it to the table
                         acceptedColumns.add(cdef);
                     }
-                    if (!column.getDataType().equals(cdef.getDataType())) {
-                        throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
-                    }
+                    
                 }
                 for (ColumnDef addDef : acceptedColumns) {
                     PName familyName = QueryConstants.DEFAULT_COLUMN_FAMILY_NAME;

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -270,6 +270,8 @@ public class FromCompiler {
                 for (ColumnDef cdef : dynColumns) {
                     try {
                         column = theTable.getColumn(cdef.getColumnDefName().getColumnName().getName());
+                        String FamilyName = cdef.getColumnDefName().getFamilyName()!=null?cdef.getColumnDefName().getFamilyName().getName():QueryConstants.DEFAULT_COLUMN_FAMILY;
+                        theTable.getColumnFamily(FamilyName);
                         if (!column.getDataType().equals(cdef.getDataType())) {
                             throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
                         }

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -270,14 +270,14 @@ public class FromCompiler {
                 for (ColumnDef cdef : dynColumns) {
                     try {
                         column = theTable.getColumn(cdef.getColumnDefName().getColumnName().getName());
-                        String FamilyName = cdef.getColumnDefName().getFamilyName()!=null?cdef.getColumnDefName().getFamilyName().getName():QueryConstants.DEFAULT_COLUMN_FAMILY;
-                        theTable.getColumnFamily(FamilyName);
                         if (!column.getDataType().equals(cdef.getDataType())) {
                             throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
                         }
                     } catch (ColumnNotFoundException e) {
                         //Only if the column is previously unknown will we add it to the table
-			acceptedColumns.add(cdef);
+			String FamilyName = cdef.getColumnDefName().getFamilyName()!=null?cdef.getColumnDefName().getFamilyName().getName():QueryConstants.DEFAULT_COLUMN_FAMILY;
+                        theTable.getColumnFamily(FamilyName);
+                        acceptedColumns.add(cdef);
                    }  
                 }
                 for (ColumnDef addDef : acceptedColumns) {

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -181,7 +181,7 @@ public class FromCompiler {
                     PSchema theSchema = connection.getPMetaData().getSchema(schemaName);
                     PTable theTable = theSchema.getTable(tableName);
                     // If dynamic columns have been specified add them to the table declaration
-                    if (dynamicColumnDefs.isEmpty()) {
+                    if (!dynamicColumnDefs.isEmpty()) {
                         theTable = this.addDynamicColumns(dynamicColumnDefs, theTable);
                     }
                     TableRef tableRef = new TableRef(alias, theTable, theSchema, timeStamp);
@@ -261,7 +261,8 @@ public class FromCompiler {
 
         protected PTable addDynamicColumns(List<ColumnDef> dynColumns, PTable theTable)
                 throws AmbiguousColumnException, ColumnFamilyNotFoundException {
-            List<ColumnDef> acceptedColumns = new ArrayList<ColumnDef>();
+            List<ColumnDef> acceptedColumns = new ArrayList<ColumnDef>(); 
+            System.out.println("i#### addDynamicColumns  "+dynColumns.size());
             if (!dynColumns.isEmpty()) {
                 List<PColumn> allcolumns = new ArrayList<PColumn>();
                 allcolumns.addAll(theTable.getColumns());
@@ -272,8 +273,10 @@ public class FromCompiler {
                         column = theTable.getColumn(cdef.getColumnDefName().getColumnName().getName());
                     } catch (ColumnNotFoundException e) {
                         //Only if th column is previously unknown will we add it to the table
-                        acceptedColumns.add(cdef);
+                        e.printStackTrace();
+			acceptedColumns.add(cdef);
                     }
+		    System.out.println("check for column "+column.getName());
                     if (!column.getDataType().equals(cdef.getDataType())) {
                         throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
                     }

--- a/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/FromCompiler.java
@@ -1,29 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2013, Salesforce.com, Inc.
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- *     Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
- *     specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.compile;
 
@@ -40,11 +28,9 @@ import com.salesforce.phoenix.parse.*;
 import com.salesforce.phoenix.query.QueryConstants;
 import com.salesforce.phoenix.schema.*;
 
-
 /**
- * 
  * Validates FROM clause and builds a ColumnResolver for resolving column references
- *
+ * 
  * @author jtaylor
  * @since 0.1
  */
@@ -61,32 +47,36 @@ public class FromCompiler {
         public ColumnRef resolveColumn(ColumnParseNode node) throws SQLException {
             throw new UnsupportedOperationException();
         }
-        
+
     };
 
-    public static ColumnResolver getResolver(final CreateTableStatement statement, final PhoenixConnection connection) throws SQLException {
+    public static ColumnResolver getResolver(final CreateTableStatement statement, final PhoenixConnection connection)
+            throws SQLException {
         return EMPTY_TABLE_RESOLVER;
     }
 
-
     // TODO: commonize with one for upsert
-    public static ColumnResolver getResolver(DropColumnStatement statement, PhoenixConnection connection) throws SQLException {
+    public static ColumnResolver getResolver(DropColumnStatement statement, PhoenixConnection connection)
+            throws SQLException {
         TableName tableName = statement.getTableName();
-        NamedTableNode tableNode =  FACTORY.namedTable(null, tableName,null);
+        NamedTableNode tableNode = FACTORY.namedTable(null, tableName, null);
         FromClauseVisitor visitor = new DDLFromClauseVisitor(connection);
         tableNode.accept(visitor);
         return visitor;
     }
 
     /**
-     * Iterate through the nodes in the FROM clause to build a column resolver used to
-     * lookup a column given the name and alias.
-     * @param statement the select statement
+     * Iterate through the nodes in the FROM clause to build a column resolver used to lookup a column given the name
+     * and alias.
+     * 
+     * @param statement
+     *            the select statement
      * @return the column resolver
-     * @throws SQLException 
-     * @throws SQLFeatureNotSupportedException if unsupported constructs appear in the FROM
-     * clause. Currently only a single table name is supported.
-     * @throws TableNotFoundException if table name not found in schema
+     * @throws SQLException
+     * @throws SQLFeatureNotSupportedException
+     *             if unsupported constructs appear in the FROM clause. Currently only a single table name is supported.
+     * @throws TableNotFoundException
+     *             if table name not found in schema
      */
     public static ColumnResolver getResolver(SelectStatement statement, PhoenixConnection connection)
             throws SQLException {
@@ -120,9 +110,10 @@ public class FromCompiler {
             super(connection);
             client = new MetaDataClient(connection);
         }
-        
+
         @Override
-        protected TableRef createTableRef(String alias, String schemaName, String tableName, List<ColumnDef> dynamicColumnDefs) throws SQLException {
+        protected TableRef createTableRef(String alias, String schemaName, String tableName,
+                List<ColumnDef> dynamicColumnDefs) throws SQLException {
             long timeStamp = Math.abs(client.updateCache(schemaName, tableName));
             PSchema theSchema = null;
             try {
@@ -131,24 +122,25 @@ public class FromCompiler {
                 throw new TableNotFoundException(schemaName, tableName);
             }
             PTable theTable = theSchema.getTable(tableName);
-            
-            //If dynamic columns have been specified add them to the table declaration
-            if(!dynamicColumnDefs.isEmpty()) {
-	        theTable = this.addDynamicColumns(dynamicColumnDefs, theTable);
+
+            // If dynamic columns have been specified add them to the table declaration
+            if (!dynamicColumnDefs.isEmpty()) {
+                theTable = this.addDynamicColumns(dynamicColumnDefs, theTable);
             }
             TableRef tableRef = new TableRef(alias, theTable, theSchema, timeStamp);
             return tableRef;
         }
-        
+
     }
-    
+
     private static class DDLFromClauseVisitor extends FromClauseVisitor {
         public DDLFromClauseVisitor(PhoenixConnection connection) {
             super(connection);
         }
-        
+
         @Override
-        protected TableRef createTableRef(String alias, String schemaName, String tableName, List<ColumnDef> dynamicColumnDefs) throws SQLException {
+        protected TableRef createTableRef(String alias, String schemaName, String tableName,
+                List<ColumnDef> dynamicColumnDefs) throws SQLException {
             PSchema theSchema = null;
             try {
                 theSchema = connection.getPMetaData().getSchema(schemaName);
@@ -160,7 +152,7 @@ public class FromCompiler {
             return tableRef;
         }
     }
-    
+
     private static class DMLFromClauseVisitor extends FromClauseVisitor {
         private MetaDataClient client;
 
@@ -189,7 +181,7 @@ public class FromCompiler {
                     PSchema theSchema = connection.getPMetaData().getSchema(schemaName);
                     PTable theTable = theSchema.getTable(tableName);
                     // If dynamic columns have been specified add them to the table declaration
-                    if(dynamicColumnDefs.isEmpty()) {
+                    if (dynamicColumnDefs.isEmpty()) {
                         theTable = this.addDynamicColumns(dynamicColumnDefs, theTable);
                     }
                     TableRef tableRef = new TableRef(alias, theTable, theSchema, timeStamp);
@@ -211,39 +203,40 @@ public class FromCompiler {
     }
 
     private static abstract class FromClauseVisitor implements TableNodeVisitor, ColumnResolver {
-        private final ListMultimap<Key,TableRef> tableMap;
+        private final ListMultimap<Key, TableRef> tableMap;
         private final List<TableRef> tables;
         protected final PhoenixConnection connection;
-        
+
         private FromClauseVisitor(PhoenixConnection connection) {
             this.connection = connection;
-            tableMap = ArrayListMultimap.<Key,TableRef>create();
+            tableMap = ArrayListMultimap.<Key, TableRef> create();
             tables = Lists.newArrayList();
         }
-        
+
         @Override
         public List<TableRef> getTables() {
             return tables;
         }
-        
+
         @Override
         public void visit(BindTableNode boundTableNode) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
-    
+
         @Override
         public void visit(JoinTableNode joinNode) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
-    
+
         @SuppressWarnings("serial")
-		private static final class Key extends Pair<String,String> {
+        private static final class Key extends Pair<String, String> {
             private Key(String schemaName, String tableName) {
-                super(schemaName,tableName);
+                super(schemaName, tableName);
             }
         }
-        
-        protected abstract TableRef createTableRef(String alias, String schemaName, String tableName, List<ColumnDef> dynamicColumnDefs) throws SQLException;
+
+        protected abstract TableRef createTableRef(String alias, String schemaName, String tableName,
+                List<ColumnDef> dynamicColumnDefs) throws SQLException;
 
         @Override
         public void visit(NamedTableNode namedTableNode) throws SQLException {
@@ -269,23 +262,20 @@ public class FromCompiler {
         protected PTable addDynamicColumns(List<ColumnDef> dynColumns, PTable theTable)
                 throws AmbiguousColumnException, ColumnFamilyNotFoundException {
             List<ColumnDef> acceptedColumns = new ArrayList<ColumnDef>();
-            if (dynColumns != null && !dynColumns.isEmpty()) {
+            if (!dynColumns.isEmpty()) {
                 List<PColumn> allcolumns = new ArrayList<PColumn>();
                 allcolumns.addAll(theTable.getColumns());
                 int position = allcolumns.size();
                 PColumn column = null;
                 for (ColumnDef cdef : dynColumns) {
-                    column = theTable.hasColumn(cdef.getColumnDefName().getColumnName().getName());
-                    if (column == null) {
+                    try {
+                        column = theTable.getColumn(cdef.getColumnDefName().getColumnName().getName());
+                    } catch (ColumnNotFoundException e) {
+                        //Only if th column is previously unknown will we add it to the table
                         acceptedColumns.add(cdef);
-                    } else if (!column.getDataType().equals(cdef.getDataType())) {
+                    }
+                    if (!column.getDataType().equals(cdef.getDataType())) {
                         throw new AmbiguousColumnException(cdef.getColumnDefName().getColumnName().getName());
-                    } else {
-                        if (cdef.getColumnDefName().getFamilyName() != null) {
-                            theTable.getColumnFamily(cdef.getColumnDefName().getFamilyName().getName());
-                        } else {
-                            theTable.getColumnFamily(QueryConstants.DEFAULT_COLUMN_FAMILY_NAME.toString());
-                        }
                     }
                 }
                 for (ColumnDef addDef : acceptedColumns) {
@@ -338,7 +328,7 @@ public class FromCompiler {
                 return tableRefs.get(0);
             }
         }
-        
+
         private ColumnFamilyRef resolveColumnFamily(String cfName, String tableName) throws SQLException {
             if (tableName == null) {
                 ColumnFamilyRef theColumnFamilyRef = null;
@@ -347,16 +337,11 @@ public class FromCompiler {
                     TableRef tableRef = iterator.next();
                     try {
                         PColumnFamily columnFamily = tableRef.getTable().getColumnFamily(cfName);
-                        if (theColumnFamilyRef != null) {
-                            throw new TableNotFoundException(cfName);
-                        }
+                        if (theColumnFamilyRef != null) { throw new TableNotFoundException(cfName); }
                         theColumnFamilyRef = new ColumnFamilyRef(tableRef, columnFamily);
-                    } catch (ColumnFamilyNotFoundException e) {
-                    }
+                    } catch (ColumnFamilyNotFoundException e) {}
                 }
-                if (theColumnFamilyRef != null) {
-                    return theColumnFamilyRef;
-                }
+                if (theColumnFamilyRef != null) { return theColumnFamilyRef; }
                 throw new TableNotFoundException(cfName);
             } else {
                 TableRef tableRef = resolveTable(null, tableName);
@@ -364,7 +349,7 @@ public class FromCompiler {
                 return new ColumnFamilyRef(tableRef, columnFamily);
             }
         }
-        
+
         @Override
         public ColumnRef resolveColumn(ColumnParseNode node) throws SQLException {
             TableName tableName = node.getTableName();
@@ -375,19 +360,15 @@ public class FromCompiler {
                 while (iterator.hasNext()) {
                     TableRef tableRef = iterator.next();
                     try {
-                        PColumn column = tableRef.getTable().getColumn(node.getName()); 
-                        if (theTableRef != null) {
-                            throw new AmbiguousColumnException(node.getName());
-                        }
+                        PColumn column = tableRef.getTable().getColumn(node.getName());
+                        if (theTableRef != null) { throw new AmbiguousColumnException(node.getName()); }
                         theTableRef = tableRef;
                         theColumnPosition = column.getPosition();
                     } catch (ColumnNotFoundException e) {
-                        
+
                     }
                 }
-                if (theTableRef != null) {
-                    return new ColumnRef(theTableRef, theColumnPosition);
-                }
+                if (theTableRef != null) { return new ColumnRef(theTableRef, theColumnPosition); }
                 throw new ColumnNotFoundException(node.getName());
             } else {
                 try {
@@ -402,7 +383,6 @@ public class FromCompiler {
                 }
             }
         }
-        
+
     }
 }
-

--- a/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
@@ -89,7 +89,7 @@ public class UpsertCompiler {
         final PhoenixConnection connection = statement.getConnection();
         ConnectionQueryServices services = connection.getQueryServices();
         final int maxSize = services.getConfig().getInt(QueryServices.MAX_MUTATION_SIZE_ATTRIB,QueryServicesOptions.DEFAULT_MAX_MUTATION_SIZE);
-        final ColumnResolver resolver = FromCompiler.getResolver(upsert, connection);
+        final ColumnResolver resolver = FromCompiler.getResolver(upsert, connection,upsert.getDynColumns());
         final TableRef tableRef = resolver.getTables().get(0);
         PTable table = tableRef.getTable();
         if (table.getType() == PTableType.VIEW) {
@@ -100,10 +100,12 @@ public class UpsertCompiler {
         // Setup array of column indexes parallel to values that are going to be set
         List<ParseNode> columnNodes = upsert.getColumns();
         List<PColumn> allColumns = table.getColumns();
+
         int[] columnIndexesToBe;
         int[] pkSlotIndexesToBe;
         PColumn[] targetColumns;
-        if (columnNodes.isEmpty()) {
+	//Alow full row upsert if no columns or only dynamic one are specified and values count match
+        if (columnNodes.isEmpty() || (upsert.onlyDynamic() && upsert.getValues().size()==table.getColumns().size())) {
             columnIndexesToBe = new int[allColumns.size()];
             pkSlotIndexesToBe = new int[columnIndexesToBe.length];
             targetColumns = new PColumn[columnIndexesToBe.length];

--- a/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
+++ b/src/main/java/com/salesforce/phoenix/compile/UpsertCompiler.java
@@ -104,13 +104,13 @@ public class UpsertCompiler {
         int[] columnIndexesToBe;
         int[] pkSlotIndexesToBe;
         PColumn[] targetColumns;
-	//Alow full row upsert if no columns or only dynamic one are specified and values count match
-        if (columnNodes.isEmpty() || (upsert.onlyDynamic() && upsert.getValues().size()==table.getColumns().size())) {
+        // Allow full row upsert if no columns or only dynamic one are specified and values count match
+        if (columnNodes.isEmpty() || (upsert.onlyDynamic() && upsert.getValues().size() == table.getColumns().size())) {
             columnIndexesToBe = new int[allColumns.size()];
             pkSlotIndexesToBe = new int[columnIndexesToBe.length];
             targetColumns = new PColumn[columnIndexesToBe.length];
             int j = table.getBucketNum() == null ? 0 : 1; // Skip over the salting byte.
-            for (int i = 0; i < allColumns.size() ; i++) {
+            for (int i = 0; i < allColumns.size(); i++) {
                 columnIndexesToBe[i] = i;
                 targetColumns[i] = allColumns.get(i);
                 if (SchemaUtil.isPKColumn(allColumns.get(i))) {

--- a/src/main/java/com/salesforce/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/src/main/java/com/salesforce/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -1,29 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2013, Salesforce.com, Inc.
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- *     Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
- *     specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.jdbc;
 
@@ -38,32 +26,15 @@ import com.salesforce.phoenix.compile.StatementPlan;
 import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.util.SQLCloseable;
 
-
-
 /**
- * 
- * JDBC PreparedStatement implementation of Phoenix.
- * Currently only the following methods (in addition to
- * the ones supported on {@link PhoenixStatement} are supported:
- * - {@link #executeQuery()}
- * - {@link #setInt(int, int)}
- * - {@link #setShort(int, short)}
- * - {@link #setLong(int, long)}
- * - {@link #setFloat(int, float)}
- * - {@link #setDouble(int, double)}
- * - {@link #setBigDecimal(int, BigDecimal)}
- * - {@link #setString(int, String)}
- * - {@link #setDate(int, Date)}
- * - {@link #setDate(int, Date, Calendar)}
- * - {@link #setTime(int, Time)}
- * - {@link #setTime(int, Time, Calendar)}
- * - {@link #setTimestamp(int, Timestamp)}
- * - {@link #setTimestamp(int, Timestamp, Calendar)}
- * - {@link #setNull(int, int)}
- * - {@link #setNull(int, int, String)}
- * - {@link #setBytes(int, byte[])}
- * - {@link #clearParameters()}
- * - {@link #getMetaData()}
+ * JDBC PreparedStatement implementation of Phoenix. Currently only the following methods (in addition to the ones
+ * supported on {@link PhoenixStatement} are supported: - {@link #executeQuery()} - {@link #setInt(int, int)} -
+ * {@link #setShort(int, short)} - {@link #setLong(int, long)} - {@link #setFloat(int, float)} -
+ * {@link #setDouble(int, double)} - {@link #setBigDecimal(int, BigDecimal)} - {@link #setString(int, String)} -
+ * {@link #setDate(int, Date)} - {@link #setDate(int, Date, Calendar)} - {@link #setTime(int, Time)} -
+ * {@link #setTime(int, Time, Calendar)} - {@link #setTimestamp(int, Timestamp)} -
+ * {@link #setTimestamp(int, Timestamp, Calendar)} - {@link #setNull(int, int)} - {@link #setNull(int, int, String)} -
+ * {@link #setBytes(int, byte[])} - {@link #clearParameters()} - {@link #getMetaData()}
  * 
  * @author jtaylor
  * @since 0.1
@@ -71,15 +42,14 @@ import com.salesforce.phoenix.util.SQLCloseable;
 public class PhoenixPreparedStatement extends PhoenixStatement implements PreparedStatement, SQLCloseable {
     private final List<Object> parameters;
     private final ExecutableStatement statement;
-    
+
     private final String query;
-    
-    public PhoenixPreparedStatement(PhoenixConnection connection, PhoenixStatementParser parser) throws SQLException, IOException {
+
+    public PhoenixPreparedStatement(PhoenixConnection connection, PhoenixStatementParser parser) throws SQLException,
+            IOException {
         super(connection);
         this.statement = parser.nextStatement(new ExecutableNodeFactory());
-        if (this.statement == null) {
-            throw new EOFException();
-        }
+        if (this.statement == null) { throw new EOFException(); }
         this.query = null; // TODO: add toString on SQLStatement
         this.parameters = Arrays.asList(new Object[statement.getBindCount()]);
         Collections.fill(parameters, UNBOUND_PARAMETER);
@@ -107,11 +77,11 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
     protected List<Object> getParameters() {
         return parameters;
     }
-    
+
     @Override
     public boolean execute() throws SQLException {
         throwIfUnboundParameters();
-	return statement.execute();
+        return statement.execute();
     }
 
     @Override
@@ -119,7 +89,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
         throwIfUnboundParameters();
         return statement.executeQuery();
     }
-    
+
     @Override
     public int executeUpdate() throws SQLException {
         throwIfUnboundParameters();
@@ -134,7 +104,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
     @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
         List<Object> nullParameters = Arrays.asList(new Object[statement.getBindCount()]);
-	StatementPlan plan = statement.compilePlan(nullParameters);
+        StatementPlan plan = statement.compilePlan(nullParameters);
         return plan.getParameterMetaData();
     }
 
@@ -165,12 +135,12 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
 
     @Override
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
@@ -246,33 +216,33 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
 
     @Override
     public void setDate(int parameterIndex, Date x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         cal.setTime(x);
-        parameters.set(parameterIndex-1, new Date(cal.getTimeInMillis()));
+        parameters.set(parameterIndex - 1, new Date(cal.getTimeInMillis()));
     }
 
     @Override
     public void setDouble(int parameterIndex, double x) throws SQLException {
-        parameters.set(parameterIndex-1, BigDecimal.valueOf(x));
+        parameters.set(parameterIndex - 1, BigDecimal.valueOf(x));
     }
 
     @Override
     public void setFloat(int parameterIndex, float x) throws SQLException {
-        parameters.set(parameterIndex-1, BigDecimal.valueOf(x));
+        parameters.set(parameterIndex - 1, BigDecimal.valueOf(x));
     }
 
     @Override
     public void setInt(int parameterIndex, int x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
     public void setLong(int parameterIndex, long x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
@@ -307,17 +277,17 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
 
     @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        parameters.set(parameterIndex-1, null);
+        parameters.set(parameterIndex - 1, null);
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
-        parameters.set(parameterIndex-1, null);
+        parameters.set(parameterIndex - 1, null);
     }
 
     @Override
     public void setObject(int parameterIndex, Object o) throws SQLException {
-        parameters.set(parameterIndex-1, o);
+        parameters.set(parameterIndex - 1, o);
     }
 
     @Override
@@ -325,12 +295,12 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
         PDataType targetType = PDataType.fromSqlType(targetSqlType);
         PDataType sourceType = PDataType.fromLiteral(o);
         o = targetType.toObject(o, sourceType);
-        parameters.set(parameterIndex-1, o);
+        parameters.set(parameterIndex - 1, o);
     }
 
     @Override
     public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
-        setObject(parameterIndex,x,targetSqlType);
+        setObject(parameterIndex, x, targetSqlType);
     }
 
     @Override
@@ -350,28 +320,28 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
 
     @Override
     public void setShort(int parameterIndex, short x) throws SQLException {
-        parameters.set(parameterIndex-1, Integer.valueOf(x));
+        parameters.set(parameterIndex - 1, Integer.valueOf(x));
     }
 
     @Override
     public void setString(int parameterIndex, String x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
     public void setTime(int parameterIndex, Time x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         cal.setTime(x);
-        parameters.set(parameterIndex-1, new Time(cal.getTimeInMillis()));
+        parameters.set(parameterIndex - 1, new Time(cal.getTimeInMillis()));
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
-        parameters.set(parameterIndex-1, x);
+        parameters.set(parameterIndex - 1, x);
     }
 
     @Override
@@ -379,12 +349,12 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
         cal.setTime(x);
         Timestamp value = new Timestamp(cal.getTimeInMillis());
         value.setNanos(x.getNanos());
-        parameters.set(parameterIndex-1, value);
+        parameters.set(parameterIndex - 1, value);
     }
 
     @Override
     public void setURL(int parameterIndex, URL x) throws SQLException {
-        parameters.set(parameterIndex-1, x.toExternalForm()); // Just treat as String
+        parameters.set(parameterIndex - 1, x.toExternalForm()); // Just treat as String
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/jdbc/PhoenixPreparedStatement.java
+++ b/src/main/java/com/salesforce/phoenix/jdbc/PhoenixPreparedStatement.java
@@ -111,7 +111,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
     @Override
     public boolean execute() throws SQLException {
         throwIfUnboundParameters();
-        return statement.execute();
+	return statement.execute();
     }
 
     @Override
@@ -134,7 +134,7 @@ public class PhoenixPreparedStatement extends PhoenixStatement implements Prepar
     @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
         List<Object> nullParameters = Arrays.asList(new Object[statement.getBindCount()]);
-        StatementPlan plan = statement.compilePlan(nullParameters);
+	StatementPlan plan = statement.compilePlan(nullParameters);
         return plan.getParameterMetaData();
     }
 

--- a/src/main/java/com/salesforce/phoenix/jdbc/PhoenixStatement.java
+++ b/src/main/java/com/salesforce/phoenix/jdbc/PhoenixStatement.java
@@ -218,7 +218,7 @@ public class PhoenixStatement implements Statement, SQLCloseable, com.salesforce
         @Override
         public MutationPlan compilePlan(List<Object> binds) throws SQLException {
             UpsertCompiler compiler = new UpsertCompiler(PhoenixStatement.this);
-            return compiler.compile(this, binds);
+	    return compiler.compile(this, binds);
         }
     }
     
@@ -725,6 +725,7 @@ public class PhoenixStatement implements Statement, SQLCloseable, com.salesforce
     @Override
     public boolean execute(String sql) throws SQLException {
         throwIfUnboundParameters();
+         System.out.println(" jbdc phoenixprepdsttmnt 728 execute "+sql);
         return parseStatement(sql).execute();
     }
 

--- a/src/main/java/com/salesforce/phoenix/parse/ColumnParseNode.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ColumnParseNode.java
@@ -1,29 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2013, Salesforce.com, Inc.
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- *     Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
- *     specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
@@ -31,44 +19,41 @@ import java.sql.SQLException;
 
 import com.salesforce.phoenix.query.QueryConstants;
 
-
-
-
 /**
- * 
  * Node representing a reference to a column in a SQL expression
- *
+ * 
  * @author jtaylor
  * @since 0.1
  */
 public class ColumnParseNode extends NamedParseNode {
     private final TableName tableName;
     private final String fullName;
-    
+
     ColumnParseNode(String name) {
         this(null, name);
     }
 
     public ColumnParseNode(TableName tableName, String name) {
-        // Upper case here so our Maps can depend on this (and we don't have to upper case and create a string on every lookup
+        // Upper case here so our Maps can depend on this (and we don't have to upper case and create a string on every
+        // lookup
         super(name);
         this.tableName = tableName;
         fullName = tableName == null ? getName() : tableName.toString() + QueryConstants.NAME_SEPARATOR + getName();
     }
-    
+
     @Override
     public <T> T accept(ParseNodeVisitor<T> visitor) throws SQLException {
         return visitor.visit(this);
-    }    
+    }
 
     public TableName getTableName() {
         return tableName;
     }
-    
+
     public String getFullName() {
         return fullName;
     }
-    
+
     @Override
     public String toString() {
         return getName();

--- a/src/main/java/com/salesforce/phoenix/parse/DynamicColumnParseNode.java
+++ b/src/main/java/com/salesforce/phoenix/parse/DynamicColumnParseNode.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.salesforce.phoenix.parse;
+
+/**
+ * 
+ * Node representing a dynamic defintion to a column in a SQL expression
+ *
+ * @author nmaillard
+ * @since 1.3
+ */
+
+public class DynamicColumnParseNode extends ColumnParseNode {
+  protected final String fullName;
+  private ColumnDef columnDef;
+  
+  DynamicColumnParseNode(ColumnDef node) {
+    super(node.getColumnDefName().getColumnName().getName());
+    columnDef = node;
+    fullName = getName();
+  }
+  
+  public String getFullName() {
+    return fullName;
+  }
+  
+  public ColumnDef getColumnDef(){
+    return columnDef;
+  }
+
+}

--- a/src/main/java/com/salesforce/phoenix/parse/DynamicColumnParseNode.java
+++ b/src/main/java/com/salesforce/phoenix/parse/DynamicColumnParseNode.java
@@ -38,7 +38,7 @@ package com.salesforce.phoenix.parse;
 
 public class DynamicColumnParseNode extends ColumnParseNode {
   protected final String fullName;
-  private ColumnDef columnDef;
+  private final ColumnDef columnDef;
   
   DynamicColumnParseNode(ColumnDef node) {
     super(node.getColumnDefName().getColumnName().getName());
@@ -46,7 +46,8 @@ public class DynamicColumnParseNode extends ColumnParseNode {
     fullName = getName();
   }
   
-  public String getFullName() {
+  @Override
+public String getFullName() {
     return fullName;
   }
   

--- a/src/main/java/com/salesforce/phoenix/parse/NamedTableNode.java
+++ b/src/main/java/com/salesforce/phoenix/parse/NamedTableNode.java
@@ -1,29 +1,19 @@
-/*copyright (c) 2013, Salesforce.com, Inc.
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- *     Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- *     Neither the name of Salesforce.com nor the names of its contributors may 
- *     be used to endorse or promote products derived from this software without 
- *     specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/*
+ * copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ****************************************************************************
+ */
 package com.salesforce.phoenix.parse;
 
 import java.sql.SQLException;
@@ -32,30 +22,28 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-
 /**
- * 
  * Node representing an explicit table reference in the FROM clause of SQL
- *
+ * 
  * @author jtaylor
  * @since 0.1
  */
 public class NamedTableNode extends ConcreteTableNode {
-	
-	 private final List<ColumnDef> dyncolumns ;
+
+    private final List<ColumnDef> dyncolumns;
 
     NamedTableNode(String alias, TableName name) {
         super(alias, name);
-	dyncolumns =  Collections.<ColumnDef>emptyList();
-    }    
+        dyncolumns = Collections.<ColumnDef> emptyList();
+    }
 
-    NamedTableNode(String alias, TableName name,List<ColumnDef> dyn_columns) {
-	super(alias, name);
-	if(dyn_columns != null){
-		this.dyncolumns = ImmutableList.copyOf(dyn_columns);
-        }else{
-		this.dyncolumns =  Collections.<ColumnDef>emptyList();
-	}
+    NamedTableNode(String alias, TableName name, List<ColumnDef> dyn_columns) {
+        super(alias, name);
+        if (dyn_columns != null) {
+            this.dyncolumns = ImmutableList.copyOf(dyn_columns);
+        } else {
+            this.dyncolumns = Collections.<ColumnDef> emptyList();
+        }
     }
 
     @Override
@@ -63,8 +51,7 @@ public class NamedTableNode extends ConcreteTableNode {
         visitor.visit(this);
     }
 
-	public List<ColumnDef> getDynamicColumns() {
-		return dyncolumns;
-	}
+    public List<ColumnDef> getDynamicColumns() {
+        return dyncolumns;
+    }
 }
-

--- a/src/main/java/com/salesforce/phoenix/parse/ParseNodeFactory.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ParseNodeFactory.java
@@ -225,6 +225,10 @@ public class ParseNodeFactory {
         return new ColumnParseNode(tableName,name);
     }
     
+    public DynamicColumnParseNode dynColumn(ColumnDef node) {
+        return new DynamicColumnParseNode(node);
+    }
+    
     public ColumnDefName columnDefName(String columnName) {
         return new ColumnDefName(columnName);
     }

--- a/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
+++ b/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
@@ -27,6 +27,7 @@
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,12 +35,19 @@ public class UpsertStatement extends MutationStatement {
     private final List<ParseNode> columns;
     private final List<ParseNode> values;
     private final SelectStatement select;
-    
+     private final List<ColumnDef> dynColumns;   
+ 
     public UpsertStatement(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
         super(table, bindCount);
         this.columns = columns == null ? Collections.<ParseNode>emptyList() : columns;
         this.values = values;
         this.select = select;
+        dynColumns = new ArrayList<ColumnDef>();
+        for(ParseNode pn:this.columns){
+          if(pn instanceof DynamicColumnParseNode){
+            dynColumns.add(((DynamicColumnParseNode)pn).getColumnDef());
+          }
+        }
     }
 
     public List<ParseNode> getColumns() {
@@ -52,5 +60,13 @@ public class UpsertStatement extends MutationStatement {
 
     public SelectStatement getSelect() {
         return select;
+    }
+
+    public List<ColumnDef> getDynColumns() {
+      return dynColumns;
+    }
+
+    public boolean onlyDynamic() {
+      return dynColumns.size()==columns.size();
     }
 }

--- a/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
+++ b/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
@@ -27,27 +27,28 @@
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+
+import com.google.common.collect.ImmutableList;
 
 public class UpsertStatement extends MutationStatement {
     private final List<ParseNode> columns;
     private final List<ParseNode> values;
     private final SelectStatement select;
-     private final List<ColumnDef> dynColumns;   
- 
+    private final List<ColumnDef> dynColumns;
+
     public UpsertStatement(TableName table, List<ParseNode> columns, List<ParseNode> values, SelectStatement select, int bindCount) {
         super(table, bindCount);
         this.columns = columns == null ? Collections.<ParseNode>emptyList() : columns;
         this.values = values;
         this.select = select;
-        dynColumns = new ArrayList<ColumnDef>();
+        List<ColumnDef> dynamicColumns = new ArrayList<ColumnDef>();
         for(ParseNode pn:this.columns){
           if(pn instanceof DynamicColumnParseNode){
-            dynColumns.add(((DynamicColumnParseNode)pn).getColumnDef());
+            dynamicColumns.add(((DynamicColumnParseNode)pn).getColumnDef());
           }
         }
+        this.dynColumns = ImmutableList.copyOf(dynamicColumns);
     }
 
     public List<ParseNode> getColumns() {

--- a/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
+++ b/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
@@ -27,8 +27,7 @@
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import com.google.common.collect.ImmutableList;
 
@@ -43,7 +42,7 @@ public class UpsertStatement extends MutationStatement {
         this.columns = columns == null ? Collections.<ParseNode>emptyList() : columns;
         this.values = values;
         this.select = select;
-        List<ColumnDef> dynamicColumns = Collections.<ColumnDef>emptyList();
+        List<ColumnDef> dynamicColumns = new ArrayList<ColumnDef>();
         for(ParseNode pn:this.columns){
           if(pn instanceof DynamicColumnParseNode){
             dynamicColumns.add(((DynamicColumnParseNode)pn).getColumnDef());

--- a/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
+++ b/src/main/java/com/salesforce/phoenix/parse/UpsertStatement.java
@@ -27,7 +27,8 @@
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
@@ -42,7 +43,7 @@ public class UpsertStatement extends MutationStatement {
         this.columns = columns == null ? Collections.<ParseNode>emptyList() : columns;
         this.values = values;
         this.select = select;
-        List<ColumnDef> dynamicColumns = new ArrayList<ColumnDef>();
+        List<ColumnDef> dynamicColumns = Collections.<ColumnDef>emptyList();
         for(ParseNode pn:this.columns){
           if(pn instanceof DynamicColumnParseNode){
             dynamicColumns.add(((DynamicColumnParseNode)pn).getColumnDef());

--- a/src/main/java/com/salesforce/phoenix/schema/PTable.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PTable.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.io.Writable;
 
+import com.salesforce.phoenix.parse.ColumnDef;
 import com.salesforce.phoenix.schema.stat.PTableStats;
 
 
@@ -157,4 +158,10 @@ public interface PTable extends Writable {
      * @return number of buckets used by this table for salting, or null if salting is not used.
      */
     Integer getBucketNum();
+   
+     /**
+     * Check if a columns is known and sends it back
+     * @return PColumn of found column or null
+     */
+    PColumn hasColumn(String name);
 }

--- a/src/main/java/com/salesforce/phoenix/schema/PTable.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PTable.java
@@ -159,9 +159,4 @@ public interface PTable extends Writable {
      */
     Integer getBucketNum();
    
-     /**
-     * Check if a columns is known and sends it back
-     * @return PColumn of found column or null
-     */
-    PColumn hasColumn(String name);
 }

--- a/src/main/java/com/salesforce/phoenix/schema/PTableImpl.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PTableImpl.java
@@ -32,6 +32,7 @@ import static com.salesforce.phoenix.schema.SaltingUtil.SALTING_COLUMN;
 
 import java.io.*;
 import java.util.*;
+import java.sql.SQLException;
 
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.WritableUtils;
 
 import com.google.common.collect.*;
+import com.salesforce.phoenix.parse.ColumnDef;
 import com.salesforce.phoenix.query.QueryConstants;
 import com.salesforce.phoenix.schema.RowKeySchema.RowKeySchemaBuilder;
 import com.salesforce.phoenix.schema.stat.PTableStats;
@@ -534,4 +536,15 @@ public class PTableImpl implements PTable {
     public Integer getBucketNum() {
         return bucketNum;
     }
+
+  @Override
+  public PColumn hasColumn(String name) {
+    List<PColumn> columns = columnsByName.get(name);
+    int size = columns.size();
+    if (size == 0) {
+      return null;
+    }else{
+      return columns.get(0);
+    }
+  }
 }

--- a/src/main/java/com/salesforce/phoenix/schema/PTableImpl.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PTableImpl.java
@@ -536,15 +536,4 @@ public class PTableImpl implements PTable {
     public Integer getBucketNum() {
         return bucketNum;
     }
-
-  @Override
-  public PColumn hasColumn(String name) {
-    List<PColumn> columns = columnsByName.get(name);
-    int size = columns.size();
-    if (size == 0) {
-      return null;
-    }else{
-      return columns.get(0);
-    }
-  }
 }

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
@@ -30,8 +30,10 @@ import org.junit.Test;
 import com.salesforce.phoenix.query.ConnectionQueryServices;
 import com.salesforce.phoenix.query.QueryConstants;
 import com.salesforce.phoenix.schema.AmbiguousColumnException;
-import com.salesforce.phoenix.schema.ConstraintViolationException;
+import com.salesforce.phoenix.schema.ColumnFamilyNotFoundException;
 import com.salesforce.phoenix.util.SchemaUtil;
+import com.salesforce.phoenix.exception.*;
+import org.apache.hadoop.hbase.regionserver.*;
 
 /**
  * Basic tests for Phoenix dynamic upserting
@@ -187,7 +189,7 @@ public class DynamicColumnTest extends BaseClientMangedTimeTest {
     /**
      * Test a select of an undefined ColumnFamily dynamic columns
      */
-    @Test(expected = ConstraintViolationException.class)
+    @Test(expected = ColumnFamilyNotFoundException.class)
     public void testFakeCFDynamicUpsert() throws Exception {
         String upsertquery = "Select * FROM HBASE_DYNAMIC_COLUMNS(fakecf.DynCol VARCHAR)";
         String url = PHOENIX_JDBC_URL + ";";

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
@@ -16,187 +16,189 @@
 
 package com.salesforce.phoenix.end2end;
 
-import static com.salesforce.phoenix.util.TestUtil.HBASE_DYNAMIC_COLUMNS;
-import static com.salesforce.phoenix.util.TestUtil.PHOENIX_JDBC_URL;
-import static com.salesforce.phoenix.util.TestUtil.TEST_PROPERTIES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.salesforce.phoenix.util.TestUtil.*;
+import static org.junit.Assert.*;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
+import java.sql.*;
+import java.util.*;
 
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.salesforce.phoenix.query.ConnectionQueryServices;
 import com.salesforce.phoenix.query.QueryConstants;
+import com.salesforce.phoenix.schema.AmbiguousColumnException;
+import com.salesforce.phoenix.schema.ConstraintViolationException;
 import com.salesforce.phoenix.util.SchemaUtil;
-
-import com.salesforce.phoenix.schema.*;
 
 /**
  * Basic tests for Phoenix dynamic upserting
- *
+ * 
  * @author nmaillard
  * @since 1.3
  */
 
-
 public class DynamicColumnTest extends BaseClientMangedTimeTest {
-	 private static final byte[] HBASE_DYNAMIC_COLUMNS_BYTES = SchemaUtil.getTableName(Bytes.toBytes(HBASE_DYNAMIC_COLUMNS));
-	 private static final byte[] FAMILY_NAME = Bytes.toBytes(SchemaUtil.normalizeIdentifier("A"));
-	 private static final byte[] FAMILY_NAME2 = Bytes.toBytes(SchemaUtil.normalizeIdentifier("B"));
-	
-	 @BeforeClass
-	    public static void doBeforeTestSetup() throws Exception {
-	        HBaseAdmin admin = new HBaseAdmin(driver.getQueryServices().getConfig());
-	        try {
-	            try {
-	                admin.disableTable(HBASE_DYNAMIC_COLUMNS_BYTES);
-	                admin.deleteTable(HBASE_DYNAMIC_COLUMNS_BYTES);
-	            } catch (org.apache.hadoop.hbase.TableNotFoundException e) {
-	            }
-	            ensureTableCreated(getUrl(),HBASE_DYNAMIC_COLUMNS);
-	            initTableValues();
-	        } finally {
-	            admin.close();
-	        }
-	    }
-	 
-	 private static void initTableValues() throws Exception {
-	        ConnectionQueryServices services = driver.getConnectionQueryServices(getUrl(), TEST_PROPERTIES);
-	        HTableInterface hTable = services.getTable(SchemaUtil.getTableName(Bytes.toBytes(HBASE_DYNAMIC_COLUMNS)));
-	        try {
-	            // Insert rows using standard HBase mechanism with standard HBase "types"
-	            List<Row> mutations = new ArrayList<Row>();
-	            byte[] dv = Bytes.toBytes("DV");
-	            byte[] first = Bytes.toBytes("F");
-	            byte[] f1v1 = Bytes.toBytes("F1V1");
-	            byte[] f1v2 = Bytes.toBytes("F1V2");
-	            byte[] f2v1 = Bytes.toBytes("F2V1");
-	            byte[] f2v2 = Bytes.toBytes("F2V2");
-	            byte[] key = Bytes.toBytes("entry1");
-	            
-	            Put put = new Put(key);
-	            put.add(QueryConstants.EMPTY_COLUMN_BYTES, dv, Bytes.toBytes("default"));
-	            put.add(QueryConstants.EMPTY_COLUMN_BYTES, first, Bytes.toBytes("first"));
-	            put.add(FAMILY_NAME, f1v1, Bytes.toBytes("f1value1"));
-	            put.add(FAMILY_NAME, f1v2,  Bytes.toBytes("f1value2"));
-	            put.add(FAMILY_NAME2, f2v1, Bytes.toBytes("f2value1"));
-	            put.add(FAMILY_NAME2, f2v2,  Bytes.toBytes("f2value2"));
-	            mutations.add(put);
-	              
-	            hTable.batch(mutations);
-	            
-	        } finally {
-	            hTable.close();
-	        }
-	        // Create Phoenix table after HBase table was created through the native APIs
-	        // The timestamp of the table creation must be later than the timestamp of the data
-	        ensureTableCreated(getUrl(),HBASE_DYNAMIC_COLUMNS);
-	    }
-	
-        /**
-  	 * Test a simple select with a dynamic Column
-   	*/
-	 @Test
-	    public void testDynamicColums() throws Exception {
-	        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar)";
-	        String url = PHOENIX_JDBC_URL + ";";
-	        Properties props = new Properties(TEST_PROPERTIES);
-	        Connection conn = DriverManager.getConnection(url, props);
-	        try {
-	            PreparedStatement statement = conn.prepareStatement(query);
-	            ResultSet rs = statement.executeQuery();
-	            assertTrue(rs.next());
-	            assertEquals("entry1", rs.getString(1));
-	            assertEquals("first", rs.getString(2));
-	            assertEquals("f1value1", rs.getString(3));
-	            assertEquals("f1value2", rs.getString(4));
-	            assertEquals("f2value1", rs.getString(5));
-	            assertEquals("default", rs.getString(6));
-	            assertFalse(rs.next());
-	        } finally {
-	            conn.close();
-	        }
-	    }
-	 
-       /**
-         * Test a select with a colum family.column dynamic Column
-        */
-	 @Test
-	    public void testDynamicColumsFamily() throws Exception {
-	        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
-	        String url = PHOENIX_JDBC_URL + ";";
-	        Properties props = new Properties(TEST_PROPERTIES);
-	        Connection conn = DriverManager.getConnection(url, props);
-	        try {
-	            PreparedStatement statement = conn.prepareStatement(query);
-	            ResultSet rs = statement.executeQuery();
-	            assertTrue(rs.next());
-	            assertEquals("entry1", rs.getString(1));
-	            assertEquals("first", rs.getString(2));
-	            assertEquals("f1value1", rs.getString(3));
-	            assertEquals("f1value2", rs.getString(4));
-	            assertEquals("f2value1", rs.getString(5));
-	            assertEquals("default", rs.getString(6));
-	            assertEquals("f2value2", rs.getString(7));
-	            assertFalse(rs.next());
-	        } finally {
-	            conn.close();
-	        }
-	    }
-	 
+    private static final byte[] HBASE_DYNAMIC_COLUMNS_BYTES = SchemaUtil.getTableName(Bytes
+            .toBytes(HBASE_DYNAMIC_COLUMNS));
+    private static final byte[] FAMILY_NAME = Bytes.toBytes(SchemaUtil.normalizeIdentifier("A"));
+    private static final byte[] FAMILY_NAME2 = Bytes.toBytes(SchemaUtil.normalizeIdentifier("B"));
 
-      	/**
-         * Test a select with a colum family.column dynamic Column and check the value
-        */
+    @BeforeClass
+    public static void doBeforeTestSetup() throws Exception {
+        HBaseAdmin admin = new HBaseAdmin(driver.getQueryServices().getConfig());
+        try {
+            try {
+                admin.disableTable(HBASE_DYNAMIC_COLUMNS_BYTES);
+                admin.deleteTable(HBASE_DYNAMIC_COLUMNS_BYTES);
+            } catch (org.apache.hadoop.hbase.TableNotFoundException e) {}
+            ensureTableCreated(getUrl(), HBASE_DYNAMIC_COLUMNS);
+            initTableValues();
+        } finally {
+            admin.close();
+        }
+    }
 
-	 @Test
-	    public void testDynamicColumsSpecificQuery() throws Exception {
-	        String query = "SELECT entry,F2V2 FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
-	        String url = PHOENIX_JDBC_URL + ";";
-	        Properties props = new Properties(TEST_PROPERTIES);
-	        Connection conn = DriverManager.getConnection(url, props);
-	        try {
-	            PreparedStatement statement = conn.prepareStatement(query);
-	            ResultSet rs = statement.executeQuery();
-	            assertTrue(rs.next());
-	            assertEquals("entry1", rs.getString(1));
-	            assertEquals("f2value2", rs.getString(2));
-	            assertFalse(rs.next());
-	        } finally {
-	            conn.close();
-	        }
-	    }
+    private static void initTableValues() throws Exception {
+        ConnectionQueryServices services = driver.getConnectionQueryServices(getUrl(), TEST_PROPERTIES);
+        HTableInterface hTable = services.getTable(SchemaUtil.getTableName(Bytes.toBytes(HBASE_DYNAMIC_COLUMNS)));
+        try {
+            // Insert rows using standard HBase mechanism with standard HBase "types"
+            List<Row> mutations = new ArrayList<Row>();
+            byte[] dv = Bytes.toBytes("DV");
+            byte[] first = Bytes.toBytes("F");
+            byte[] f1v1 = Bytes.toBytes("F1V1");
+            byte[] f1v2 = Bytes.toBytes("F1V2");
+            byte[] f2v1 = Bytes.toBytes("F2V1");
+            byte[] f2v2 = Bytes.toBytes("F2V2");
+            byte[] key = Bytes.toBytes("entry1");
 
-   /**
-   * Test an upsert of prexisting schema defined columns and dynamic ones with  different datatypes
-   */
-  @Test(expected = AmbiguousColumnException.class)
-  public void testAmbiguousStaticSelect() throws Exception {
-      String upsertquery = "Select * FROM HBASE_DYNAMIC_COLUMNS(A.F1V1 INTEGER)";
-      String url = PHOENIX_JDBC_URL + ";";
-      Properties props = new Properties(TEST_PROPERTIES);
-      Connection conn = DriverManager.getConnection(url, props);
-      try {
-          PreparedStatement statement = conn.prepareStatement(upsertquery);
-          ResultSet rs = statement.executeQuery();
-      } finally {
-          conn.close();
-      }
-  }	
+            Put put = new Put(key);
+            put.add(QueryConstants.EMPTY_COLUMN_BYTES, dv, Bytes.toBytes("default"));
+            put.add(QueryConstants.EMPTY_COLUMN_BYTES, first, Bytes.toBytes("first"));
+            put.add(FAMILY_NAME, f1v1, Bytes.toBytes("f1value1"));
+            put.add(FAMILY_NAME, f1v2, Bytes.toBytes("f1value2"));
+            put.add(FAMILY_NAME2, f2v1, Bytes.toBytes("f2value1"));
+            put.add(FAMILY_NAME2, f2v2, Bytes.toBytes("f2value2"));
+            mutations.add(put);
+
+            hTable.batch(mutations);
+
+        } finally {
+            hTable.close();
+        }
+        // Create Phoenix table after HBase table was created through the native APIs
+        // The timestamp of the table creation must be later than the timestamp of the data
+        ensureTableCreated(getUrl(), HBASE_DYNAMIC_COLUMNS);
+    }
+
+    /**
+     * Test a simple select with a dynamic Column
+     */
+    @Test
+    public void testDynamicColums() throws Exception {
+        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar)";
+        String url = PHOENIX_JDBC_URL + ";";
+        Properties props = new Properties(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(url, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(query);
+            ResultSet rs = statement.executeQuery();
+            assertTrue(rs.next());
+            assertEquals("entry1", rs.getString(1));
+            assertEquals("first", rs.getString(2));
+            assertEquals("f1value1", rs.getString(3));
+            assertEquals("f1value2", rs.getString(4));
+            assertEquals("f2value1", rs.getString(5));
+            assertEquals("default", rs.getString(6));
+            assertFalse(rs.next());
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Test a select with a colum family.column dynamic Column
+     */
+    @Test
+    public void testDynamicColumsFamily() throws Exception {
+        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
+        String url = PHOENIX_JDBC_URL + ";";
+        Properties props = new Properties(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(url, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(query);
+            ResultSet rs = statement.executeQuery();
+            assertTrue(rs.next());
+            assertEquals("entry1", rs.getString(1));
+            assertEquals("first", rs.getString(2));
+            assertEquals("f1value1", rs.getString(3));
+            assertEquals("f1value2", rs.getString(4));
+            assertEquals("f2value1", rs.getString(5));
+            assertEquals("default", rs.getString(6));
+            assertEquals("f2value2", rs.getString(7));
+            assertFalse(rs.next());
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Test a select with a colum family.column dynamic Column and check the value
+     */
+
+    @Test
+    public void testDynamicColumsSpecificQuery() throws Exception {
+        String query = "SELECT entry,F2V2 FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
+        String url = PHOENIX_JDBC_URL + ";";
+        Properties props = new Properties(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(url, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(query);
+            ResultSet rs = statement.executeQuery();
+            assertTrue(rs.next());
+            assertEquals("entry1", rs.getString(1));
+            assertEquals("f2value2", rs.getString(2));
+            assertFalse(rs.next());
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Test an upsert of prexisting schema defined columns and dynamic ones with different datatypes
+     */
+    @Test(expected = AmbiguousColumnException.class)
+    public void testAmbiguousStaticSelect() throws Exception {
+        String upsertquery = "Select * FROM HBASE_DYNAMIC_COLUMNS(A.F1V1 INTEGER)";
+        String url = PHOENIX_JDBC_URL + ";";
+        Properties props = new Properties(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(url, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(upsertquery);
+            ResultSet rs = statement.executeQuery();
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * Test a select of an undefined ColumnFamily dynamic columns
+     */
+    @Test(expected = ConstraintViolationException.class)
+    public void testFakeCFDynamicUpsert() throws Exception {
+        String upsertquery = "Select * FROM HBASE_DYNAMIC_COLUMNS(fakecf.DynCol VARCHAR)";
+        String url = PHOENIX_JDBC_URL + ";";
+        Properties props = new Properties(TEST_PROPERTIES);
+        Connection conn = DriverManager.getConnection(url, props);
+        try {
+            PreparedStatement statement = conn.prepareStatement(upsertquery);
+            ResultSet rs = statement.executeQuery();
+        } finally {
+            conn.close();
+        }
+    }
 
 }
-

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicColumnTest.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
 package com.salesforce.phoenix.end2end;
 
 import static com.salesforce.phoenix.util.TestUtil.HBASE_DYNAMIC_COLUMNS;
@@ -26,6 +42,16 @@ import org.junit.Test;
 import com.salesforce.phoenix.query.ConnectionQueryServices;
 import com.salesforce.phoenix.query.QueryConstants;
 import com.salesforce.phoenix.util.SchemaUtil;
+
+import com.salesforce.phoenix.schema.*;
+
+/**
+ * Basic tests for Phoenix dynamic upserting
+ *
+ * @author nmaillard
+ * @since 1.3
+ */
+
 
 public class DynamicColumnTest extends BaseClientMangedTimeTest {
 	 private static final byte[] HBASE_DYNAMIC_COLUMNS_BYTES = SchemaUtil.getTableName(Bytes.toBytes(HBASE_DYNAMIC_COLUMNS));
@@ -81,6 +107,9 @@ public class DynamicColumnTest extends BaseClientMangedTimeTest {
 	        ensureTableCreated(getUrl(),HBASE_DYNAMIC_COLUMNS);
 	    }
 	
+        /**
+  	 * Test a simple select with a dynamic Column
+   	*/
 	 @Test
 	    public void testDynamicColums() throws Exception {
 	        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar)";
@@ -103,6 +132,9 @@ public class DynamicColumnTest extends BaseClientMangedTimeTest {
 	        }
 	    }
 	 
+       /**
+         * Test a select with a colum family.column dynamic Column
+        */
 	 @Test
 	    public void testDynamicColumsFamily() throws Exception {
 	        String query = "SELECT * FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
@@ -126,6 +158,11 @@ public class DynamicColumnTest extends BaseClientMangedTimeTest {
 	        }
 	    }
 	 
+
+      	/**
+         * Test a select with a colum family.column dynamic Column and check the value
+        */
+
 	 @Test
 	    public void testDynamicColumsSpecificQuery() throws Exception {
 	        String query = "SELECT entry,F2V2 FROM HBASE_DYNAMIC_COLUMNS (DV varchar,B.F2V2 varchar)";
@@ -143,6 +180,23 @@ public class DynamicColumnTest extends BaseClientMangedTimeTest {
 	            conn.close();
 	        }
 	    }
+
+   /**
+   * Test an upsert of prexisting schema defined columns and dynamic ones with  different datatypes
+   */
+  @Test(expected = AmbiguousColumnException.class)
+  public void testAmbiguousStaticSelect() throws Exception {
+      String upsertquery = "Select * FROM HBASE_DYNAMIC_COLUMNS(A.F1V1 INTEGER)";
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          ResultSet rs = statement.executeQuery();
+      } finally {
+          conn.close();
+      }
+  }	
 
 }
 

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
@@ -26,7 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.salesforce.phoenix.schema.AmbiguousColumnException;
-import com.salesforce.phoenix.schema.ColumnFamilyNotFoundException;
+import com.salesforce.phoenix.schema.ConstraintViolationException;
 
 /**
  * Basic tests for Phoenix dynamic upserting
@@ -203,7 +203,7 @@ public class DynamicUpsertTest extends BaseClientMangedTimeTest {
     /**
      * Test an upsert of an undefined ColumnFamily dynamic columns
      */
-    @Test(expected = ColumnFamilyNotFoundException.class)
+    @Test(expected = ConstraintViolationException.class)
     public void testFakeCFDynamicUpsert() throws Exception {
         String upsertquery = "UPSERT INTO " + TABLE + " (fakecf.DynCol VARCHAR) VALUES('dynCol')";
         String url = PHOENIX_JDBC_URL + ";";

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
@@ -26,7 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.salesforce.phoenix.schema.AmbiguousColumnException;
-import com.salesforce.phoenix.schema.ConstraintViolationException;
+import com.salesforce.phoenix.schema.ColumnFamilyNotFoundException;
 
 /**
  * Basic tests for Phoenix dynamic upserting
@@ -203,7 +203,7 @@ public class DynamicUpsertTest extends BaseClientMangedTimeTest {
     /**
      * Test an upsert of an undefined ColumnFamily dynamic columns
      */
-    @Test(expected = ConstraintViolationException.class)
+    @Test(expected = ColumnFamilyNotFoundException.class)
     public void testFakeCFDynamicUpsert() throws Exception {
         String upsertquery = "UPSERT INTO " + TABLE + " (fakecf.DynCol VARCHAR) VALUES('dynCol')";
         String url = PHOENIX_JDBC_URL + ";";

--- a/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/DynamicUpsertTest.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc. All rights reserved. Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the following conditions are met: Redistributions of source code
+ * must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution. Neither the name of Salesforce.com nor the names
+ * of its contributors may be used to endorse or promote products derived from this software without specific prior
+ * written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.end2end;
+
+import static com.salesforce.phoenix.util.TestUtil.PHOENIX_JDBC_URL;
+import static com.salesforce.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.salesforce.phoenix.schema.*;
+
+/**
+ * Basic tests for Phoenix dynamic upserting
+ * 
+ * @author nmaillard
+ * @since 1.3
+ */
+
+public class DynamicUpsertTest extends BaseClientMangedTimeTest {
+
+  private static final String TABLE = "DynamicUpserts";
+  private static final byte[] TABLE_BYTES = Bytes.toBytes(TABLE); 
+ 
+   @BeforeClass
+  public static void doBeforeTestSetup() throws Exception {
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(getUrl(), props);
+      String ddl = "create table if not exists  " + TABLE
+              + "   (entry varchar not null primary key,"
+              + "    a.dummy varchar," 
+              + "    b.dummy varchar)";
+      conn.createStatement().execute(ddl);
+      conn.close();
+  }
+ 
+  
+  /**
+   * Test a simple upsert with a dynamic Column
+   */
+    @Test
+  public void testUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (entry, a.DynCol VARCHAR,a.dummy) VALUES ('dynEntry','DynValue','DynColValue')";
+      String selectquery = "SELECT DynCol FROM "+TABLE+" (a.DynCol VARCHAR) where entry='dynEntry'";
+     //String selectquery = "SELECT * FROM "+TABLE;      
+
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      conn.setAutoCommit(true);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          int rowsInserted = statement.executeUpdate();
+          assertEquals(1, rowsInserted); 
+
+          //since the upsert does not alter the schema check with a dynamicolumn	
+	  PreparedStatement selectStatement = conn.prepareStatement(selectquery);
+          ResultSet rs = selectStatement.executeQuery();
+          assertTrue(rs.next());
+          assertEquals("DynValue", rs.getString(1));
+          assertFalse(rs.next());
+      } finally {
+          conn.close();
+      }
+  }
+  
+  /**
+   * Test an upsert of multiple dynamic Columns
+   */
+    @Test
+  public void testMultiUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (entry, a.DynColA VARCHAR,b.DynColB varchar) VALUES('dynEntry','DynColValuea','DynColValueb')";
+      String selectquery = "SELECT DynColA,entry,DynColB FROM "+TABLE+" (a.DynColA VARCHAR,b.DynColB VARCHAR) where entry='dynEntry'";
+      
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      conn.setAutoCommit(true);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          int rowsInserted = statement.executeUpdate();
+          assertEquals(1, rowsInserted); 
+ 
+          //since the upsert does not alter the schema check with a dynamicolumn
+          statement = conn.prepareStatement(selectquery);
+          ResultSet rs = statement.executeQuery();
+          assertTrue(rs.next());
+          assertEquals("DynColValuea", rs.getString(1));
+          assertEquals("dynEntry", rs.getString(2));
+          assertEquals("DynColValueb", rs.getString(3));
+          assertFalse(rs.next());
+      } finally {
+          conn.close();
+      }
+  }
+  
+  /**
+   * Test an upsert of a full row with dynamic Columns
+   */
+   @Test
+  public void testFullUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (a.DynColA VARCHAR,b.DynColB varchar) VALUES('dynEntry','aValue','bValue','DynColValuea','DynColValueb')";
+      String selectquery = "SELECT entry,DynColA,a.dummy,DynColB,b.dummy FROM "+TABLE+" (a.DynColA VARCHAR,b.DynColB VARCHAR) where entry='dynEntry'";
+      
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      conn.setAutoCommit(true);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          int rowsInserted = statement.executeUpdate();
+          assertEquals(1, rowsInserted);         
+ 
+          //since the upsert does not alter the schema check with a dynamicolumn
+          statement = conn.prepareStatement(selectquery);
+          ResultSet rs = statement.executeQuery();
+          assertTrue(rs.next());
+          assertEquals("dynEntry", rs.getString(1));
+          assertEquals("DynColValuea", rs.getString(2));
+          assertEquals("aValue", rs.getString(3));
+          assertEquals("DynColValueb", rs.getString(4));
+          assertEquals("bValue", rs.getString(5));
+          assertFalse(rs.next());
+      } finally {
+          conn.close();
+      }
+  }
+  
+  
+  /**
+   * Test an upsert of a full row with dynamic Columns and unbalanced number of values
+   */
+  @Test(expected = AmbiguousColumnException.class)
+  public void testFullUnbalancedUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (a.DynCol VARCHAR,b.DynCol varchar) VALUES('dynEntry','aValue','bValue','dyncola')";
+     
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          statement.execute();
+      } finally {
+          conn.close();
+      }
+  }
+  
+  
+  /**
+   * Test an upsert of prexisting schema defined columns and dynamic ones with  different datatypes
+   */
+  @Test(expected = AmbiguousColumnException.class)
+  public void testAmbiguousStaticUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (a.dummy INTEGER,b.dummy INTEGER) VALUES(1,2)";
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          statement.execute();
+      } finally {
+          conn.close();
+      }
+  }
+
+  /**
+   * Test an upsert of two conflicting dynamic columns
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testAmbiguousDynamicUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (a.DynCol VARCHAR,a.DynCol INTEGER) VALUES('dynCol',1)";
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          statement.execute();
+      } finally {
+          conn.close();
+      }
+  }
+
+  /**
+   * Test an upsert of an undefined ColumnFamily dynamic columns
+   */
+  @Test(expected = ColumnFamilyNotFoundException.class)
+  public void testFakeCFDynamicUpsert() throws Exception {
+      String upsertquery = "UPSERT INTO "+TABLE+" (fakecf.DynCol VARCHAR) VALUES('dynCol')";
+      String url = PHOENIX_JDBC_URL + ";";
+      Properties props = new Properties(TEST_PROPERTIES);
+      Connection conn = DriverManager.getConnection(url, props);
+      try {
+          PreparedStatement statement = conn.prepareStatement(upsertquery);
+          statement.execute();
+      } finally {
+          conn.close();
+      }
+  }
+}
+


### PR DESCRIPTION
This is a first step for the dynamic upsert functionality.
Upsert into TABLE (key,column, Dyn VARCHAR, Dyn2 VARCHAR) VALUES ('key','entry','val','val2')
it also allows a full upsert:
Upsert into TABLE (Dyn VARCHAR, Dyn2 VARCHAR) VALUES ('key','entry','val','val2')
where your dynamic columns are at the end.

Import missing features are
A table alter when a dynamic column is upserted to have in the schema for next time. this feature could be disabled.
Missing case sensitivity

Improvements:
Refactoring of Dynamic columns between select and upsert
test for column ambiguouity
test for wrong column families
Added tests to DynamicColumnTest to test these issues
DynamicUpsertTest for the upsert part
