### PR TITLE
No need to evaluate ColumnExpression in DistinctValueWithCountServerAggregator#aggregate()

### DIFF
--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DistinctValueWithCountServerAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DistinctValueWithCountServerAggregator.java
@@ -27,20 +27,15 @@
  ******************************************************************************/
 package com.salesforce.phoenix.expression.aggregator;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 
-import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
-import com.salesforce.phoenix.util.ByteUtil;
-import com.salesforce.phoenix.util.ImmutableBytesPtr;
-import com.salesforce.phoenix.util.SizedUtil;
+import com.salesforce.phoenix.util.*;
 
 /**
  * Server side Aggregator which will aggregate data and find distinct values with number of occurrences for each.
@@ -52,26 +47,20 @@ public class DistinctValueWithCountServerAggregator extends BaseAggregator {
     public static final int DEFAULT_ESTIMATED_DISTINCT_VALUES = 10000;
     
     private byte[] buffer = null;
-    private Expression expression = null;
     private Map<ImmutableBytesPtr, Integer> valueVsCount = new HashMap<ImmutableBytesPtr, Integer>();
 
-    public DistinctValueWithCountServerAggregator(List<Expression> expressions) {
+    public DistinctValueWithCountServerAggregator() {
         super(null);
-        this.expression = expressions.get(0);
     }
 
     @Override
     public void aggregate(Tuple tuple, ImmutableBytesWritable ptr) {
-        ImmutableBytesWritable colValue = new ImmutableBytesWritable(ByteUtil.EMPTY_BYTE_ARRAY);
-        if (expression.evaluate(tuple, colValue)) {
-            ImmutableBytesPtr key = new ImmutableBytesPtr(colValue.get(), colValue.getOffset(),
-                    colValue.getLength());
-            Integer count = this.valueVsCount.get(key);
-            if (count == null) {
-                this.valueVsCount.put(key, 1);
-            } else {
-                this.valueVsCount.put(key, count++);
-            }
+        ImmutableBytesPtr key = new ImmutableBytesPtr(ptr.get(), ptr.getOffset(), ptr.getLength());
+        Integer count = this.valueVsCount.get(key);
+        if (count == null) {
+            this.valueVsCount.put(key, 1);
+        } else {
+            this.valueVsCount.put(key, count++);
         }
     }
 

--- a/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
@@ -33,9 +33,7 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.Aggregator;
-import com.salesforce.phoenix.expression.aggregator.DistinctCountClientAggregator;
-import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
+import com.salesforce.phoenix.expression.aggregator.*;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -104,7 +102,7 @@ public class DistinctCountAggregateFunction extends DelegateConstantToCountAggre
     
     @Override 
     public Aggregator newServerAggregator() {
-        return new DistinctValueWithCountServerAggregator(getChildren());
+        return new DistinctValueWithCountServerAggregator();
     }
     
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/function/PercentRankAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/PercentRankAggregateFunction.java
@@ -57,7 +57,7 @@ public class PercentRankAggregateFunction extends SingleAggregateFunction {
 
     @Override
     public Aggregator newServerAggregator() {
-        return new DistinctValueWithCountServerAggregator(children);
+        return new DistinctValueWithCountServerAggregator();
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/function/PercentileContAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/PercentileContAggregateFunction.java
@@ -58,7 +58,7 @@ public class PercentileContAggregateFunction extends SingleAggregateFunction {
 
     @Override
     public Aggregator newServerAggregator() {
-        return new DistinctValueWithCountServerAggregator(children);
+        return new DistinctValueWithCountServerAggregator();
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/function/StddevPopFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/StddevPopFunction.java
@@ -30,9 +30,7 @@ package com.salesforce.phoenix.expression.function;
 import java.util.List;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.Aggregator;
-import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
-import com.salesforce.phoenix.expression.aggregator.StddevPopAggregator;
+import com.salesforce.phoenix.expression.aggregator.*;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -58,7 +56,7 @@ public class StddevPopFunction extends SingleAggregateFunction {
 
     @Override
     public Aggregator newServerAggregator() {
-        return new DistinctValueWithCountServerAggregator(children);
+        return new DistinctValueWithCountServerAggregator();
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/function/StddevSampFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/StddevSampFunction.java
@@ -30,9 +30,7 @@ package com.salesforce.phoenix.expression.function;
 import java.util.List;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.Aggregator;
-import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
-import com.salesforce.phoenix.expression.aggregator.StddevSampAggregator;
+import com.salesforce.phoenix.expression.aggregator.*;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -58,7 +56,7 @@ public class StddevSampFunction extends SingleAggregateFunction {
 
     @Override
     public Aggregator newServerAggregator() {
-        return new DistinctValueWithCountServerAggregator(children);
+        return new DistinctValueWithCountServerAggregator();
     }
 
     @Override


### PR DESCRIPTION
No need to evaluate ColumnExpression in DistinctValueWithCountServerAggregator#aggregate()

ServerAggregators#aggregate evaluate the column expression already.(CE is the 1st expression in the child expressions of all the aggregate functions which uses DistinctValueWithCountServerAggregator)
