### PR TITLE
Test for metadatascan with table name containing underscore

### DIFF
--- a/src/test/java/com/salesforce/phoenix/end2end/QueryDatabaseMetaDataTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/QueryDatabaseMetaDataTest.java
@@ -92,6 +92,13 @@ public class QueryDatabaseMetaDataTest extends BaseClientMangedTimeTest {
         assertEquals(CUSTOM_ENTITY_DATA_SCHEMA_NAME, rs.getString("TABLE_SCHEM"));
         assertEquals(CUSTOM_ENTITY_DATA_NAME, rs.getString("TABLE_NAME"));
         assertEquals(PTableType.USER.getSerializedValue(), rs.getString("TABLE_TYPE"));
+
+        rs = dbmd.getTables(null, CUSTOM_ENTITY_DATA_SCHEMA_NAME, CUSTOM_ENTITY_DATA_NAME, null);
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_SCHEM"),CUSTOM_ENTITY_DATA_SCHEMA_NAME);
+        assertEquals(rs.getString("TABLE_NAME"),CUSTOM_ENTITY_DATA_NAME);
+        assertEquals(PTableType.USER.getSerializedValue(), rs.getString("TABLE_TYPE"));
+        assertFalse(rs.next());
         
         try {
             rs.getString("RANDOM_COLUMN_NAME");


### PR DESCRIPTION
For table name containing underscore, PhoenixDatabaseMetaData.getTables throws the following exception. If table name contains underscore then skipscan is used otherwise range scan. To fix this should range scan hint be used in getTables method?

Caused by: java.lang.ArrayIndexOutOfBoundsException: 11
    at com.salesforce.phoenix.schema.RowKeySchema.next(RowKeySchema.java:97)
    at com.salesforce.phoenix.filter.SkipScanFilter.navigate(SkipScanFilter.java:366)
    at com.salesforce.phoenix.filter.SkipScanFilter.intersect(SkipScanFilter.java:188)
    at com.salesforce.phoenix.filter.SkipScanFilter.intersect(SkipScanFilter.java:147)
    at com.salesforce.phoenix.util.ScanUtil.intersectScanRange(ScanUtil.java:132)
    at com.salesforce.phoenix.iterate.ParallelIterators.getIterators(ParallelIterators.java:114)
    ... 33 more
