### PR TITLE
Multiple fixes for Decimal precision and scale

### DIFF
--- a/src/main/java/com/salesforce/phoenix/expression/BaseAddSubtractExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/BaseAddSubtractExpression.java
@@ -40,16 +40,19 @@ abstract public class BaseAddSubtractExpression extends ArithmeticExpression {
         super(children);
     }
 
-    protected static int getPrecision(int lp, int rp, int ls, int rs) {
+    protected static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
+    	if (ls == null || rs == null) {
+    		return PDataType.MAX_PRECISION;
+    	}
         int val = getScale(lp, rp, ls, rs) + Math.max(lp - ls, rp - rs) + 1;
         return Math.min(PDataType.MAX_PRECISION, val);
     }
 
-    protected static int getScale(int lp, int rp, int ls, int rs) {
+    protected static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
     	// If we are adding a decimal with scale and precision to a decimal
     	// with no precision nor scale, the scale system does not apply.
-    	if (ls == PDataType.NO_SCALE || rs == PDataType.NO_SCALE) {
-    		return PDataType.NO_SCALE;
+    	if (ls == null || rs == null) {
+    		return null;
     	}
         int val = Math.max(ls, rs);
         return Math.min(PDataType.MAX_PRECISION, val);

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalAddExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalAddExpression.java
@@ -53,8 +53,7 @@ public class DecimalAddExpression extends AddExpression {
             if (i == 0) {
                 maxLength = childExpr.getMaxLength();
                 scale = childExpr.getScale();
-            } else if (maxLength != null && scale != null && childExpr.getMaxLength() != null
-                    && childExpr.getScale() != null) {
+            } else {
                 maxLength = getPrecision(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
                 scale = getScale(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
             }

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalDivideExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalDivideExpression.java
@@ -93,16 +93,19 @@ public class DecimalDivideExpression extends DivideExpression {
         return true;
     }
 
-    private static int getPrecision(int lp, int rp, int ls, int rs) {
+    private static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
+    	if (ls == null || rs == null) {
+    		return PDataType.MAX_PRECISION;
+    	}
         int val = getScale(lp, rp, ls, rs) + lp - ls + rp;
         return Math.min(PDataType.MAX_PRECISION, val);
     }
 
-    private static int getScale(int lp, int rp, int ls, int rs) {
+    private static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
     	// If we are adding a decimal with scale and precision to a decimal
     	// with no precision nor scale, the scale system does not apply.
-    	if (ls == PDataType.NO_SCALE || rs == PDataType.NO_SCALE) {
-    		return PDataType.NO_SCALE;
+    	if (ls == null || rs == null) {
+    		return null;
     	}
         int val = Math.max(PDataType.MAX_PRECISION - lp + ls - rs, 0);
         return Math.min(PDataType.MAX_PRECISION, val);

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalDivideExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalDivideExpression.java
@@ -40,25 +40,12 @@ import com.salesforce.phoenix.util.NumberUtil;
 
 
 public class DecimalDivideExpression extends DivideExpression {
-    private Integer maxLength;
-    private Integer scale;
 
     public DecimalDivideExpression() {
     }
 
     public DecimalDivideExpression(List<Expression> children) {
         super(children);
-        for (int i=0; i<children.size(); i++) {
-            Expression childExpr = children.get(i);
-            if (i == 0) {
-                maxLength = childExpr.getMaxLength();
-                scale = childExpr.getScale();
-            } else if (maxLength != null && scale != null && childExpr.getMaxLength() != null
-                    && childExpr.getScale() != null) {
-                maxLength = getPrecision(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
-                scale = getScale(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
-            }
-        }
     }
 
     @Override
@@ -83,46 +70,18 @@ public class DecimalDivideExpression extends DivideExpression {
                 result = result.divide(bd, PDataType.DEFAULT_MATH_CONTEXT);
             }
         }
-        if (maxLength != null && scale != null) {
-            result = NumberUtil.setDecimalWidthAndScale(result, maxLength, scale);
+        if (getMaxLength() != null && getScale() != null) {
+            result = NumberUtil.setDecimalWidthAndScale(result, getMaxLength(), getScale());
         }
         if (result == null) {
-            throw new ValueTypeIncompatibleException(PDataType.DECIMAL, maxLength, scale);
+            throw new ValueTypeIncompatibleException(PDataType.DECIMAL, getMaxLength(), getScale());
         }
         ptr.set(PDataType.DECIMAL.toBytes(result));
         return true;
     }
 
-    private static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
-    	if (ls == null || rs == null) {
-    		return PDataType.MAX_PRECISION;
-    	}
-        int val = getScale(lp, rp, ls, rs) + lp - ls + rp;
-        return Math.min(PDataType.MAX_PRECISION, val);
-    }
-
-    private static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
-    	// If we are adding a decimal with scale and precision to a decimal
-    	// with no precision nor scale, the scale system does not apply.
-    	if (ls == null || rs == null) {
-    		return null;
-    	}
-        int val = Math.max(PDataType.MAX_PRECISION - lp + ls - rs, 0);
-        return Math.min(PDataType.MAX_PRECISION, val);
-    }
-
     @Override
     public PDataType getDataType() {
         return PDataType.DECIMAL;
-    }
-
-    @Override
-    public Integer getScale() {
-        return scale;
-    }
-
-    @Override
-    public Integer getMaxLength() {
-        return maxLength;
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalMultiplyExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalMultiplyExpression.java
@@ -40,25 +40,12 @@ import com.salesforce.phoenix.util.NumberUtil;
 
 
 public class DecimalMultiplyExpression extends MultiplyExpression {
-    private Integer maxLength;
-    private Integer scale;
 
     public DecimalMultiplyExpression() {
     }
 
     public DecimalMultiplyExpression(List<Expression> children) {
         super(children);
-        for (int i=0; i<children.size(); i++) {
-            Expression childExpr = children.get(i);
-            if (i == 0) {
-                maxLength = childExpr.getMaxLength();
-                scale = childExpr.getScale();
-            } else if (maxLength != null && scale != null && childExpr.getMaxLength() != null
-                    && childExpr.getScale() != null) {
-                maxLength = getPrecision(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
-                scale = getScale(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
-            }
-        }
     }
 
     @Override
@@ -83,46 +70,18 @@ public class DecimalMultiplyExpression extends MultiplyExpression {
                 result = result.multiply(bd);
             }
         }
-        if (maxLength != null && scale != null) {
-            result = NumberUtil.setDecimalWidthAndScale(result, maxLength, scale);
+        if (getMaxLength() != null && getScale() != null) {
+            result = NumberUtil.setDecimalWidthAndScale(result, getMaxLength(), getScale());
         }
         if (result == null) {
-            throw new ValueTypeIncompatibleException(PDataType.DECIMAL, maxLength, scale);
+            throw new ValueTypeIncompatibleException(PDataType.DECIMAL, getMaxLength(), getScale());
         }
         ptr.set(PDataType.DECIMAL.toBytes(result));
         return true;
     }
 
-    private static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
-    	if (ls == null || rs == null) {
-    		return PDataType.MAX_PRECISION;
-    	}
-        int val = lp + rp;
-        return Math.min(PDataType.MAX_PRECISION, val);
-    }
-
-    private static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
-    	// If we are adding a decimal with scale and precision to a decimal
-    	// with no precision nor scale, the scale system does not apply.
-    	if (ls == null || rs == null) {
-    		return null;
-    	}
-        int val = ls + rs;
-        return Math.min(PDataType.MAX_PRECISION, val);
-    }
-
     @Override
     public PDataType getDataType() {
         return PDataType.DECIMAL;
-    }
-
-    @Override
-    public Integer getScale() {
-        return scale;
-    }
-
-    @Override
-    public Integer getMaxLength() {
-        return maxLength;
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalMultiplyExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalMultiplyExpression.java
@@ -93,16 +93,19 @@ public class DecimalMultiplyExpression extends MultiplyExpression {
         return true;
     }
 
-    private static int getPrecision(int lp, int rp, int ls, int rs) {
+    private static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
+    	if (ls == null || rs == null) {
+    		return PDataType.MAX_PRECISION;
+    	}
         int val = lp + rp;
         return Math.min(PDataType.MAX_PRECISION, val);
     }
 
-    private static int getScale(int lp, int rp, int ls, int rs) {
+    private static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
     	// If we are adding a decimal with scale and precision to a decimal
     	// with no precision nor scale, the scale system does not apply.
-    	if (ls == PDataType.NO_SCALE || rs == PDataType.NO_SCALE) {
-    		return PDataType.NO_SCALE;
+    	if (ls == null || rs == null) {
+    		return null;
     	}
         int val = ls + rs;
         return Math.min(PDataType.MAX_PRECISION, val);

--- a/src/main/java/com/salesforce/phoenix/expression/DecimalSubtractExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/DecimalSubtractExpression.java
@@ -60,8 +60,7 @@ public class DecimalSubtractExpression extends SubtractExpression {
             if (i == 0) {
                 maxLength = childExpr.getMaxLength();
                 scale = childExpr.getScale();
-            } else if (maxLength != null && scale != null && childExpr.getMaxLength() != null
-                    && childExpr.getScale() != null) {
+            } else {
                 maxLength = getPrecision(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
                 scale = getScale(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
             }

--- a/src/main/java/com/salesforce/phoenix/expression/MultiplyExpression.java
+++ b/src/main/java/com/salesforce/phoenix/expression/MultiplyExpression.java
@@ -30,6 +30,7 @@ package com.salesforce.phoenix.expression;
 import java.util.List;
 
 import com.salesforce.phoenix.expression.visitor.ExpressionVisitor;
+import com.salesforce.phoenix.schema.PDataType;
 
 
 /**
@@ -40,11 +41,24 @@ import com.salesforce.phoenix.expression.visitor.ExpressionVisitor;
  * @since 0.1
  */
 public abstract class MultiplyExpression extends ArithmeticExpression {
+    private Integer maxLength;
+    private Integer scale;
+
     public MultiplyExpression() {
     }
 
     public MultiplyExpression(List<Expression> children) {
         super(children);
+        for (int i=0; i<children.size(); i++) {
+            Expression childExpr = children.get(i);
+            if (i == 0) {
+                maxLength = childExpr.getMaxLength();
+                scale = childExpr.getScale();
+            } else {
+                maxLength = getPrecision(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
+                scale = getScale(maxLength, childExpr.getMaxLength(), scale, childExpr.getScale());
+            }
+        }
     }
 
     @Override
@@ -60,5 +74,33 @@ public abstract class MultiplyExpression extends ArithmeticExpression {
     @Override
     public String getOperatorString() {
         return " * ";
+    }
+    
+    private static Integer getPrecision(Integer lp, Integer rp, Integer ls, Integer rs) {
+    	if (ls == null || rs == null) {
+    		return PDataType.MAX_PRECISION;
+    	}
+        int val = lp + rp;
+        return Math.min(PDataType.MAX_PRECISION, val);
+    }
+
+    private static Integer getScale(Integer lp, Integer rp, Integer ls, Integer rs) {
+    	// If we are adding a decimal with scale and precision to a decimal
+    	// with no precision nor scale, the scale system does not apply.
+    	if (ls == null || rs == null) {
+    		return null;
+    	}
+        int val = ls + rs;
+        return Math.min(PDataType.MAX_PRECISION, val);
+    }
+    
+    @Override
+    public Integer getScale() {
+        return scale;
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        return maxLength;
     }
 }

--- a/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
@@ -92,7 +92,7 @@ public class ColumnDef {
                 // When neither a precision nor a scale is specified, the precision and scale is
                 // ignored. All decimal are stored with as much decimal points as possible.
                 scale = scale == null ? 
-                		maxLength == null ? PDataType.NO_SCALE : PDataType.DEFAULT_SCALE : 
+                		maxLength == null ? null : PDataType.DEFAULT_SCALE : 
                 		scale > maxLength ? maxLength : scale; 
             } else if (this.dataType == PDataType.BINARY) {
                 if (maxLength == null) {

--- a/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
+++ b/src/main/java/com/salesforce/phoenix/parse/ColumnDef.java
@@ -75,6 +75,7 @@ public class ColumnDef {
                 }
                 scale = null;
             } else if (this.dataType == PDataType.DECIMAL) {
+            	Integer origMaxLength = maxLength;
                 maxLength = maxLength == null ? PDataType.MAX_PRECISION : maxLength;
                 // for deciaml, 1 <= maxLength <= PDataType.MAX_PRECISION;
                 if (maxLength < 1 || maxLength > PDataType.MAX_PRECISION) {
@@ -92,7 +93,7 @@ public class ColumnDef {
                 // When neither a precision nor a scale is specified, the precision and scale is
                 // ignored. All decimal are stored with as much decimal points as possible.
                 scale = scale == null ? 
-                		maxLength == null ? null : PDataType.DEFAULT_SCALE : 
+                		origMaxLength == null ? null : PDataType.DEFAULT_SCALE : 
                 		scale > maxLength ? maxLength : scale; 
             } else if (this.dataType == PDataType.BINARY) {
                 if (maxLength == null) {

--- a/src/main/java/com/salesforce/phoenix/schema/PDataType.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PDataType.java
@@ -1363,7 +1363,7 @@ public enum PDataType {
                 }
             }
             if (desiredMaxLength != null && desiredScale != null && maxLength != null && scale != null &&
-            		((desiredScale == PDataType.NO_SCALE && desiredMaxLength < maxLength) || 
+            		((desiredScale == null && desiredMaxLength < maxLength) || 
             				(desiredMaxLength - desiredScale) < (maxLength - scale))) {
                 return false;
             }
@@ -1373,7 +1373,7 @@ public enum PDataType {
         @Override
         public byte[] coerceBytes(byte[] b, Object object, PDataType actualType, Integer maxLength, Integer scale,
                 Integer desiredMaxLength, Integer desiredScale) {
-            if (desiredScale == null || desiredScale == PDataType.NO_SCALE) {
+            if (desiredScale == null || desiredScale == null) {
                 // deiredScale not available, or we do not have scale requirement, delegate to parents.
                 return super.coerceBytes(b, object, actualType);
             }
@@ -3529,7 +3529,6 @@ public enum PDataType {
     public static final int MAX_PRECISION = 38; // Max precision guaranteed to fit into a long (and this should be plenty)
     public static final int MIN_DECIMAL_AVG_SCALE = 4;
     public static final MathContext DEFAULT_MATH_CONTEXT = new MathContext(MAX_PRECISION, RoundingMode.HALF_UP);
-    public static final int NO_SCALE = Integer.MIN_VALUE; // Oracle allows negative scale, so use the smallest value for this purpose.
     public static final int DEFAULT_SCALE = 0;
 
     private static final Integer MAX_BIG_DECIMAL_BYTES = 21;

--- a/src/test/java/com/salesforce/phoenix/end2end/ArithmeticQueryTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/ArithmeticQueryTest.java
@@ -47,26 +47,28 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
         try {
             String ddl = "CREATE TABLE IF NOT EXISTS testDecimalArithmetic" + 
                     "  (pk VARCHAR NOT NULL PRIMARY KEY, " +
-                    "col1 DECIMAL(31,0), col2 DECIMAL(5), col3 DECIMAL(5,2))";
+                    "col1 DECIMAL(31,0), col2 DECIMAL(5), col3 DECIMAL(5,2), col4 DECIMAL)";
             createTestTable(getUrl(), ddl);
             
             // Test upsert correct values 
-            String query = "UPSERT INTO testDecimalArithmetic(pk, col1, col2, col3) VALUES(?,?,?,?)";
+            String query = "UPSERT INTO testDecimalArithmetic(pk, col1, col2, col3, col4) VALUES(?,?,?,?,?)";
             PreparedStatement stmt = conn.prepareStatement(query);
             stmt.setString(1, "valueOne");
             stmt.setBigDecimal(2, new BigDecimal("123456789123456789"));
             stmt.setBigDecimal(3, new BigDecimal("12345"));
             stmt.setBigDecimal(4, new BigDecimal("12.34"));
+            stmt.setBigDecimal(5, new BigDecimal("12345.6789"));
             stmt.execute();
             conn.commit();
             
-            query = "SELECT col1, col2, col3 FROM testDecimalArithmetic WHERE pk = 'valueOne'";
+            query = "SELECT col1, col2, col3, col4 FROM testDecimalArithmetic WHERE pk = 'valueOne'";
             stmt = conn.prepareStatement(query);
             ResultSet rs = stmt.executeQuery();
             assertTrue(rs.next());
             assertEquals(new BigDecimal("123456789123456789"), rs.getBigDecimal(1));
             assertEquals(new BigDecimal("12345"), rs.getBigDecimal(2));
             assertEquals(new BigDecimal("12.34"), rs.getBigDecimal(3));
+            assertEquals(new BigDecimal("12345.6789"), rs.getBigDecimal(4));
             assertFalse(rs.next());
             
             query = "UPSERT INTO testDecimalArithmetic(pk, col1, col2, col3) VALUES(?,?,?,?)";
@@ -268,9 +270,6 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             ResultSet rs = stmt.executeQuery();
             assertTrue(rs.next());
             BigDecimal result = rs.getBigDecimal(1);
-            /* Flapped here once:
-             * expected:<33333333333333333333.03333333333> but was:<49999999999999999999.55>
-             */
             assertEquals(new BigDecimal("33333333333333333333.03333333333"), result);
             
             query = "SELECT avg(col2) FROM testDecimalArithmatic";
@@ -300,16 +299,17 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
         try {
             String ddl = "CREATE TABLE IF NOT EXISTS testDecimalArithmatic" + 
                     "  (pk VARCHAR NOT NULL PRIMARY KEY, " +
-                    "col1 DECIMAL, col2 DECIMAL(5, 2), col3 INTEGER, col4 BIGINT)";
+                    "col1 DECIMAL(38,0), col2 DECIMAL(5, 2), col3 INTEGER, col4 BIGINT, col5 DECIMAL)";
             createTestTable(getUrl(), ddl);
             
-            String query = "UPSERT INTO testDecimalArithmatic(pk, col1, col2, col3, col4) VALUES(?,?,?,?,?)";
+            String query = "UPSERT INTO testDecimalArithmatic(pk, col1, col2, col3, col4, col5) VALUES(?,?,?,?,?,?)";
             PreparedStatement stmt = conn.prepareStatement(query);
             stmt.setString(1, "testValueOne");
             stmt.setBigDecimal(2, new BigDecimal("1234567890123456789012345678901"));
             stmt.setBigDecimal(3, new BigDecimal("123.45"));
             stmt.setInt(4, 10);
             stmt.setLong(5, 10L);
+            stmt.setBigDecimal(6, new BigDecimal("111.111"));
             stmt.execute();
             conn.commit();
 
@@ -318,6 +318,7 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             stmt.setBigDecimal(3, new BigDecimal("123.45"));
             stmt.setInt(4, 10);
             stmt.setLong(5, 10L);
+            stmt.setBigDecimal(6, new BigDecimal("123456789.0123456789"));
             stmt.execute();
             conn.commit();
             
@@ -351,6 +352,20 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             result = rs.getBigDecimal(1);
             assertEquals(new BigDecimal("133.45"), result);
             
+            query = "SELECT col5 + col3 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("121.111"), result);
+            
+            query = "SELECT col5 + col4 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("121.111"), result);
+            
             query = "SELECT col1 - col3 FROM testDecimalArithmatic WHERE pk='testValueOne'";
             stmt = conn.prepareStatement(query);
             rs = stmt.executeQuery();
@@ -378,6 +393,20 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             assertTrue(rs.next());
             result = rs.getBigDecimal(1);
             assertEquals(new BigDecimal("113.45"), result);
+            
+            query = "SELECT col5 - col3 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("101.111"), result);
+            
+            query = "SELECT col5 - col4 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("101.111"), result);
             
             query = "SELECT col1 * col3 FROM testDecimalArithmatic WHERE pk='testValueOne'";
             stmt = conn.prepareStatement(query);
@@ -422,6 +451,20 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             	assertTrue(e.getMessage(), e.getMessage().contains("ERROR 206 (22003): The value is outside the range for the data type. DECIMAL(38,0)"));
             }
             
+            query = "SELECT col4 * col5 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(0, result.compareTo(new BigDecimal("1111.11")));
+
+            query = "SELECT col3 * col5 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(0, result.compareTo(new BigDecimal("1111.11")));
+            
             query = "SELECT col2 * col4 FROM testDecimalArithmatic WHERE pk='testValueOne'";
             stmt = conn.prepareStatement(query);
             rs = stmt.executeQuery();
@@ -458,6 +501,21 @@ public class ArithmeticQueryTest extends BaseHBaseManagedTimeTest {
             assertTrue(rs.next());
             result = rs.getBigDecimal(1);
             assertEquals(new BigDecimal("12.34"), result);
+            
+            // col5 has NO_SCALE, so the result's scale is not expected to be truncated to col5 value's scale of 4
+            query = "SELECT col5 / col3 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("11.1111"), result);
+            
+            query = "SELECT col5 / col4 FROM testDecimalArithmatic WHERE pk='testValueOne'";
+            stmt = conn.prepareStatement(query);
+            rs = stmt.executeQuery();
+            assertTrue(rs.next());
+            result = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal("11.1111"), result);
         } finally {
             conn.close();
         }


### PR DESCRIPTION
- Apply rules for multiple and divide on not just decimal
- Use null as NO_SCALE consistently
- Included Eli's tests.

Tests done:
- ArithmeticOperationTests and ArithmeticQueryTests with Eli's new tests are passing.
- TODOs:
  More tests.
