### PR TITLE
Fix java.lang.ArrayIndexOutOfBoundsException for ValueSchema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 #maven stuffs
 target/
+
+#idea
+.idea/
+*.iml

--- a/src/main/java/com/salesforce/phoenix/schema/KeyValueSchema.java
+++ b/src/main/java/com/salesforce/phoenix/schema/KeyValueSchema.java
@@ -99,4 +99,18 @@ public class KeyValueSchema extends ValueSchema {
         offset += length;
         return offset;
     }
+
+    @Override
+    protected int writeVarLengthField(ImmutableBytesWritable ptr, Object[] bWrapper, int offset) {
+        byte[] b = (byte[]) bWrapper[0];
+        int length = ptr.getLength();
+        int vintLen = WritableUtils.getVIntSize(length);
+        b = ensureSize(b, offset, offset + vintLen);
+        offset += ByteUtil.vintToBytes(b, offset, length);
+        b = ensureSize(b, offset, offset + length);
+        System.arraycopy(ptr.get(), ptr.getOffset(), b, offset, length);
+        offset += length;
+        bWrapper[0]=b;
+        return offset;
+    }
 }

--- a/src/main/java/com/salesforce/phoenix/schema/RowKeySchema.java
+++ b/src/main/java/com/salesforce/phoenix/schema/RowKeySchema.java
@@ -130,7 +130,19 @@ public class RowKeySchema extends ValueSchema {
         b[offset-1] = QueryConstants.SEPARATOR_BYTE;
         return offset;
     }
-    
+
+    @Override
+    protected int writeVarLengthField(ImmutableBytesWritable ptr, Object[] bWrapper, int offset) {
+        byte[] b = (byte[]) bWrapper[0];
+        int length = ptr.getLength();
+        b = ensureSize(b, offset, offset + length + 1);
+        System.arraycopy(ptr.get(), ptr.getOffset(), b, offset, length);
+        offset += length + 1;
+        b[offset-1] = QueryConstants.SEPARATOR_BYTE;
+        bWrapper[0] = b;
+        return offset;
+    }
+
     public int getMaxFields() {
         return this.getMinNullable();
     }


### PR DESCRIPTION
Fix the java.lang.ArrayIndexOutOfBoundsException for ValueSchema and KeyValueSchema.
Apply this path,the select min or select max return the correct values,mabye this is helpful.
Thanks.
