### PR TITLE
change jline to 2.11 to make the sqline.sh work @ Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>0.9.9</version>
+      <version>2.11</version>
     </dependency>
     <dependency>
       <groupId>sqlline</groupId>


### PR DESCRIPTION
The jline is too old I think. It can not work on Mac. 
Upgrade it to 2.11 will make it work better.
thanks.
