### PR TITLE
Adding a basic column-covered index implementation to hbase-index

### DIFF
--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/IndexUtil.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/IndexUtil.java
@@ -34,7 +34,6 @@ public final class IndexUtil {
     desc.addCoprocessor(Indexer.class.getName(), null, Coprocessor.PRIORITY_USER, properties);
   }
 
-
   /**
    * Validate that the version and configuration parameters are supported
    * @param hBaseVersion current version of HBase on which <tt>this</tt> coprocessor is installed

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/BaseIndexBuilder.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/BaseIndexBuilder.java
@@ -1,11 +1,12 @@
 package com.salesforce.hbase.index.builder;
 
+import java.io.IOException;
 import java.util.Map;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 
 /**
  * Basic implementation of the {@link IndexBuilder} that doesn't do any actual work of indexing.
@@ -19,17 +20,17 @@ public class BaseIndexBuilder implements IndexBuilder {
   public void extendBaseIndexBuilderInstead() { }
   
   @Override
-  public void setup(Configuration conf) {
+  public void setup(RegionCoprocessorEnvironment conf) throws IOException {
     // noop
   }
 
   @Override
-  public Map<Mutation, String> getIndexUpdate(Put put) {
+  public Map<Mutation, String> getIndexUpdate(Put put) throws IOException {
     return null;
   }
 
   @Override
-  public Map<Mutation, String> getIndexUpdate(Delete delete) {
+  public Map<Mutation, String> getIndexUpdate(Delete delete) throws IOException {
     return null;
   }
 

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/ColumnFamilyIndexer.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/ColumnFamilyIndexer.java
@@ -17,6 +17,7 @@ import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 
@@ -63,7 +64,9 @@ public class ColumnFamilyIndexer extends BaseIndexBuilder {
 
   private Map<ImmutableBytesWritable, String> columnTargetMap;
 
-  public void setup(Configuration conf) {
+  @Override
+  public void setup(RegionCoprocessorEnvironment env) {
+    Configuration conf = env.getConfiguration();
     String[] families = conf.get(INDEX_TO_TABLE_COUNT_KEY).split(SEPARATOR);
 
     // build up our mapping of column - > index table

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/IndexBuilder.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/IndexBuilder.java
@@ -1,14 +1,13 @@
 package com.salesforce.hbase.index.builder;
 
+import java.io.IOException;
 import java.util.Map;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 
-import com.salesforce.hbase.index.IndexUtil;
 import com.salesforce.hbase.index.Indexer;
 
 /**
@@ -23,10 +22,10 @@ public interface IndexBuilder {
   /**
    * This is always called exactly once on install of {@link Indexer}, before any calls
    * {@link #getIndexUpdate} on
-   * @param conf {@link Configuration} containing any properties specified in
-   *          {@link IndexUtil#enableIndexing(HTableDescriptor, Class, Map)}
+   * @param env in which the builder is running
+   * @throws IOException on failure to setup the builder
    */
-  public void setup(Configuration conf);
+  public void setup(RegionCoprocessorEnvironment env) throws IOException;
 
   /**
    * Your opportunity to update any/all index tables based on the delete of the primary table row.
@@ -34,8 +33,9 @@ public interface IndexBuilder {
    * tables.
    * @param put {@link Put} to the primary table that may be indexed
    * @return a Map of the mutations to make -> target index table name
+   * @throws IOException on failure
    */
-  public Map<Mutation, String> getIndexUpdate(Put put);
+  public Map<Mutation, String> getIndexUpdate(Put put) throws IOException;
 
   /**
    * The counter-part to {@link #getIndexUpdate(Put)} - your opportunity to update any/all index
@@ -43,8 +43,9 @@ public interface IndexBuilder {
    * that timestamps match between the primary and index tables.
    * @param delete {@link Delete} to the primary table that may be indexed
    * @return a {@link Map} of the mutations to make -> target index table name
+   * @throws IOException on failure
    */
-  public Map<Mutation, String> getIndexUpdate(Delete delete);
+  public Map<Mutation, String> getIndexUpdate(Delete delete) throws IOException;
 
   /** Helper method signature to ensure people don't attempt to extend this class directly */
   public void extendBaseIndexBuilderInstead();

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/ColumnGroup.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/ColumnGroup.java
@@ -1,0 +1,90 @@
+
+package com.salesforce.hbase.index.builder.covered;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * A collection of {@link CoveredColumn}s that should be included in a covered index.
+ */
+public class ColumnGroup implements Iterable<CoveredColumn> {
+
+  private List<CoveredColumn> columns = new ArrayList<CoveredColumn>();
+  private String table;
+
+  public ColumnGroup(String tableName) {
+    this.table = tableName;
+  }
+
+  public void add(CoveredColumn column) {
+    this.columns.add(column);
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  /**
+   * Check to see if any {@link CoveredColumn} in <tt>this</tt> matches the given family
+   * @param family to check
+   * @return <tt>true</tt> if any column covers the family
+   */
+  public boolean matches(String family) {
+    for (CoveredColumn column : columns) {
+      if (column.matchesFamily(family)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check to see if any column matches the family/qualifier pair
+   * @param family family to match against
+   * @param qualifier qualifier to match, can be <tt>null</tt>, in which case we match all
+   *          qualifiers
+   * @return <tt>true</tt> if any column matches, <tt>false</tt> otherwise
+   */
+  public boolean matches(byte[] family, byte[] qualifier) {
+    // families are always printable characters
+    String fam = Bytes.toString(family);
+    for (CoveredColumn column : columns) {
+      if (column.matchesFamily(fam)) {
+        // check the qualifier
+          if (column.matchesQualifier(qualifier)) {
+            return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @return the number of columns in the group
+   */
+  public int size() {
+    return this.columns.size();
+  }
+
+  @Override
+  public Iterator<CoveredColumn> iterator() {
+    return columns.iterator();
+  }
+
+  /**
+   * @param index index of the column to get
+   * @return the specified column
+   */
+  public CoveredColumn getColumnForTesting(int index) {
+    return this.columns.get(index);
+  }
+
+  @Override
+  public String toString() {
+    return "ColumnGroup - table: " + table + ", columns: " + columns;
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumn.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumn.java
@@ -1,0 +1,93 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * A single Column (either a Column Family or a full Family:Qualifier pair) in a {@link ColumnGroup}
+ * . If no column qualifier is specified, matches all known qualifiers of the family.
+ */
+public class CoveredColumn {
+
+  public static final String SEPARATOR = ":";
+  String family;
+  byte[] qualifier;
+
+  public CoveredColumn(String family, byte[] qualifier) {
+    this.family = family;
+    this.qualifier = qualifier;
+  }
+
+  public static CoveredColumn parse(String spec) {
+    int sep = spec.indexOf(SEPARATOR);
+    if (sep < 0) {
+      throw new IllegalArgumentException(spec + " is not a valid specifier!");
+    }
+    String family = spec.substring(0, sep);
+    String qual = spec.substring(sep + 1);
+    byte[] column = qual.length() == 0 ? null : Bytes.toBytes(qual);
+    return new CoveredColumn(family, column);
+  }
+
+  public String serialize() {
+    return CoveredColumn.serialize(family, qualifier);
+  }
+
+  public static String serialize(String first, byte[] second) {
+    String nextValue = first + CoveredColumn.SEPARATOR;
+    if (second != null) {
+      nextValue += Bytes.toString(second);
+    }
+    return nextValue;
+  }
+
+  /**
+   * @param family2 to check
+   * @return <tt>true</tt> if the passed family matches the family this column covers
+   */
+  public boolean matchesFamily(String family2) {
+    return this.family.equals(family2);
+  }
+
+  /**
+   * @param qual to check against
+   * @return <tt>true</tt> if this column covers the given qualifier.
+   */
+  public boolean matchesQualifier(byte[] qual) {
+    // empty qualifier matches all
+    return qualifier == null || Arrays.equals(qual, qualifier);
+  }
+
+  /**
+   * @return <tt>true</tt> if this should include all column qualifiers, <tt>false</tt> otherwise
+   */
+  public boolean allColumns() {
+    return this.qualifier == null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    CoveredColumn other = (CoveredColumn) o;
+    if (this.family.equals(other.family)) {
+      return Bytes.equals(qualifier, other.qualifier);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = this.family.hashCode();
+    if (this.qualifier != null) {
+      hash += Bytes.hashCode(qualifier);
+    }
+
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    String qualString = qualifier == null ? "null" : Bytes.toString(qualifier);
+    return "CoveredColumn:[" + family + ":" + qualString + "]";
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexCodec.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexCodec.java
@@ -1,0 +1,402 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.regionserver.ExposedMemStore;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
+
+import com.salesforce.hbase.index.builder.covered.util.FamilyOnlyFilter;
+import com.salesforce.hbase.index.builder.covered.util.FilteredKeyValueScanner;
+import com.salesforce.hbase.index.builder.covered.util.NewerTimestampFilter;
+
+/**
+ * Handle serialization to/from a column-covered index.
+ * @see CoveredColumnIndexer
+ */
+public class CoveredColumnIndexCodec {
+  private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+  public static final byte[] INDEX_ROW_COLUMN_FAMILY = Bytes.toBytes("INDEXED_COLUMNS");
+  private static final Configuration conf = HBaseConfiguration.create();
+  {
+    // keep it all on the heap - hopefully this should be a bit faster and shouldn't need to grow
+    // very large as we are just handling a single row.
+    conf.setBoolean("hbase.hregion.memstore.mslab.enabled", false);
+  }
+
+  private ColumnGroup group;
+  private ExposedMemStore memstore;
+  private byte[] pk;
+
+  public CoveredColumnIndexCodec(byte[] primaryKey, Result currentRow, ColumnGroup group) {
+    this.pk =primaryKey;
+    this.group = group;
+    this.memstore = new ExposedMemStore(conf, KeyValue.COMPARATOR);
+    if(!currentRow.isEmpty()){
+      addAll(currentRow.list());
+    }
+  }
+  
+  /**
+   * Setup the codec on the specified row for the current group of columns
+   * @param currentRow must not return <tt>null</tt> for {@link Result#getRow()} - its expected to
+   *          be the {@link Result} from reading an existing row. If you are not sure, you should
+   *          call the constructor which specifies the primary key.
+   * @param group columns for which we want to build an index codec
+   */
+  public CoveredColumnIndexCodec(Result currentRow, ColumnGroup group) {
+    this(currentRow.getRow(), currentRow, group);
+  }
+
+  /**
+   * Create a codec on the given primary row with the given backing current state. If you use this
+   * constructor, you must specify a group via {@link #setGroup(ColumnGroup)} before calling any
+   * other instance methods.
+   * @param sourceRow primary key of the row in questions
+   * @param r current state of the current row (can be empty)
+   */
+  public CoveredColumnIndexCodec(byte[] sourceRow, Result r) {
+    this(sourceRow, r, null);
+  }
+
+  public void setGroup(ColumnGroup group) {
+    this.group = group;
+  }
+
+  /**
+   * Add all the {@link KeyValue}s in the list to the memstore. This is just a small utility method
+   * around {@link ExposedMemStore#add(KeyValue)} to make it easier to deal with batches of
+   * {@link KeyValue}s.
+   * @param list keyvalues to add
+   */
+  public void addAll(Iterable<KeyValue> list) {
+    for (KeyValue kv : list) {
+      this.memstore.add(kv);
+    }
+  }
+
+  /**
+   * Get the most recent value for each column group, in the order of the columns stored in the
+   * group and then build them into a single byte array to use as row key for an index update for
+   * the column group.
+   * @return the row key and the corresponding list of {@link CoveredColumn}s to the position of
+   *         their value in the row key
+   */
+  public Pair<byte[], List<CoveredColumn>> getIndexRowKey() {
+    return getIndexRowKey(Long.MAX_VALUE);
+  }
+
+  /**
+   * Get the most recent value for each column group, less than the specified timestamps, in the
+   * order of the columns stored in the group and then build them into a single byte array to use as
+   * the row key for an index update for the column group.
+   * @param timestamp timestamp at which to extract the state of the current row. No
+   *          {@link KeyValue} for the row newer than the timestamp is included (so inclusive up to
+   *          and including this time).
+   * @return the row key and the corresponding list of {@link CoveredColumn}s to the position of
+   *         their value in the row key
+   */
+  public Pair<byte[], List<CoveredColumn>> getIndexRowKey(long timestamp) {
+    int length = 0;
+    List<byte[]> topValues = new ArrayList<byte[]>();
+    // columns that match against values, as we find them
+    List<CoveredColumn> columns = new ArrayList<CoveredColumn>();
+
+    // filter out the for anything older than what we want
+    NewerTimestampFilter timestamps = new NewerTimestampFilter(timestamp);
+
+    // go through each group,in order, to find the matching value (or none)
+    for (CoveredColumn column : group) {
+      final byte[] family = Bytes.toBytes(column.family);
+      // filter families that aren't what we are looking for
+      FamilyOnlyFilter familyFilter = new FamilyOnlyFilter(new BinaryComparator(family));
+      // join the filters so we only include things that match both (correct family and the TS is
+      // older than the given ts)
+      Filter filter = new FilterList(timestamps, familyFilter);
+      KeyValueScanner scanner = new FilteredKeyValueScanner(filter, this.memstore);
+
+      /*
+       * now we have two possibilities. (1) the CoveredColumn has a specific column - this is the
+       * easier one, we can just seek down to that keyvalue and then pull the next one out. If there
+       * aren't any keys, we just inject a null value and point at the coveredcolumn, or (2) it
+       * includes all qualifiers - we need to match all column families, but only inject the null
+       * mapping if its the first key
+       */
+
+      // key to seek. We can only seek to the family because we may have a family delete on top that
+      // covers everything below it, which we would miss if we seek right to the family:qualifier
+      KeyValue first = KeyValue.createFirstOnRow(pk, Bytes.toBytes(column.family), null);
+      try {
+        // seek to right before the key in the scanner
+        byte[] value = EMPTY_BYTE_ARRAY;
+        // no values, so add a null against the entire CoveredColumn
+        if (!scanner.seek(first)) {
+          topValues.add(value);
+          columns.add(column);
+          continue;
+        }
+
+        byte[] prevCol = null;
+        // not null because seek() returned true
+        KeyValue next = scanner.next();
+        boolean done = false;
+        do {
+          byte[] qual = next.getQualifier();
+          boolean columnMatches = column.matchesQualifier(qual);
+
+          /*
+           * check delete to see if we can just replace this with a single delete if its a family
+           * delete then we have deleted all columns and are definitely done with this
+           * coveredcolumn. This works because deletes will always sort first, so we can be sure
+           * that if we see a delete, we can skip everything else.
+           */
+          if (next.isDeleteFamily()) {
+            // count it as a non-match for all rows, so we add a single null for the entire column
+            value = EMPTY_BYTE_ARRAY;
+            break;
+          } else if (columnMatches) {
+            // we are deleting a single column/kv
+            if (next.isDelete()) {
+              value = EMPTY_BYTE_ARRAY;
+            } else {
+              value = next.getValue();
+            }
+            done = true;
+            // we are covering a single column, then we are done.
+            if (column.allColumns()) {
+              /*
+               * we are matching all columns, so we need to make sure that this is a new qualifier.
+               * If its a new qualifier, then we want to add that value, but otherwise we can skip
+               * ahead to the next key.
+               */
+              if (prevCol == null || !Bytes.equals(prevCol, qual)) {
+                prevCol = qual;
+              } else {
+                continue;
+              }
+            }
+          }
+
+          // add the array to the list
+          length += value.length;
+          topValues.add(value);
+          columns.add(column);
+          // only go around again if there is more data and we are matching against all column
+        } while ((!done || column.allColumns()) && (next = scanner.next()) != null);
+
+        // we never found a match, so we need to add an empty entry
+        if (!done) {
+          length += value.length;
+          topValues.add(value);
+          columns.add(column);
+        }
+
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    byte[] key = CoveredColumnIndexCodec.composeRowKey(pk, length, topValues);
+    return new Pair<byte[], List<CoveredColumn>>(key, columns);
+  }
+
+  /**
+   * Create a {@link Put} to add to the index based on the state of the row at the given timestamp.
+   * Only the most recent version (up to the timestamp) is included for each column in the current
+   * {@link ColumnGroup}.
+   * <p>
+   * Add each {@link CoveredColumn} to a {@link Put} under a single column family. Each value stored
+   * in the key is matched to a column group - value 1 matches family:qualfier 1. This holds true
+   * even if the {@link CoveredColumn} matches all columns in the family.
+   * <p>
+   * Columns are added as:
+   * 
+   * <pre>
+   * &lt{@value CoveredColumnIndexCodec#INDEX_ROW_COLUMN_FAMILY}&gt | &lti&gt[covered column family]:[covered column qualifier] | &lttimestamp&gt | <tt>null</tt>
+   * </pre>
+   * 
+   * where "i" is the integer index matching the index of the value in the row key.
+   * @param timestamp time (up to and including) of the current row to extract.
+   * @return the put to add to the index table or <tt>null</tt> if no update is necessary
+   */
+  public Put getPutToIndex(long timestamp) {
+    Pair<byte[], List<CoveredColumn>> indexRow = this.getIndexRowKey();
+    byte[] rowKey = indexRow.getFirst();
+
+    // no update to the table, we are done
+    if (CoveredColumnIndexCodec.checkRowKeyForAllNulls(rowKey)) {
+      return null;
+    }
+    
+    Put indexInsert = new Put(indexRow.getFirst());
+    addColumnsToPut(indexInsert, indexRow, timestamp);
+    return indexInsert;
+  }
+
+  /**
+   * Add a {@link Mutation} to the values stored for the current row
+   * @param pendingUpdate update to apply
+   */
+  public void addUpdateForTesting(Mutation pendingUpdate) {
+    for (Map.Entry<byte[], List<KeyValue>> e : pendingUpdate.getFamilyMap().entrySet()) {
+      List<KeyValue> edits = e.getValue();
+      addAll(edits);
+    }
+  }
+
+  private static void addColumnsToPut(Put indexInsert, Pair<?, List<CoveredColumn>> columns,
+      long timestamp) {
+    // add each of the corresponding families to the put
+    int count = 0;
+    for (CoveredColumn column : columns.getSecond()) {
+      indexInsert.add(INDEX_ROW_COLUMN_FAMILY,
+        ArrayUtils.addAll(Bytes.toBytes(count++), toIndexQualifier(column)), timestamp, null);
+    }
+  }
+
+  private static byte[] toIndexQualifier(CoveredColumn column) {
+    return ArrayUtils.addAll(Bytes.toBytes(column.family + CoveredColumn.SEPARATOR),
+      column.qualifier);
+  }
+
+  /**
+   * Essentially a short-cut from building a {@link Put}.
+   * @param pk row key
+   * @param timestamp timestamp of all the keyvalues
+   * @param values expected value--column pair
+   * @return a keyvalues that the index contains for a given row at a timestamp with the given value
+   *         -- column pairs.
+   */
+  public static List<KeyValue> getIndexKeyValueForTesting(byte[] pk, long timestamp,
+      List<Pair<byte[], CoveredColumn>> values) {
+
+    int length = 0;
+    List<byte[]> firsts = new ArrayList<byte[]>(values.size());
+    List<CoveredColumn> columns = new ArrayList<CoveredColumn>(values.size());
+    for (Pair<byte[], CoveredColumn> value : values) {
+      firsts.add(value.getFirst());
+      length += value.getFirst().length;
+      columns.add(value.getSecond());
+    }
+
+    byte[] rowKey = composeRowKey(pk, length, firsts);
+    Put p = new Put(rowKey);
+    addColumnsToPut(p, new Pair<Void, List<CoveredColumn>>(null, columns), timestamp);
+    List<KeyValue> kvs = new ArrayList<KeyValue>();
+    for (Entry<byte[], List<KeyValue>> entry : p.getFamilyMap().entrySet()) {
+      kvs.addAll(entry.getValue());
+    }
+
+    return kvs;
+  }
+
+  /**
+   * Compose the final index row key.
+   * <p>
+   * This is faster than adding each value independently as we can just build a single a array and
+   * copy everything over once.
+   * @param pk primary key of the original row
+   * @param length total number of bytes of all the values that should be added
+   * @param values to use when building the key
+   * @return
+   */
+  static byte[] composeRowKey(byte[] pk, int length, List<byte[]> values) {
+    // now build up expected row key, each of the values, in order, followed by the PK and then some
+    // info about lengths so we can deserialize each value
+    byte[] output = new byte[length + pk.length];
+    int pos = 0;
+    int[] lengths = new int[values.size()];
+    int i = 0;
+    for (byte[] v : values) {
+      System.arraycopy(v, 0, output, pos, v.length);
+      lengths[i++] = v.length;
+      pos += v.length;
+    }
+  
+    // add the primary key to the end of the row key
+    System.arraycopy(pk, 0, output, pos, pk.length);
+  
+    // add the lengths as suffixes so we can deserialize the elements again
+    for (int l : lengths) {
+      output = ArrayUtils.addAll(output, Bytes.toBytes(l));
+    }
+  
+    // and the last integer is the number of values
+    return ArrayUtils.addAll(output, Bytes.toBytes(values.size()));
+  }
+
+  /**
+   * Get the values for each the columns that were stored in the row key from calls to
+   * {@link #getPutToIndex(long)}in the order they were stored.
+   * @param bytes bytes that were written by this codec
+   * @return the list of values for the columns
+   */
+  public static List<byte[]> getValues(byte[] bytes) {
+    // get the total number of keys in the bytes
+    int keyCount = CoveredColumnIndexCodec.getPreviousInteger(bytes, bytes.length);
+    List<byte[]> keys = new ArrayList<byte[]>(keyCount);
+    int[] lengths = new int[keyCount];
+    int lengthPos = keyCount - 1;
+    int pos = bytes.length - Bytes.SIZEOF_INT;
+    // figure out the length of each key
+    for (int i = 0; i < keyCount; i++) {
+      lengths[lengthPos--] = CoveredColumnIndexCodec.getPreviousInteger(bytes, pos);
+      pos -= Bytes.SIZEOF_INT;
+    }
+
+    int current = 0;
+    for (int length : lengths) {
+      byte[] key = Arrays.copyOfRange(bytes, current, current + length);
+      keys.add(key);
+      current += length;
+    }
+    
+    return keys;
+  }
+
+  /**
+   * Check to see if an row key just contains a list of null values.
+   * @param bytes row key to examine
+   * @return <tt>true</tt> if all the values are zero-length, <tt>false</tt> otherwise
+   */
+  public static boolean checkRowKeyForAllNulls(byte[] bytes) {
+    int keyCount = CoveredColumnIndexCodec.getPreviousInteger(bytes, bytes.length);
+    int pos = bytes.length - Bytes.SIZEOF_INT;
+    for (int i = 0; i < keyCount; i++) {
+      int next = CoveredColumnIndexCodec.getPreviousInteger(bytes, pos);
+      if (next > 0) {
+        return false;
+      }
+      pos -= Bytes.SIZEOF_INT;
+    }
+  
+    return true;
+  }
+
+  /**
+   * Read an integer from the preceding {@value Bytes#SIZEOF_INT} bytes
+   * @param bytes array to read from
+   * @param start start point, backwards from which to read. For example, if specifying "25", we
+   *          would try to read an integer from 21 -> 25
+   * @return an integer from the proceeding {@value Bytes#SIZEOF_INT} bytes, if it exists.
+   */
+  private static int getPreviousInteger(byte[] bytes, int start) {
+    return Bytes.toInt(bytes, start - Bytes.SIZEOF_INT);
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexSpecifierBuilder.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexSpecifierBuilder.java
@@ -1,0 +1,149 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HTableDescriptor;
+
+import com.salesforce.hbase.index.IndexUtil;
+
+/**
+ * Helper to build the configuration for the {@link CoveredColumnIndexer}.
+ * <p>
+ * This class is NOT thread-safe; all concurrent access must be managed externally.
+ */
+public class CoveredColumnIndexSpecifierBuilder {
+
+  private static final String INDEX_TO_TABLE_CONF_PREFX = "hbase.index.covered.";
+  // number of index 'groups'. Each group represents a set of 'joined' columns. The data stored with
+  // each joined column are either just the columns in the group or all the most recent data in the
+  // row (a fully covered index).
+  private static final String COUNT = ".count";
+  private static final String INDEX_GROUPS_COUNT_KEY = INDEX_TO_TABLE_CONF_PREFX + ".groups" + COUNT;
+  private static final String INDEX_GROUP_PREFIX = INDEX_TO_TABLE_CONF_PREFX + "group.";
+  private static final String INDEX_GROUP_COVERAGE_SUFFIX = ".columns";
+  private static final String TABLE_SUFFIX = ".table";
+
+  // right now, we don't support this should be easy enough to add later
+  // private static final String INDEX_GROUP_FULLY_COVERED = ".covered";
+
+  List<ColumnGroup> groups = new ArrayList<ColumnGroup>();
+
+  /**
+   * Add a group of columns to index
+   * @param columns Pairs of cf:cq (full specification of a column) to index
+   * @return the index of the group. This can be used to remove or modify the group via
+   *         {@link #remove(int)} or {@link #get(int)}, any time before building
+   */
+  public int addIndexGroup(ColumnGroup columns) {
+    if (columns == null || columns.size() == 0) {
+      throw new IllegalArgumentException("Must specify some columns to index!");
+    }
+    int size = this.groups.size();
+    this.groups.add(columns);
+    return size;
+  }
+
+  public void remove(int i) {
+    this.groups.remove(i);
+  }
+
+  public ColumnGroup get(int i) {
+    return this.groups.get(i);
+  }
+
+  /**
+   * Clear the stored {@link ColumnGroup}s for resuse.
+   */
+  public void reset() {
+    this.groups.clear();
+  }
+
+  Map<String, String> convertToMap() {
+    Map<String, String> specs = new HashMap<String, String>();
+    int total = this.groups.size();
+    // hbase.index.covered.groups = i
+    specs.put(INDEX_GROUPS_COUNT_KEY, Integer.toString(total));
+
+    int i = 0;
+    for (ColumnGroup group : groups) {
+      addIndexGroupToSpecs(specs, group, i++);
+    }
+
+    return specs;
+  }
+
+  /**
+   * @param specs
+   * @param columns
+   * @param index
+   */
+  private void addIndexGroupToSpecs(Map<String, String> specs, ColumnGroup columns, int index) {
+    // hbase.index.covered.group.<i>
+    String prefix = INDEX_GROUP_PREFIX + Integer.toString(index);
+
+    // set the table to which the group writes
+    // hbase.index.covered.group.<i>.table
+    specs.put(prefix + TABLE_SUFFIX, columns.getTable());
+    
+    // a different key for each column in the group
+    // hbase.index.covered.group.<i>.columns
+    String columnPrefix = prefix + INDEX_GROUP_COVERAGE_SUFFIX;
+    // hbase.index.covered.group.<i>.columns.count = <j>
+    String columnsSizeKey = columnPrefix + COUNT;
+    specs.put(columnsSizeKey, Integer.toString(columns.size()));
+    
+    // add each column in the group
+    int i=0; 
+    for (CoveredColumn column : columns) {
+      // hbase.index.covered.group.<i>.columns.<j>
+      String nextKey = columnPrefix + "." + Integer.toString(i);
+      String nextValue = column.serialize();
+      specs.put(nextKey, nextValue);
+      i++;
+    }
+  }
+
+  public void build(HTableDescriptor desc) throws IOException {
+    IndexUtil.enableIndexing(desc, CoveredColumnIndexer.class, this.convertToMap());
+  }
+
+  static List<ColumnGroup> getColumns(Configuration conf) {
+    int count= conf.getInt(INDEX_GROUPS_COUNT_KEY, 0);
+    if (count ==0) {
+      return Collections.emptyList();
+    }
+
+    // parse out all the column groups we should index
+    List<ColumnGroup> columns = new ArrayList<ColumnGroup>(count);
+    for (int i = 0; i < count; i++) {
+      // parse out each group
+      String prefix = INDEX_GROUP_PREFIX + i;
+
+      // hbase.index.covered.group.<i>.table
+      String table = conf.get(prefix + TABLE_SUFFIX);
+      ColumnGroup group = new ColumnGroup(table);
+
+      // parse out each column in the group
+      // hbase.index.covered.group.<i>.columns
+      String columnPrefix = prefix + INDEX_GROUP_COVERAGE_SUFFIX;
+      // hbase.index.covered.group.<i>.columns.count = j
+      String columnsSizeKey = columnPrefix + COUNT;
+      int columnCount = conf.getInt(columnsSizeKey, 0);
+      for(int j=0; j< columnCount; j++){
+        String columnKey = columnPrefix + "." + j;
+        CoveredColumn column = CoveredColumn.parse(conf.get(columnKey));
+        group.add(column);
+      }
+
+      // add the group
+      columns.add(group);
+    }
+    return columns;
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexer.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/CoveredColumnIndexer.java
@@ -1,0 +1,369 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+
+import com.google.common.collect.Ordering;
+import com.google.common.collect.TreeMultimap;
+import com.salesforce.hbase.index.builder.BaseIndexBuilder;
+
+/**
+ * Index maintainer that maintains multiple indexes based on '{@link ColumnGroup}s'. Each group is a
+ * fully covered within itself and stores the fully 'pre-joined' version of that values for that
+ * group of columns.
+ * <p>
+ * <h2>Index Layout</h2> The row key for a given index entry is the current state of the all the
+ * values of the columns in a column group, followed by the primary key (row key) of the original
+ * row, and then the length of each value and then finally the total number of values. This is then
+ * enough information to completely rebuild the latest value of row for each column in the group.
+ * <p>
+ * The family is always {@link CoveredColumnIndexCodec#INDEX_ROW_COLUMN_FAMILY}
+ * <p>
+ * The qualifier is prepended with the integer index (serialized with {@link Bytes#toBytes(int)}) of
+ * the column in the group. This index corresponds the index of the value for the group in the row
+ * key.
+ * 
+ * <pre>
+ *         ROW                            ||   FAMILY     ||    QUALIFIER     ||   VALUE
+ * (v1)(v2)...(vN)(pk)(L1)(L2)...(Ln)(#V) || INDEX_FAMILY ||     1Cf1:Cq1     ||  null
+ * (v1)(v2)...(vN)(pk)(L1)(L2)...(Ln)(#V) || INDEX_FAMILY ||     2Cf2:Cq2     ||  null
+ * ...
+ * (v1)(v2)...(vN)(pk)(L1)(L2)...(Ln)(#V) || INDEX_FAMILY ||     NCfN:CqN     ||  null
+ * </pre>
+ * 
+ * <h2>Index Maintenance</h2>
+ * <p>
+ * When making an insertion into the table, we also attempt to cleanup the index. This means that we
+ * need to remove the previous entry from the index. Generally, this is completed by inserting a
+ * delete at the previous value of the previous row.
+ * <p>
+ * The main caveat here is when dealing with custom timestamps. If there is no special timestamp
+ * specified, we can just insert the proper {@link Delete} at the current timestamp and move on.
+ * However, when the client specifies a timestamp, we could see updates out of order. In that case,
+ * we can do an insert using the specified timestamp, but a delete is different...
+ * <p>
+ * Taking the simple case, assume we do a single column in a group. Then if we get an out of order
+ * update, we need to check the current state of that column in the current row. If the current row
+ * is older, we can issue a delete as normal. If the current row is newer, however, we then have to
+ * issue a delete for the index update at the time of the current row. This ensures that the index
+ * update made for the 'future' time still covers the existing row.
+ * <p>
+ * <b>ASSUMPTION:</b> all key-values in a single {@link Delete}/{@link Put} have the same timestamp.
+ * This dramatically simplifies the logic needed to manage updating the index for out-of-order
+ * {@link Put}s as we don't need to manage multiple levels of timestamps across multiple columns.
+ * <p>
+ * We can extend this to multiple columns by picking the latest update of any column in group as the
+ * delete point.
+ * <p>
+ * <b>NOTE:</b> this means that we need to do a lookup (point {@link Get}) of the entire row
+ * <i>every time there is a write to the table</i>.
+ */
+public class CoveredColumnIndexer extends BaseIndexBuilder {
+
+  private static final Log LOG = LogFactory.getLog(CoveredColumnIndexer.class);
+
+  /** Empty put that has no information - used to build index delete markers */
+
+  /**
+   * Create the specified index table with the necessary columns
+   * @param admin {@link HBaseAdmin} to use when creating the table
+   * @param indexTable name of the index table.
+   * @throws IOException
+   */
+  public static void createIndexTable(HBaseAdmin admin, String indexTable) throws IOException {
+    HTableDescriptor index = new HTableDescriptor(indexTable);
+    HColumnDescriptor col = new HColumnDescriptor(CoveredColumnIndexCodec.INDEX_ROW_COLUMN_FAMILY);
+    // ensure that we can 'see past' delete markers when doing scans
+    col.setKeepDeletedCells(true);
+    index.addFamily(col);
+    admin.createTable(index);
+  }
+
+  private volatile HTableInterface localTable;
+  private List<ColumnGroup> groups;
+  private RegionCoprocessorEnvironment env;
+
+  @Override
+  public void setup(RegionCoprocessorEnvironment env) throws IOException {
+    groups = CoveredColumnIndexSpecifierBuilder.getColumns(env.getConfiguration());
+    this.env = env;
+  }
+
+  // TODO we loop through all the keyvalues for the row a few times - we should be able to do better
+
+  /**
+   * Ensure we have a connection to the local table. We need to do this after
+   * {@link #setup(RegionCoprocessorEnvironment)} because we are created on region startup and the
+   * table isn't actually accessible until later.
+   * @throws IOException if we can't reach the table
+   */
+  private void ensureLocalTable() throws IOException {
+    if (this.localTable == null) {
+      synchronized (this) {
+        if (this.localTable == null) {
+          localTable = env.getTable(env.getRegion().getTableDesc().getName());
+        }
+      }
+    }
+  }
+
+  @Override
+  public Map<Mutation, String> getIndexUpdate(Put p) throws IOException {
+    // if not columns to index, we are done
+    if (groups == null || groups.size() == 0) {
+      return Collections.emptyMap();
+    }
+
+    ensureLocalTable();
+
+    // get the current state of the row in our table. We will always need to do this to cleanup the
+    // index, so we might as well do this up front
+    final byte[] sourceRow = p.getRow();
+    Result r = localTable.get(new Get(sourceRow));
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Updating index for row: " + Bytes.toString(sourceRow));
+    }
+
+    // we need to check each key-value in the update to see if it matches the others. Generally,
+    // this will be the case, but you can add kvs to a mutation that don't all have the timestamp,
+    // so we need to manage everything in batches based on timestamp.
+    TreeMultimap<Long, KeyValue> timestampMap = createTimestampBatchesFromFamilyMap(p);
+
+    // build the index updates for each group
+    Map<Mutation, String> updateMap = new HashMap<Mutation, String>();
+    Collection<ColumnGroup> matches = findMatchingGroups(p);
+
+    // we can use a single codec for everything, as long as we apply the updates in timestamp order
+    CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(sourceRow, r);
+
+    // go through each batch of keyvalues and build separate index entries for each
+    for (Entry<Long, Collection<KeyValue>> batch : timestampMap.asMap().entrySet()) {
+      /*
+       * We have to split the work between the cleanup and the update for each group because when we
+       * update the current state of the row for the current batch (appending the mutations for the
+       * current batch) the next group will see that as the current state, which will can cause the
+       * a delete and a put to be created for the next group.
+       */
+      addMutationsForBatch(updateMap, batch, matches, codec);
+    }
+
+    return updateMap;
+  }
+
+  @Override
+  public Map<Mutation, String> getIndexUpdate(Delete d) throws IOException {
+    // if not columns to index, we are done
+    if (groups == null || groups.size() == 0) {
+      return Collections.emptyMap();
+    }
+
+    ensureLocalTable();
+
+    // stores all the return values
+    Map<Mutation, String> updateMap = new HashMap<Mutation, String>();
+
+    // get the current state of the row in our table. We will always need to do this to cleanup the
+    // index, so we might as well do this up front
+    final byte[] sourceRow = d.getRow();
+    Result r = localTable.get(new Get(sourceRow));
+
+    // We have to figure out which kind of delete it is, since we need to do different things if its
+    // a general (row) delete, versus a delete of just a single column or family
+    Map<byte[], List<KeyValue>> families = d.getFamilyMap();
+
+    // Option 1: its a row delete marker, so we just need to delete the most recent state for each
+    // group, as of the specified timestamp in the delete
+    if (families.size() == 0) {
+      // get a consistent view of name
+      long now = d.getTimeStamp();
+      if (now == HConstants.LATEST_TIMESTAMP) {
+        now = EnvironmentEdgeManager.currentTimeMillis();
+        // update the delete's idea of 'now' to be consistent with the index
+        d.setTimestamp(now);
+      }
+
+      // insert a delete for each group since the delete will cover all columns
+      for (ColumnGroup group : groups) {
+        CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(sourceRow, r, group);
+        byte[] row = codec.getIndexRowKey(now).getFirst();
+        Delete indexUpdate = new Delete(row);
+        indexUpdate.setTimestamp(now);
+        updateMap.put(indexUpdate, group.getTable());
+      }
+
+      return updateMap;
+    }
+
+    // Option 2: Its actually a bunch single updaets, which can have different timestamps.
+    // Therefore, we need to do something similar to the put case and batch by timestamp
+    TreeMultimap<Long, KeyValue> batches = createTimestampBatchesFromFamilyMap(d);
+
+    // check the map to see if we are affecting any of the groups
+    Collection<ColumnGroup> matches = findMatchingGroups(d);
+
+    // build up the index entries for each group
+    CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(sourceRow, r);
+    for (Entry<Long, Collection<KeyValue>> batch : batches.asMap().entrySet()) {
+      addMutationsForBatch(updateMap, batch, matches, codec);
+    }
+    return updateMap;
+  }
+
+  /**
+   * Batch all the {@link KeyValue}s in a {@link Mutation} by timestamp. Updates any
+   * {@link KeyValue} with a timestamp == {@link HConstants#LATEST_TIMESTAMP} to a single value
+   * obtained when the method is called.
+   * @param m {@link Mutation} from which to extract the {@link KeyValue}s
+   * @return map of timestamp to all the keyvalues with the same timestamp. the implict tree sorting
+   *         in the returned ensures that batches (when iterating through the keys) will iterate the
+   *         kvs in timestamp order
+   */
+  private TreeMultimap<Long, KeyValue> createTimestampBatchesFromFamilyMap(Mutation m) {
+    long now = EnvironmentEdgeManager.currentTimeMillis();
+    byte[] nowBytes = Bytes.toBytes(now);
+    TreeMultimap<Long, KeyValue> batches =
+        TreeMultimap.create(Ordering.natural(), KeyValue.COMPARATOR);
+    for (List<KeyValue> kvs : m.getFamilyMap().values()) {
+      for (KeyValue kv : kvs) {
+        long ts = kv.getTimestamp();
+        // override the timestamp to the current time, so the index and primary tables match
+        // all the keys with LATEST_TIMESTAMP will then be put into the same batch
+        if (ts == HConstants.LATEST_TIMESTAMP) {
+          kv.updateLatestStamp(nowBytes);
+        }
+        batches.put(kv.getTimestamp(), kv);
+      }
+    }
+    return batches;
+  }
+
+  /**
+   * Find all the {@link ColumnGroup}s that match this {@link Mutation} to the primary table.
+   * @param m mutation to match against
+   * @return the {@link ColumnGroup}s that should be updated with this {@link Mutation}.
+   */
+  private Collection<ColumnGroup> findMatchingGroups(Mutation m) {
+    // just using pointer hashes here - we don't need to calculate actual equality, just that we
+    // don't get dupes
+    Set<ColumnGroup> matches = new HashSet<ColumnGroup>();
+    for (Entry<byte[], List<KeyValue>> entry : m.getFamilyMap().entrySet()) {
+      // early exit if we already know we need to match all the groups
+      if (matches.size() == this.groups.size()) {
+        return matches;
+      }
+
+      // get the keys for this family that we are indexing
+      List<KeyValue> kvs = entry.getValue();
+      if (kvs == null || kvs.isEmpty()) {
+        // should never be the case, but just to be careful
+        continue;
+      }
+
+      // figure out the groups we need to index
+      String family = Bytes.toString(entry.getKey());
+      for (ColumnGroup column : groups) {
+        if (column.matches(family)) {
+          matches.add(column);
+        }
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * @param updateMap
+   * @param batch
+   */
+  private void addMutationsForBatch(Map<Mutation, String> updateMap,
+      Entry<Long, Collection<KeyValue>> batch, Collection<ColumnGroup> matches,
+      CoveredColumnIndexCodec codec) {
+    /*
+     * Generally, the current Put will be the most recent thing to be added. In that case, all we
+     * need to is issue a delete for the previous index row (the state of the row, without the put
+     * applied) at the Put's current timestamp. This gets rid of anything currently in the index for
+     * the current state of the row (at the timestamp). If things arrive out of order (we are using
+     * custom timestamps) we should always still only see the most recent update in the index, even
+     * if we are making a put back in time (out of order). Therefore, we need to issue a delete for
+     * the index update but at the next most recent timestam; using batches helps, but we still need
+     * to do this iteratively since we need to cleanup the current state first as it could be
+     * overwritten by a key-value at the same timestamp
+     */
+
+    long ts = batch.getKey();
+    // start by getting the cleanup for the current state of the
+    for (ColumnGroup group : matches) {
+      codec.setGroup(group);
+      Delete cleanup = getIndexCleanupForCurrentRow(codec, ts);
+      String table = group.getTable();
+      if (cleanup != null) {
+        updateMap.put(cleanup, table);
+      }
+
+    }
+
+    // add the current batch to the map
+    codec.addAll(batch.getValue());
+
+    // get the updates to the current index
+    for (ColumnGroup group : matches) {
+      codec.setGroup(group);
+      String table = group.getTable();
+      Put indexInsert = codec.getPutToIndex(ts);
+      if (indexInsert != null) {
+        updateMap.put(indexInsert, table);
+      }
+    }
+  }
+
+  /**
+   * Make a delete for the state of the current row, at the given timestamp.
+   * @param codec to form the row key
+   * @param timestamp
+   * @return the delete to apply or <tt>null</tt>, if no {@link Delete} is necessary
+   */
+  private Delete getIndexCleanupForCurrentRow(CoveredColumnIndexCodec codec, long timestamp) {
+    byte[] currentRowkey = codec.getIndexRowKey(timestamp).getFirst();
+    // no previous state for the current group, so don't create a delete
+    if (CoveredColumnIndexCodec.checkRowKeyForAllNulls(currentRowkey)) {
+      return null;
+    }
+
+    Delete cleanup = new Delete(currentRowkey);
+    cleanup.setTimestamp(timestamp);
+
+    return cleanup;
+  }
+
+  /**
+   * Exposed for testing! Set the local table that should be used to lookup the state of the current
+   * row.
+   * @param table
+   */
+  public void setTableForTesting(HTableInterface table) {
+    this.localTable = table;
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/FamilyOnlyFilter.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/FamilyOnlyFilter.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.hbase.index.builder.covered.util;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.FamilyFilter;
+import org.apache.hadoop.hbase.filter.WritableByteArrayComparable;
+
+/**
+ * Similar to the {@link FamilyFilter} but stops when the end of the family is reached and only
+ * supports equality
+ */
+public class FamilyOnlyFilter extends FamilyFilter {
+
+  boolean done = false;
+  private boolean previousMatchFound;
+
+  /**
+   * Filter on exact binary matches to the passed family
+   * @param family to compare against
+   */
+  public FamilyOnlyFilter(final byte[] family) {
+    this(new BinaryComparator(family));
+  }
+
+  public FamilyOnlyFilter(final WritableByteArrayComparable familyComparator) {
+    super(CompareOp.EQUAL, familyComparator);
+  }
+
+
+  @Override
+  public boolean filterAllRemaining() {
+    return done;
+  }
+
+  @Override
+  public void reset() {
+    done = false;
+    previousMatchFound = false;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(KeyValue v) {
+    if (done) {
+      return ReturnCode.SKIP;
+    }
+    ReturnCode code = super.filterKeyValue(v);
+    if (previousMatchFound) {
+      // we found a match before, and now we are skipping the key because of the family, therefore
+      // we are done (no more of the family).
+      if (code.equals(ReturnCode.SKIP)) {
+      done = true;
+      }
+    } else {
+      // if we haven't seen a match before, then it doesn't matter what we see now, except to mark
+      // if we've seen a match
+      if (code.equals(ReturnCode.INCLUDE)) {
+        previousMatchFound = true;
+      }
+    }
+    return code;
+  }
+
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/FilteredKeyValueScanner.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/FilteredKeyValueScanner.java
@@ -1,0 +1,132 @@
+package com.salesforce.hbase.index.builder.covered.util;
+
+import java.io.IOException;
+import java.util.SortedSet;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.Filter.ReturnCode;
+import org.apache.hadoop.hbase.regionserver.ExposedMemStore;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+
+/**
+ * Combine a simplified version of the logic in the ScanQueryMatcher and the KeyValueScanner. We can
+ * get away with this here because we are only concerned with a single {@link ExposedMemStore} for
+ * the index; we don't need to worry about multiple column families or minimizing seeking through
+ * file - we just want to iterate the kvs quickly, in-memory.
+ */
+public class FilteredKeyValueScanner implements KeyValueScanner {
+
+  private KeyValueScanner delegate;
+  private Filter filter;
+
+  public FilteredKeyValueScanner(Filter filter, ExposedMemStore store) {
+    this(filter, store.getScanners().get(0));
+  }
+
+  private FilteredKeyValueScanner(Filter filter, KeyValueScanner delegate) {
+    this.delegate = delegate;
+    this.filter = filter;
+  }
+
+  @Override
+  public KeyValue peek() {
+    return delegate.peek();
+  }
+
+  /**
+   * Same a {@link KeyValueScanner#next()} except that we filter out the next {@link KeyValue} until
+   * we find one that passes the filter.
+   * @return the next {@link KeyValue} or <tt>null</tt> if no next {@link KeyValue} is present and
+   *         passes all the filters.
+   */
+  @Override
+  public KeyValue next() throws IOException {
+    seekToNextUnfilteredKeyValue();
+    return delegate.next();
+  }
+
+  @Override
+  public boolean seek(KeyValue key) throws IOException {
+    if(filter.filterAllRemaining()){
+      return false;
+    }
+    // see if we can seek to the next key
+    if (!delegate.seek(key)) {
+      return false;
+    }
+
+    return seekToNextUnfilteredKeyValue();
+  }
+
+  private boolean seekToNextUnfilteredKeyValue() throws IOException {
+    while (true) {
+      KeyValue peeked = delegate.peek();
+      // no more key values, so we are done
+      if (peeked == null) {
+        return false;
+      }
+
+      // filter the peeked value to see if it should be served
+      ReturnCode code = filter.filterKeyValue(peeked);
+      switch (code) {
+      // included, so we are done
+      case INCLUDE:
+      case INCLUDE_AND_NEXT_COL:
+        return true;
+      // not included, so we need to go to th next row
+      case SKIP:
+      case NEXT_COL:
+      case NEXT_ROW:
+        delegate.next();
+        break;
+      // use a seek hint to find out where we should go
+      case SEEK_NEXT_USING_HINT:
+        delegate.seek(filter.getNextKeyHint(peeked));
+      }
+    }
+  }
+
+  @Override
+  public boolean reseek(KeyValue key) throws IOException {
+    this.delegate.reseek(key);
+    return this.seekToNextUnfilteredKeyValue();
+  }
+
+  @Override
+  public boolean requestSeek(KeyValue kv, boolean forward, boolean useBloom) throws IOException {
+    return this.reseek(kv);
+  }
+
+  @Override
+  public boolean isFileScanner() {
+    return false;
+  }
+
+  @Override
+  public long getSequenceID() {
+    return this.delegate.getSequenceID();
+  }
+
+  @Override
+  public boolean shouldUseScanner(Scan scan, SortedSet<byte[]> columns, long oldestUnexpiredTS) {
+    return this.delegate.shouldUseScanner(scan, columns, oldestUnexpiredTS);
+  }
+
+
+  @Override
+  public boolean realSeekDone() {
+    return this.delegate.realSeekDone();
+  }
+
+  @Override
+  public void enforceSeek() throws IOException {
+    this.delegate.enforceSeek();
+  }
+
+  @Override
+  public void close() {
+    this.delegate.close();
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/NewerTimestampFilter.java
+++ b/contrib/hbase-index/index-core/src/main/java/com/salesforce/hbase/index/builder/covered/util/NewerTimestampFilter.java
@@ -1,0 +1,37 @@
+package com.salesforce.hbase.index.builder.covered.util;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+/**
+ * Server-side only class used in the indexer to filter out keyvalues newer than a given timestamp
+ * (so allows anything <code><=</code> timestamp through).
+ * <p>
+ * Note,<tt>this</tt> doesn't support {@link #write(DataOutput)} or {@link #readFields(DataInput)}.
+ */
+public class NewerTimestampFilter extends FilterBase {
+
+  private long timestamp;
+
+  public NewerTimestampFilter(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(KeyValue ignored) {
+    return ignored.getTimestamp() > timestamp ? ReturnCode.SKIP : ReturnCode.INCLUDE;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    throw new UnsupportedOperationException("TimestampFilter is server-side only!");
+  }
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    throw new UnsupportedOperationException("TimestampFilter is server-side only!");
+  }
+}

--- a/contrib/hbase-index/index-core/src/main/java/org/apache/hadoop/hbase/regionserver/ExposedMemStore.java
+++ b/contrib/hbase-index/index-core/src/main/java/org/apache/hadoop/hbase/regionserver/ExposedMemStore.java
@@ -1,0 +1,84 @@
+package org.apache.hadoop.hbase.regionserver;
+
+import java.rmi.UnexpectedException;
+import java.util.List;
+import java.util.SortedSet;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValue.KVComparator;
+
+/**
+ * A {@link MemStore} that exposes all the package-protected methods.
+ * <p>
+ * If used improperly, this class can completely hose the memstore - its only for expert usage.
+ * <p>
+ * @see MemStore
+ */
+public class ExposedMemStore extends MemStore {
+
+  public ExposedMemStore(Configuration conf, KVComparator comparator) {
+    super(conf, comparator);
+  }
+
+  @Override
+  public void dump() {
+    super.dump();
+  }
+
+  @Override
+  void snapshot() {
+    super.snapshot();
+  }
+
+  @Override
+  public KeyValueSkipListSet getSnapshot() {
+    return super.getSnapshot();
+  }
+
+  @Override
+  public void clearSnapshot(SortedSet<KeyValue> ss) throws UnexpectedException {
+    super.clearSnapshot(ss);
+  }
+
+
+  @Override
+  public long add(KeyValue kv) {
+    return super.add(kv);
+  }
+
+  @Override
+  public void rollback(KeyValue kv) {
+    super.rollback(kv);
+  }
+
+  /**
+   * Use {@link #add(KeyValue)} instead! This method is not used in the usual HBase codepaths for
+   * adding deletes
+   */
+  @Override
+  public long delete(KeyValue delete) {
+    return super.delete(delete);
+  }
+
+  @Override
+  public KeyValue getNextRow(KeyValue kv) {
+    return getNextRow(kv);
+  }
+
+  @Override
+  void getRowKeyAtOrBefore(GetClosestRowBeforeTracker state) {
+    super.getRowKeyAtOrBefore(state);
+  }
+
+  @Override
+  public List<KeyValueScanner> getScanners() {
+    return super.getScanners();
+  }
+
+  @Override
+  public long heapSizeChange(KeyValue kv, boolean notpresent) {
+    return super.heapSizeChange(kv, notpresent);
+  }
+
+}

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/TestFailForUnsupportedHBaseVersions.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/TestFailForUnsupportedHBaseVersions.java
@@ -3,7 +3,6 @@ package com.salesforce.hbase.index;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestCoveredColumnIndexCodec.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestCoveredColumnIndexCodec.java
@@ -1,0 +1,269 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class TestCoveredColumnIndexCodec {
+  private static final byte[] PK = new byte[] { 'a' };
+  private static final String FAMILY_STRING = "family";
+  private static final byte[] FAMILY = Bytes.toBytes(FAMILY_STRING);
+  private static final byte[] QUAL = Bytes.toBytes("qual");
+
+  @Test
+  public void toFromIndexKey() throws Exception {
+    // start with empty values
+    byte[] indexKey = CoveredColumnIndexCodec
+        .composeRowKey(PK, 0, Collections.<byte[]> emptyList());
+    List<byte[]> stored = CoveredColumnIndexCodec.getValues(indexKey);
+    assertEquals("Found some stored values in an index row key that wasn't created with values!",
+      0, stored.size());
+
+    // a single, empty value
+    indexKey = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    stored = CoveredColumnIndexCodec.getValues(indexKey);
+    assertEquals("Found some stored values in an index row key that wasn't created with values!",
+      1, stored.size());
+    assertEquals("Found a non-zero length value: " + Bytes.toString(stored.get(0)), 0,
+      stored.get(0).length);
+
+    // try with a couple values, some different lengthss
+    byte[] v1 = new byte[] { 'a' };
+    byte[] v2 = new byte[] { 'b' };
+    byte[] v3 = Bytes.toBytes("v3");
+    int len = v1.length + v2.length + v3.length;
+    indexKey = CoveredColumnIndexCodec.composeRowKey(PK, len, Arrays.asList(v1, v2, v3));
+    stored = CoveredColumnIndexCodec.getValues(indexKey);
+    assertEquals("Didn't find expected number of values in index key!", 3, stored.size());
+    assertTrue("First index keys don't match!", Bytes.equals(v1, stored.get(0)));
+    assertTrue("Second index keys don't match!", Bytes.equals(v2, stored.get(1)));
+    assertTrue("Third index keys don't match!", Bytes.equals(v3, stored.get(2)));
+  }
+
+  /**
+   * If the Result has a <tt>null</tt> backing {@link KeyValue} list, you could possibly get a
+   * {@link NullPointerException}.
+   */
+  @Test
+  public void testWorksWithEmptyResult() {
+    ColumnGroup group = new ColumnGroup("group");
+    CoveredColumn column = new CoveredColumn(FAMILY_STRING, QUAL);
+    group.add(column);
+    Result r = new Result();
+    new CoveredColumnIndexCodec(r, group);
+  }
+
+  @Test
+  public void testFullColumnSpecification() {
+    ColumnGroup group = new ColumnGroup("testFullColumnSpecification");
+    CoveredColumn column = new CoveredColumn(FAMILY_STRING, QUAL);
+    group.add(column);
+
+    // setup the kvs to add
+    List<KeyValue> kvs = new ArrayList<KeyValue>();
+    byte[] v1 = Bytes.toBytes("v1");
+    KeyValue kv = new KeyValue(PK, FAMILY, QUAL, 1, v1);
+    kvs.add(kv);
+    byte[] v2 = Bytes.toBytes("v2");
+    kv = new KeyValue(PK, Bytes.toBytes("family2"), QUAL, 1, v2);
+    kvs.add(kv);
+    Result r = new Result(kvs);
+
+    // make a new codec on those kvs
+    CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(r, group);
+
+    // simple case - no deletes
+    byte[] indexValue = codec.getIndexRowKey().getFirst();
+    byte[] expected = CoveredColumnIndexCodec.composeRowKey(PK, v1.length, Arrays.asList(v1));
+    assertArrayEquals("Didn't get expected index value", expected, indexValue);
+
+    // now add a delete that covers that column family
+    Delete d = new Delete(PK);
+    d.deleteFamily(FAMILY);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try with a full column delete
+    d = new Delete(PK);
+    d.deleteColumns(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try by deleting the single value
+    d = new Delete(PK);
+    d.deleteColumn(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+  }
+
+  /**
+   * Test where we match against all the qualifiers in a single column family with a single stored
+   * famility:qualifier that matches. This is the simpler case to
+   * {@link #testFullyCoveredFamilyWithMultipleStoredColumns()}.
+   */
+  @Test
+  public void testFullyCoveredFamilyWithSingleStoredColumn() {
+    ColumnGroup group = new ColumnGroup("testOnlySpecifyFamilyWithSingleStoredColumn");
+    CoveredColumn column = new CoveredColumn(FAMILY_STRING, null);
+    group.add(column);
+
+    // setup the underlying data
+    List<KeyValue> kvs = new ArrayList<KeyValue>();
+    byte[] v1 = Bytes.toBytes("v1");
+    KeyValue kv = new KeyValue(PK, FAMILY, QUAL, 1, v1);
+    kvs.add(kv);
+    byte[] v2 = Bytes.toBytes("v2");
+    kv = new KeyValue(PK, Bytes.toBytes("family2"), QUAL, 1, v2);
+    kvs.add(kv);
+    kvs.add(kv);
+    Result r = new Result(kvs);
+
+    // setup the codec on those kvs
+    CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(r, group);
+
+    // simple case - no deletes, all columns
+    byte[] indexValue = codec.getIndexRowKey().getFirst();
+    byte[] expected = CoveredColumnIndexCodec.composeRowKey(PK, v1.length, Arrays.asList(v1));
+    assertArrayEquals("Didn't get expected index value", expected, indexValue);
+
+    // now add a delete that covers that entire column family
+    Delete d = new Delete(PK);
+    d.deleteFamily(FAMILY);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try deleting one of the columns
+    d = new Delete(PK);
+    d.deleteColumns(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try by deleting the single value
+    d = new Delete(PK);
+    d.deleteColumn(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+  }
+
+  @Test
+  public void testFullyCoveredFamilyWithMultipleStoredColumns() {
+    ColumnGroup group = new ColumnGroup("testOnlySpecifyFamilyWithMultipleStoredColumns");
+    CoveredColumn column = new CoveredColumn(FAMILY_STRING, null);
+    group.add(column);
+
+    List<KeyValue> kvs = new ArrayList<KeyValue>();
+    byte[] v1 = Bytes.toBytes("v1");
+    KeyValue kv = new KeyValue(PK, FAMILY, QUAL, 1, v1);
+    kvs.add(kv);
+    byte[] v2 = Bytes.toBytes("v2");
+    kv = new KeyValue(PK, Bytes.toBytes("family2"), QUAL, 1, v2);
+    kvs.add(kv);
+    // add another value for a different column in the indexed family
+    byte[] v3 = Bytes.toBytes("v3");
+    kv = new KeyValue(PK, FAMILY, Bytes.toBytes("qual2"), 1, v3);
+    kvs.add(kv);
+    Result r = new Result(kvs);
+
+    // setup the codec on those kvs
+    CoveredColumnIndexCodec codec = new CoveredColumnIndexCodec(r, group);
+
+    // simple case - no deletes, all columns
+    byte[] indexValue = codec.getIndexRowKey().getFirst();
+    byte[] expected = CoveredColumnIndexCodec.composeRowKey(PK, v1.length + v3.length,
+      Arrays.asList(v1, v3));
+    assertArrayEquals("Didn't get expected index value", expected, indexValue);
+
+    // now add a delete that covers that entire column family
+    Delete d = new Delete(PK);
+    d.deleteFamily(FAMILY);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, 0, Lists.newArrayList(new byte[0]));
+    assertArrayEquals("Deleting family didn't specify null value as expected", expected, indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try deleting one of the columns
+    d = new Delete(PK);
+    d.deleteColumns(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, v3.length,
+      Lists.newArrayList(new byte[0], v3));
+    assertArrayEquals("Deleting columns didn't specify null value as expected", expected,
+      indexValue);
+
+    // reset the codec
+    codec = new CoveredColumnIndexCodec(r, group);
+
+    // now try by deleting the single value
+    d = new Delete(PK);
+    d.deleteColumn(FAMILY, QUAL);
+    codec.addUpdateForTesting(d);
+    indexValue = codec.getIndexRowKey().getFirst();
+    expected = CoveredColumnIndexCodec.composeRowKey(PK, v3.length,
+      Lists.newArrayList(new byte[0], v3));
+    assertArrayEquals("Deleting col:qual didn't specify null value as expected", expected,
+      indexValue);
+  }
+
+  @Test
+  public void testCheckRowKeyForAllNulls() {
+    byte[] pk = new byte[] { 'a', 'b', 'z' };
+    // check positive cases first
+    byte[] result = CoveredColumnIndexCodec.composeRowKey(pk, 0, Arrays.asList(new byte[0]));
+    assertTrue("Didn't correctly read single element as being null in row key",
+      CoveredColumnIndexCodec.checkRowKeyForAllNulls(result));
+    result = CoveredColumnIndexCodec.composeRowKey(pk, 0, Arrays.asList(new byte[0], new byte[0]));
+    assertTrue("Didn't correctly read two elements as being null in row key",
+      CoveredColumnIndexCodec.checkRowKeyForAllNulls(result));
+
+    // check cases where it isn't null
+    result = CoveredColumnIndexCodec.composeRowKey(pk, 2, Arrays.asList(new byte[] { 1, 2 }));
+    assertFalse("Found a null key, when it wasn't!",
+      CoveredColumnIndexCodec.checkRowKeyForAllNulls(result));
+    result = CoveredColumnIndexCodec.composeRowKey(pk, 2,
+      Arrays.asList(new byte[] { 1, 2 }, new byte[0]));
+    assertFalse("Found a null key, when it wasn't!",
+      CoveredColumnIndexCodec.checkRowKeyForAllNulls(result));
+  }
+}

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestCoveredIndexSpecifierBuilder.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestCoveredIndexSpecifierBuilder.java
@@ -1,0 +1,55 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+public class TestCoveredIndexSpecifierBuilder {
+  private static final String FAMILY = "FAMILY";
+  private static final String FAMILY2 = "FAMILY2";
+  private static final String INDEX_TABLE = "INDEX_TABLE";
+  private static final String INDEX_TABLE2 = "INDEX_TABLE2";
+
+
+  @Test
+  public void testSimpleSerialziationDeserialization() throws Exception {
+    byte[] indexed_qualifer = Bytes.toBytes("indexed_qual");
+
+    //setup the index 
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    ColumnGroup fam1 = new ColumnGroup(INDEX_TABLE);
+    // match a single family:qualifier pair
+    CoveredColumn col1 = new CoveredColumn(FAMILY, indexed_qualifer);
+    fam1.add(col1);
+    // matches the family2:* columns
+    CoveredColumn col2 = new CoveredColumn(FAMILY2, null);
+    fam1.add(col2);
+    builder.addIndexGroup(fam1);
+    ColumnGroup fam2 = new ColumnGroup(INDEX_TABLE2);
+    // match a single family2:qualifier pair
+    CoveredColumn col3 = new CoveredColumn(FAMILY2, indexed_qualifer);
+    fam2.add(col3);
+    builder.addIndexGroup(fam2);
+    
+    Configuration conf = new Configuration(false);
+    //convert the map that HTableDescriptor gets into the conf the coprocessor receives
+    Map<String, String> map = builder.convertToMap();
+    for(Entry<String, String> entry: map.entrySet()){
+      conf.set(entry.getKey(), entry.getValue());
+    }
+
+    List<ColumnGroup> columns = CoveredColumnIndexSpecifierBuilder.getColumns(conf);
+    assertEquals("Didn't deserialize the expected number of column groups", 2, columns.size());
+    ColumnGroup group = columns.get(0);
+    assertEquals("Didn't deserialize expected column in first group", col1, group.getColumnForTesting(0));
+    assertEquals("Didn't deserialize expected column in first group", col2, group.getColumnForTesting(1));
+    group = columns.get(1);
+    assertEquals("Didn't deserialize expected column in second group", col3, group.getColumnForTesting(0));
+  }
+}

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestEndToEndCoveredIndexing.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestEndToEndCoveredIndexing.java
@@ -1,0 +1,521 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test Covered Column indexing in an 'end-to-end' manner on a minicluster. This covers cases where
+ * we manage custom timestamped updates that arrive in and out of order as well as just using the
+ * generically timestamped updates.
+ */
+public class TestEndToEndCoveredIndexing {
+  private static final HBaseTestingUtility UTIL = new HBaseTestingUtility();
+  private static final String FAM_STRING = "FAMILY";
+  private static final byte[] FAM = Bytes.toBytes(FAM_STRING);
+  private static final String FAM2_STRING = "FAMILY2";
+  private static final byte[] FAM2 = Bytes.toBytes(FAM2_STRING);
+  private static final String INDEX_TABLE = "INDEX_TABLE";
+  private static final String INDEX_TABLE2 = "INDEX_TABLE2";
+  private static final byte[] EMPTY_BYTES = new byte[0];
+  private static final byte[] indexed_qualifer = Bytes.toBytes("indexed_qual");
+  private static final byte[] regular_qualifer = Bytes.toBytes("reg_qual");
+  private static final byte[] row1 = Bytes.toBytes("row1");
+  private static final byte[] value1 = Bytes.toBytes("val1");
+  private static final byte[] value2 = Bytes.toBytes("val2");
+  private static final byte[] value3 = Bytes.toBytes("val3");
+
+  // setup a couple of index columns
+  private static final ColumnGroup fam1 = new ColumnGroup(INDEX_TABLE);
+  private static final ColumnGroup fam2 = new ColumnGroup(INDEX_TABLE2);
+  // match a single family:qualifier pair
+  private static final CoveredColumn col1 = new CoveredColumn(FAM_STRING, indexed_qualifer);
+  // matches the family2:* columns
+  private static final CoveredColumn col2 = new CoveredColumn(FAM2_STRING, null);
+  private static final CoveredColumn col3 = new CoveredColumn(FAM2_STRING, indexed_qualifer);
+  static {
+    // values are [col1][col2_1]...[col2_n]
+    fam1.add(col1);
+    fam1.add(col2);
+    // value is [col2]
+    fam2.add(col3);
+  }
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    UTIL.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardownCluster() throws Exception {
+    UTIL.shutdownMiniCluster();
+  }
+
+  /**
+   * Test that a bunch of puts with a single timestamp across all the puts builds and inserts index
+   * entries as expected
+   * @throws Exception on failure
+   */
+  @Test
+  public void testSimpleTimestampedUpdates() throws Exception {
+    //setup the index 
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testSimpleTimestampedUpdates";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a put to the primary table
+    Put p = new Put(row1);
+    long ts = 10;
+    p.add(FAM, indexed_qualifer, ts, value1);
+    p.add(FAM, regular_qualifer, ts, value2);
+    primary.put(p);
+    primary.flushCommits();
+
+    // read the index for the expected values
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+
+    // build the expected kvs
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+    List<KeyValue> expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+
+    // verify that the index matches
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1);
+  }
+
+  /**
+   * Test that the multiple timestamps in a single put build the correct index updates.
+   * @throws Exception on failure
+   */
+  @Test
+  public void testMultipleTimestampsInSinglePut() throws Exception {
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testMultipleTimestampsInSinglePut";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a put to the primary table
+    Put p = new Put(row1);
+    long ts1 = 10;
+    long ts2 = 11;
+    p.add(FAM, indexed_qualifer, ts1, value1);
+    p.add(FAM, regular_qualifer, ts1, value2);
+    // our group indexes all columns in the this family, so any qualifier here is ok
+    p.add(FAM2, regular_qualifer, ts2, value3);
+    primary.put(p);
+    primary.flushCommits();
+
+    // read the index for the expected values
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+
+    // build the expected kvs
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+
+    // check the first entry at ts1
+    List<KeyValue> expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts1, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts1, value1);
+
+    // check the second entry at ts2
+    pairs.clear();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(value3, col2));
+    expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts2, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts2, value1);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1);
+  }
+
+  /**
+   * Test that we make updates to multiple {@link ColumnGroup}s across a single put/delete 
+   * @throws Exception on failure
+   */
+  @Test
+  public void testMultipleConcurrentGroupsUpdated() throws Exception {
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+    builder.addIndexGroup(fam2);
+
+    // setup the primary table
+    String indexedTableName = "testMultipleConcurrentGroupsUpdated";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE2);
+
+    // do a put to the primary table
+    Put p = new Put(row1);
+    long ts = 10;
+    p.add(FAM, indexed_qualifer, ts, value1);
+    p.add(FAM, regular_qualifer, ts, value2);
+    p.add(FAM2, indexed_qualifer, ts, value3);
+    primary.put(p);
+    primary.flushCommits();
+
+    // read the index for the expected values
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+    HTable index2 = new HTable(UTIL.getConfiguration(), INDEX_TABLE2);
+
+    // build the expected kvs
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(value3, col2));
+    List<KeyValue> expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // and check the second index as well
+    pairs.clear();
+    pairs.add(new Pair<byte[], CoveredColumn>(value3, col3));
+    expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+    verifyIndexTableAtTimestamp(index2, expected, ts, value3);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1, index2);
+  }
+
+  /**
+   * HBase has a 'fun' property wherein you can completely clobber an existing row if you make a
+   * {@link Put} at the exact same dimension (row, cf, cq, ts) as an existing row. The old row
+   * disappears and the new value (since the rest of the row is the same) completely subsumes it.
+   * This test ensures that we remove the old entry and put a new entry in its place.
+   * @throws Exception on failure
+   */
+  @Test
+  public void testOverwritingPutsCorrectlyGetIndexed() throws Exception {
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testMultipleTimestampsInSinglePut";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a put to the primary table
+    Put p = new Put(row1);
+    long ts = 10;
+    p.add(FAM, indexed_qualifer, ts, value1);
+    p.add(FAM, regular_qualifer, ts, value2);
+    primary.put(p);
+    primary.flushCommits();
+
+    // read the index for the expected values
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+
+    // build the expected kvs
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+
+    // check the first entry at ts
+    List<KeyValue> expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // now overwrite the put in the primary table with a new value
+    p = new Put(row1);
+    p.add(FAM, indexed_qualifer, ts, value3);
+    primary.put(p);
+    primary.flushCommits();
+
+    pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value3, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+
+    // check the first entry at ts
+    expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts, value3);
+    // and verify that a scan at the first entry returns nothing (ignore the updated row)
+    verifyIndexTableAtTimestamp(index1, Collections.<KeyValue> emptyList(), ts, value1, value2);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1);
+  }
+  
+  @Test
+  public void testSimpleDeletes() throws Exception {
+
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testSimpleDelete";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a simple Put
+    long ts = 10;
+    Put p = new Put(row1);
+    p.add(FAM, indexed_qualifer, ts, value1);
+    p.add(FAM, regular_qualifer, ts, value2);
+    primary.put(p);
+    primary.flushCommits();
+
+    Delete d = new Delete(row1);
+    primary.delete(d);
+
+    HTable index = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+    List<KeyValue> expected = Collections.<KeyValue> emptyList();
+    // scan over all time should cause the delete to be covered
+    verifyIndexTableAtTimestamp(index, expected, 0, Long.MAX_VALUE, value1,
+      HConstants.EMPTY_END_ROW);
+
+    // scan at the older timestamp should still show the older value
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+    expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts, pairs);
+    verifyIndexTableAtTimestamp(index, expected, ts, value1);
+
+    // cleanup
+    closeAndCleanupTables(index, primary);
+  }
+
+  /**
+   * If we don't have any updates to make to the index, we don't take a lock on the WAL. However, we
+   * need to make sure that we don't try to unlock the WAL on write time when we don't write
+   * anything, since that will cause an java.lang.IllegalMonitorStateException
+   * @throws Exception on failure
+   */
+  @Test
+  public void testDeletesWithoutPreviousState() throws Exception {
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testSimpleDelete";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a delete on the primary table (no data, so no index updates...hopefully).
+    long ts = 10;
+    Delete d = new Delete(row1);
+    primary.delete(d);
+
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+    List<KeyValue> expected = Collections.<KeyValue> emptyList();
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // a delete of a specific family/column should also not show any index updates
+    d = new Delete(row1);
+    d.deleteColumn(FAM, indexed_qualifer);
+    primary.delete(d);
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // also just a family marker should have the same effect
+    d = new Delete(row1);
+    d.deleteFamily(FAM);
+    primary.delete(d);
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // also just a family marker should have the same effect
+    d = new Delete(row1);
+    d.deleteColumns(FAM, indexed_qualifer);
+    primary.delete(d);
+    primary.flushCommits();
+    verifyIndexTableAtTimestamp(index1, expected, ts, value1);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1);
+  }
+
+  /**
+   * Similar to the {@link #testMultipleTimestampsInSinglePut()}, this check the same with deletes
+   * @throws Exception on failure
+   */
+  @Test
+  public void testMultipleTimestampsInSingleDelete() throws Exception {
+    // setup the index
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    builder.addIndexGroup(fam1);
+
+    // setup the primary table
+    String indexedTableName = "testMultipleTimestampsInSinglePut";
+    HTableDescriptor pTable = new HTableDescriptor(indexedTableName);
+    pTable.addFamily(new HColumnDescriptor(FAM));
+    pTable.addFamily(new HColumnDescriptor(FAM2));
+    builder.build(pTable);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    HTable primary = new HTable(UTIL.getConfiguration(), indexedTableName);
+
+    // create the index tables
+    CoveredColumnIndexer.createIndexTable(admin, INDEX_TABLE);
+
+    // do a put to the primary table
+    Put p = new Put(row1);
+    long ts1 = 10, ts2 = 11, ts3 = 12;
+    p.add(FAM, indexed_qualifer, ts1, value1);
+    p.add(FAM, regular_qualifer, ts1, value2);
+    // our group indexes all columns in the this family, so any qualifier here is ok
+    p.add(FAM2, regular_qualifer, ts2, value3);
+    primary.put(p);
+    primary.flushCommits();
+
+    // now build up a delete with a couple different timestamps
+    Delete d = new Delete(row1);
+    d.deleteColumn(FAM, indexed_qualifer, ts2);
+    d.deleteColumn(FAM2, regular_qualifer, ts3);
+    primary.delete(d);
+
+    // read the index for the expected values
+    HTable index1 = new HTable(UTIL.getConfiguration(), INDEX_TABLE);
+
+    // build the expected kvs
+    List<Pair<byte[], CoveredColumn>> pairs = new ArrayList<Pair<byte[], CoveredColumn>>();
+    pairs.add(new Pair<byte[], CoveredColumn>(value1, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col2));
+
+    // check the first entry at ts1
+    List<KeyValue> expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts1, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts1, value1);
+
+    // delete at ts2 changes what the put would insert
+    pairs.clear();
+    pairs.add(new Pair<byte[], CoveredColumn>(EMPTY_BYTES, col1));
+    pairs.add(new Pair<byte[], CoveredColumn>(value3, col2));
+    expected = CoveredColumnIndexCodec.getIndexKeyValueForTesting(row1, ts2, pairs);
+    verifyIndexTableAtTimestamp(index1, expected, ts2, value1);
+
+    // final delete clears out everything
+    expected = Collections.emptyList();
+    verifyIndexTableAtTimestamp(index1, expected, ts3, value1);
+
+    // cleanup
+    closeAndCleanupTables(primary, index1);
+  }
+
+  private void verifyIndexTableAtTimestamp(HTable index1, List<KeyValue> expected, long ts,
+      byte[] startKey) throws IOException {
+    verifyIndexTableAtTimestamp(index1, expected, ts, startKey, HConstants.EMPTY_END_ROW);
+  }
+
+  private void verifyIndexTableAtTimestamp(HTable index1, List<KeyValue> expected, long start,
+      byte[] startKey, byte[] endKey) throws IOException {
+    verifyIndexTableAtTimestamp(index1, expected, start, start + 1, startKey, endKey);
+  }
+
+  private void verifyIndexTableAtTimestamp(HTable index1, List<KeyValue> expected, long start,
+      long end,
+      byte[] startKey, byte[] endKey) throws IOException {
+    Scan s = new Scan(startKey, endKey);
+    s.setTimeRange(start, end);
+    // s.setRaw(true);
+    List<KeyValue> received = new ArrayList<KeyValue>();
+    ResultScanner scanner = index1.getScanner(s);
+    for (Result r : scanner) {
+      received.addAll(r.list());
+    }
+    scanner.close();
+    assertEquals("Didn't get the expected kvs from the index table!", expected, received);
+  }
+
+  private void closeAndCleanupTables(HTable... tables) throws IOException {
+    if (tables == null) {
+      return;
+    }
+
+    for (HTable table : tables) {
+      table.close();
+      UTIL.deleteTable(table.getTableName());
+    }
+  }
+}

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestFamilyOnlyFilter.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestFamilyOnlyFilter.java
@@ -1,0 +1,90 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.Filter.ReturnCode;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+import com.salesforce.hbase.index.builder.covered.util.FamilyOnlyFilter;
+
+/**
+ * Test that the family only filter only allows a single family through
+ */
+public class TestFamilyOnlyFilter {
+
+  byte[] row = new byte[] { 'a' };
+  byte[] qual = new byte[] { 'b' };
+  byte[] val = Bytes.toBytes("val");
+
+  @Test
+  public void testPassesFirstFamily() {
+    byte[] fam = Bytes.toBytes("fam");
+    byte[] fam2 = Bytes.toBytes("fam2");
+
+    FamilyOnlyFilter filter = new FamilyOnlyFilter(fam);
+
+    KeyValue kv = new KeyValue(row, fam, qual, 10, val);
+    ReturnCode code = filter.filterKeyValue(kv);
+    assertEquals("Didn't pass matching family!", ReturnCode.INCLUDE, code);
+
+    kv = new KeyValue(row, fam2, qual, 10, val);
+    code = filter.filterKeyValue(kv);
+    assertEquals("Didn't filter out non-matching family!", ReturnCode.SKIP, code);
+  }
+
+  @Test
+  public void testPassesTargetFamilyAsNonFirstFamily() {
+    byte[] fam = Bytes.toBytes("fam");
+    byte[] fam2 = Bytes.toBytes("fam2");
+    byte[] fam3 = Bytes.toBytes("way_after_family");
+
+    FamilyOnlyFilter filter = new FamilyOnlyFilter(fam2);
+
+    KeyValue kv = new KeyValue(row, fam, qual, 10, val);
+
+    ReturnCode code = filter.filterKeyValue(kv);
+    assertEquals("Didn't filter out non-matching family!", ReturnCode.SKIP, code);
+
+    kv = new KeyValue(row, fam2, qual, 10, val);
+    code = filter.filterKeyValue(kv);
+    assertEquals("Didn't pass matching family", ReturnCode.INCLUDE, code);
+
+    kv = new KeyValue(row, fam3, qual, 10, val);
+    code = filter.filterKeyValue(kv);
+    assertEquals("Didn't filter out non-matching family!", ReturnCode.SKIP, code);
+  }
+
+  @Test
+  public void testResetFilter() {
+    byte[] fam = Bytes.toBytes("fam");
+    byte[] fam2 = Bytes.toBytes("fam2");
+    byte[] fam3 = Bytes.toBytes("way_after_family");
+
+    FamilyOnlyFilter filter = new FamilyOnlyFilter(fam2);
+
+    KeyValue kv = new KeyValue(row, fam, qual, 10, val);
+
+    ReturnCode code = filter.filterKeyValue(kv);
+    assertEquals("Didn't filter out non-matching family!", ReturnCode.SKIP, code);
+
+    KeyValue accept = new KeyValue(row, fam2, qual, 10, val);
+    code = filter.filterKeyValue(accept);
+    assertEquals("Didn't pass matching family", ReturnCode.INCLUDE, code);
+
+    kv = new KeyValue(row, fam3, qual, 10, val);
+    code = filter.filterKeyValue(kv);
+    assertEquals("Didn't filter out non-matching family!", ReturnCode.SKIP, code);
+
+    // we shouldn't match the family again - everything after a switched family should be ignored
+    code = filter.filterKeyValue(accept);
+    assertEquals("Should have skipped a 'matching' family if it arrives out of order",
+      ReturnCode.SKIP, code);
+
+    // reset the filter and we should accept it again
+    filter.reset();
+    code = filter.filterKeyValue(accept);
+    assertEquals("Didn't pass matching family after reset", ReturnCode.INCLUDE, code);
+  }
+}

--- a/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestNewerTimestampFilter.java
+++ b/contrib/hbase-index/index-core/src/test/java/com/salesforce/hbase/index/builder/covered/TestNewerTimestampFilter.java
@@ -1,0 +1,32 @@
+package com.salesforce.hbase.index.builder.covered;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.filter.Filter.ReturnCode;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+import com.salesforce.hbase.index.builder.covered.util.NewerTimestampFilter;
+
+public class TestNewerTimestampFilter {
+  byte[] row = new byte[] { 'a' };
+  byte[] fam = Bytes.toBytes("family");
+  byte[] qual = new byte[] { 'b' };
+  byte[] val = Bytes.toBytes("val");
+
+  @Test
+  public void testOnlyAllowsOlderTimestamps() {
+    long ts = 100;
+    NewerTimestampFilter filter = new NewerTimestampFilter(ts);
+
+    KeyValue kv = new KeyValue(row, fam, qual, ts, val);
+    assertEquals("Didn't accept kv with matching ts", ReturnCode.INCLUDE, filter.filterKeyValue(kv));
+
+    kv = new KeyValue(row, fam, qual, ts + 1, val);
+    assertEquals("Didn't skip kv with greater ts", ReturnCode.SKIP, filter.filterKeyValue(kv));
+
+    kv = new KeyValue(row, fam, qual, ts - 1, val);
+    assertEquals("Didn't accept kv with lower ts", ReturnCode.INCLUDE, filter.filterKeyValue(kv));
+  }
+}

--- a/contrib/hbase-index/index-core/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALReplayWithIndexWrites.java
+++ b/contrib/hbase-index/index-core/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALReplayWithIndexWrites.java
@@ -13,7 +13,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -23,12 +22,10 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.coprocessor.RegionObserver;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionServerAccounting;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
@@ -40,9 +37,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.salesforce.hbase.index.Indexer;
 import com.salesforce.hbase.index.builder.ColumnFamilyIndexer;
-import com.salesforce.hbase.index.table.HTableFactory;
+import com.salesforce.hbase.index.builder.covered.CoveredColumnIndexer;
 
 /**
  * most of the underlying work (creating/splitting the WAL, etc) is from
@@ -167,7 +163,7 @@ public class TestWALReplayWithIndexWrites {
     wal.close();
 
     // then create the index table so we are successful on WAL replay
-    ColumnFamilyIndexer.createIndexTable(UTIL.getHBaseAdmin(), INDEX_TABLE_NAME);
+    CoveredColumnIndexer.createIndexTable(UTIL.getHBaseAdmin(), INDEX_TABLE_NAME);
 
     // run the WAL split and setup the region
     runWALSplit(this.conf);


### PR DESCRIPTION
This is a Indexer that demonstrates how one might build
a covered index. In this case, we cover only the specified
columns and ignore the rest of the columns in the row.

The implementation has three main parts: the specifier, the
codec, and the indexer. The specifier is a helper to correctly
configure the columns that you want to index. The codec does the
work of transforming to/from index entries. It also supports
manipulation of the backing data so you can apply a delete/put
(or a subset of their kvs) to the row and then build the new index entry.
Finally, the indexer manages getting the local row, batching entries
based on their timestamp (one of the tricker pieces as a put/delete
can have KVs that all correspond to different timestamps).

Also, this commit fixes a small bug in the Indexer.
Previously, when we attempt to make an index update, but there are no resulting updates
(i.e. delete of an empty row) we early out in doPre which skips taking the update lock
since we don't need to lock rolling of the WAL if there are no index updates to write.
However, we still release the lock in doPost, even if no index updates had been made.
Therefore, we end up getting an IllegalMonitorException since that lock is unheld.
