### PR TITLE
check null when parse remote exception

### DIFF
--- a/src/main/java/com/salesforce/phoenix/util/ServerUtil.java
+++ b/src/main/java/com/salesforce/phoenix/util/ServerUtil.java
@@ -107,6 +107,11 @@ public class ServerUtil {
     }
 
     private static SQLException parseRemoteException(Throwable t) {
+    	String message = t.getLocalizedMessage();
+    	if (message == null) {
+    		return new PhoenixIOException(t);
+		}
+    	
         // If the message matches the standard pattern, recover the SQLException and throw it.
         Matcher matcher = PATTERN.matcher(t.getLocalizedMessage());
         if (matcher.find()) {


### PR DESCRIPTION
throwable t may have not set detail message.
in this case,PATTERN.matcher would throw a null pointer exception.
