### PR TITLE
fix for relative path of phoenix_jar_path and log4j.properties

### DIFF
--- a/bin/performance.sh
+++ b/bin/performance.sh
@@ -42,7 +42,8 @@ qry="query.sql"
 statements=""
 
 # Phoenix client jar. To generate new jars: $ mvn package -DskipTests
-phoenix_jar_path="../target"
+current_dir=$(cd $(dirname $0);pwd)
+phoenix_jar_path="$current_dir/../target"
 phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 testjar="$phoenix_jar_path/phoenix-*-tests.jar"
 

--- a/bin/performance.sh
+++ b/bin/performance.sh
@@ -50,7 +50,7 @@ testjar="$phoenix_jar_path/phoenix-*-tests.jar"
 # HBase configuration folder path (where hbase-site.xml reside) for HBase/Phoenix client side property override
 hbase_config_path="."
 
-execute="java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:log4j.properties com.salesforce.phoenix.util.PhoenixRuntime -t $table $zookeeper "
+execute="java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:$current_dir/log4j.properties com.salesforce.phoenix.util.PhoenixRuntime -t $table $zookeeper "
 function usage {
 	echo "Performance script arguments not specified. Usage: performance.sh <zookeeper> <row count>"
 	echo "Example: performance.sh localhost 100000"

--- a/bin/psql.sh
+++ b/bin/psql.sh
@@ -35,4 +35,4 @@ phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 # HBase configuration folder path (where hbase-site.xml reside) for HBase/Phoenix client side property override
 hbase_config_path="."
 
-java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:log4j.properties com.salesforce.phoenix.util.PhoenixRuntime "$@"
+java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:$current_dir/log4j.properties com.salesforce.phoenix.util.PhoenixRuntime "$@"

--- a/bin/psql.sh
+++ b/bin/psql.sh
@@ -28,7 +28,8 @@
 ############################################################################
 
 # Phoenix client jar. To generate new jars: $ mvn package -DskipTests
-phoenix_jar_path="../target"
+current_dir=$(cd $(dirname $0);pwd)
+phoenix_jar_path="$current_dir/../target"
 phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 
 # HBase configuration folder path (where hbase-site.xml reside) for HBase/Phoenix client side property override

--- a/bin/sqlline.sh
+++ b/bin/sqlline.sh
@@ -41,4 +41,4 @@ if [ "$2" ]
   then sqlfile="--run=$2";
 fi
 
-java -cp ".:$phoenix_client_jar" -Dlog4j.configuration=file:log4j.properties sqlline.SqlLine -d com.salesforce.phoenix.jdbc.PhoenixDriver -u jdbc:phoenix:$1 -n none -p none --color=true --fastConnect=false --silent=true --isolation=TRANSACTION_READ_COMMITTED $sqlfile
+java -cp ".:$phoenix_client_jar" -Dlog4j.configuration=file:$current_dir/log4j.properties sqlline.SqlLine -d com.salesforce.phoenix.jdbc.PhoenixDriver -u jdbc:phoenix:$1 -n none -p none --color=true --fastConnect=false --silent=true --isolation=TRANSACTION_READ_COMMITTED $sqlfile

--- a/bin/sqlline.sh
+++ b/bin/sqlline.sh
@@ -28,7 +28,8 @@
 ############################################################################
 
 # Phoenix client jar. To generate new jars: $ mvn package -DskipTests
-phoenix_jar_path="../target"
+current_dir=$(cd $(dirname $0);pwd)
+phoenix_jar_path="$current_dir/../target"
 phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 
 if [ -z "$1" ] 

--- a/bin/upgradeTo2.sh
+++ b/bin/upgradeTo2.sh
@@ -35,4 +35,4 @@ phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 # HBase configuration folder path (where hbase-site.xml reside) for HBase/Phoenix client side property override
 hbase_config_path="."
 
-java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:log4j.properties com.salesforce.phoenix.util.PhoenixRuntime -u "$@"
+java -cp "$hbase_config_path:$phoenix_client_jar" -Dlog4j.configuration=file:$current_dir/log4j.properties com.salesforce.phoenix.util.PhoenixRuntime -u "$@"

--- a/bin/upgradeTo2.sh
+++ b/bin/upgradeTo2.sh
@@ -28,7 +28,8 @@
 ############################################################################
 
 # Phoenix client jar. To generate new jars: $ mvn package -DskipTests
-phoenix_jar_path="../target"
+current_dir=$(cd $(dirname $0);pwd)
+phoenix_jar_path="$current_dir/../target"
 phoenix_client_jar=$(find $phoenix_jar_path/phoenix-*-client.jar)
 
 # HBase configuration folder path (where hbase-site.xml reside) for HBase/Phoenix client side property override


### PR DESCRIPTION
We have to execute the shell scripts under the bin folder.

This patch enables  execute the shell scripts outside of the bin folder.
