### PR TITLE
Version specific Hadoop profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <!-- Plugin versions -->
     <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
     <maven-build-helper-plugin.version>1.7</maven-build-helper-plugin.version>
+    <maven-dependency-plugin.version>2.1</maven-dependency-plugin.version>
 
     <!-- Set default encoding so multi-byte tests work correctly on the Mac -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -334,34 +335,6 @@
       <version>${opencsv.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
-      <version>${hadoop.version}</version>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>hsqldb</groupId>
-          <artifactId>hsqldb</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sf.kosmosfs</groupId>
-          <artifactId>kfs</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jdt</groupId>
-          <artifactId>core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.java.dev.jets3t</groupId>
-          <artifactId>jets3t</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>oro</groupId>
-          <artifactId>oro</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
       <version>0.11.0</version>
@@ -415,13 +388,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-test</artifactId>
-      <version>${hadoop.version}</version>
-      <optional>true</optional>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
@@ -436,5 +402,122 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+
+    <!--
+      Profile for building against Hadoop 1. Active by default.
+      Not used if another Hadoop profile is specified with
+        mvn -Dhadoop.profile=foo
+    -->
+    <profile>
+      <id>hadoop-1</id>
+      <activation>
+        <property>
+          <name>!hadoop.profile</name>
+	</property>
+      </activation>
+      <dependencies>
+	<dependency>
+	  <groupId>org.apache.hadoop</groupId>
+	  <artifactId>hadoop-core</artifactId>
+	  <version>${hadoop.version}</version>
+	  <optional>true</optional>
+	  <exclusions>
+	    <exclusion>
+	      <groupId>hsqldb</groupId>
+	      <artifactId>hsqldb</artifactId>
+	    </exclusion>
+	    <exclusion>
+	      <groupId>net.sf.kosmosfs</groupId>
+	      <artifactId>kfs</artifactId>
+	    </exclusion>
+	    <exclusion>
+	      <groupId>org.eclipse.jdt</groupId>
+	      <artifactId>core</artifactId>
+	    </exclusion>
+	    <exclusion>
+	      <groupId>net.java.dev.jets3t</groupId>
+	      <artifactId>jets3t</artifactId>
+	    </exclusion>
+	    <exclusion>
+	      <groupId>oro</groupId>
+	      <artifactId>oro</artifactId>
+	    </exclusion>
+	  </exclusions>
+	</dependency>
+	<dependency>
+	  <groupId>org.apache.hadoop</groupId>
+	  <artifactId>hadoop-test</artifactId>
+	  <version>${hadoop.version}</version>
+	  <optional>true</optional>
+	  <scope>test</scope>
+	</dependency>
+      </dependencies>
+    </profile>
+
+    <!--
+      Profile for building against Hadoop 2. Activate using:
+        mvn -Dhadoop.profile=2
+    -->
+    <profile>
+      <id>hadoop-2</id>
+      <activation>
+        <property>
+          <name>hadoop.profile</name>
+          <value>2</value>
+        </property>
+      </activation>
+      <properties>
+        <hadoop.version>2.0.4-alpha</hadoop.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-annotations</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-mapreduce-client-core</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-minicluster</artifactId>
+          <version>${hadoop.version}</version>
+	  <optional>true</optional>
+	  <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+	<plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+	    <version>${maven-dependency-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>create-mrapp-generated-classpath</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>build-classpath</goal>
+                </goals>
+                <configuration>
+                  <outputFile>${project.build.directory}/classes/mrapp-generated-classpath</outputFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+	</plugins>
+      </build>
+
+    </profile>
+    
+  </profiles>
 
 </project>

--- a/src/build/all.xml
+++ b/src/build/all.xml
@@ -90,7 +90,7 @@
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>
         <include>com.google.guava:guava</include>
-        <include>org.apache.hadoop:hadoop-core</include>
+        <include>org.apache.hadoop:hadoop*</include>
 
         <include>com.google.protobuf:protobuf-java</include>
         <include>org.slf4j:slf4j-api</include>

--- a/src/build/client.xml
+++ b/src/build/client.xml
@@ -20,7 +20,7 @@
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>
         <include>com.google.guava:guava</include>
-        <include>org.apache.hadoop:hadoop-core</include>
+        <include>org.apache.hadoop:hadoop*</include>
         <include>com.google.protobuf:protobuf-java</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-log4j12</include>


### PR DESCRIPTION
Introduce version specific Hadoop profiles. Introduce a default profile for Hadoop 1 and another for Hadoop 2. Useful when HBase artifacts are built using its Hadoop 2 profile. It is necessary to do this in the Phoenix POM because the Hadoop artifact names for version 2 are different from version 1, and more are required.

Unit tests complete successfully, except for com.salesforce.phoenix.expression.DescColumnSortOrderExpressionTest, which is unrelated to this change as it is failing on forcedotcom/phoenix master already, with 

```
mvn -Dhadoop.profile=2 -Dhadoop.version=2.0.4-alpha -Dhbase.version=0.94.8 clean package
```

where HBase 0.94.8 was built against 2.0.4-alpha and installed into the local Maven cache.
