### PR TITLE
Adding Hadoop OutputFormat, RecordWriter to handle database connection, ...

### DIFF
--- a/src/main/java/com/salesforce/phoenix/pig/PhoenixHBaseStorage.java
+++ b/src/main/java/com/salesforce/phoenix/pig/PhoenixHBaseStorage.java
@@ -28,27 +28,29 @@
 package com.salesforce.phoenix.pig;
 
 import java.io.IOException;
-import java.sql.*;
-import java.util.*;
+import java.util.Properties;
 
-import org.apache.commons.cli.*;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapreduce.*;
-import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
-import org.apache.pig.*;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.pig.ResourceSchema;
 import org.apache.pig.ResourceSchema.ResourceFieldSchema;
-import org.apache.pig.data.DataType;
+import org.apache.pig.StoreFuncInterface;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.util.ObjectSerializer;
 import org.apache.pig.impl.util.UDFContext;
 
-import com.salesforce.phoenix.jdbc.PhoenixConnection;
-import com.salesforce.phoenix.schema.PDataType;
-import com.salesforce.phoenix.util.ColumnInfo;
-import com.salesforce.phoenix.util.QueryUtil;
+import com.salesforce.phoenix.pig.hadoop.PhoenixOutputFormat;
+import com.salesforce.phoenix.pig.hadoop.PhoenixRecord;
+import com.salesforce.phoenix.pig.hadoop.PhoenixRecordWriter;
 
 /**
  * StoreFunc that uses Phoenix to store data into HBase.
@@ -73,26 +75,21 @@ import com.salesforce.phoenix.util.QueryUtil;
 @SuppressWarnings("rawtypes")
 public class PhoenixHBaseStorage implements StoreFuncInterface {
 
-	private List<ColumnInfo> columnMetadataList = new LinkedList<ColumnInfo>();
-
-	private static final Log LOG = LogFactory.getLog(PhoenixHBaseStorage.class);
-
+	private PhoenixPigConfiguration config;
 	private String tableName;
-	private PreparedStatement statement;
-	private final String server;
-	private PhoenixConnection conn;
-	
-	private int batchSize;
-	private int rowCount;
+	private RecordWriter<NullWritable, PhoenixRecord> writer;
+	private String contextSignature = null;
+	private ResourceSchema schema;	
+	private long batchSize;
+	private final PhoenixOutputFormat outputFormat = new PhoenixOutputFormat();
 
 	// Set of options permitted
 	private final static Options validOptions = new Options();
-	private final CommandLine configuredOptions;
 	private final static CommandLineParser parser = new GnuParser();
-	
-	private String contextSignature = null;
-	private ResourceSchema schema;
-	private static final String SCHEMA = "_schema";
+	private final static String SCHEMA = "_schema";
+
+	private final CommandLine configuredOptions;
+	private final String server;
 
 	public PhoenixHBaseStorage(String server) throws ParseException {
 		this(server, null);
@@ -112,8 +109,7 @@ public class PhoenixHBaseStorage implements StoreFuncInterface {
 			throw e;
 		}
 
-		rowCount = 0;
-		batchSize = Integer.parseInt(configuredOptions.getOptionValue("batchSize"));
+		batchSize = Long.parseLong(configuredOptions.getOptionValue("batchSize"));
 	}
 
 	private static void populateValidOptions() {
@@ -124,8 +120,7 @@ public class PhoenixHBaseStorage implements StoreFuncInterface {
 	 * Returns UDFProperties based on <code>contextSignature</code>.
 	 */
 	private Properties getUDFProperties() {
-		return UDFContext.getUDFContext().getUDFProperties(this.getClass(),
-				new String[] { contextSignature });
+		return UDFContext.getUDFContext().getUDFProperties(this.getClass(), new String[] { contextSignature });
 	}
 
 	
@@ -134,86 +129,40 @@ public class PhoenixHBaseStorage implements StoreFuncInterface {
 	 */
 	@Override
 	public void setStoreLocation(String location, Job job) throws IOException {
-		if (location.startsWith("hbase://")) {
-			tableName = location.substring(8);
+		String prefix = "hbase://";
+		if (location.startsWith(prefix)) {
+			tableName = location.substring(prefix.length());
 		}
+		config = new PhoenixPigConfiguration(job.getConfiguration());
+		config.configure(server, tableName, batchSize);
 
-		Configuration conf = job.getConfiguration();
-		PhoenixPigConfiguration.configure(conf);
-		
-        String serializedSchema = getUDFProperties().getProperty(contextSignature + SCHEMA);
-        if (serializedSchema!= null) {
-            schema = (ResourceSchema) ObjectSerializer.deserialize(serializedSchema);
-        }
-
+		String serializedSchema = getUDFProperties().getProperty(contextSignature + SCHEMA);
+		if (serializedSchema != null) {
+			schema = (ResourceSchema) ObjectSerializer.deserialize(serializedSchema);
+		}
 	}
 
-	/**
-	 * This method gets called before putNext(Tuple t). Initialize
-	 * driver/connections here
-	 */
 	@Override
 	public void prepareToWrite(RecordWriter writer) throws IOException {
-		try {
-			Properties props = new Properties();
-			conn = DriverManager.getConnection(QueryUtil.getUrl(server), props).unwrap(PhoenixConnection.class);
-			// Default to config defined upsert batch size if user did not specify it.
-			batchSize = batchSize <= 0 ? conn.getMutateBatchSize() : batchSize;
-			String[] tableMetadata = getTableMetadata(tableName);
-			ResultSet rs = conn.getMetaData().getColumns(null, tableMetadata[0], tableMetadata[1], null);
-			while (rs.next()) {
-				columnMetadataList.add(new ColumnInfo(rs.getString(QueryUtil.COLUMN_NAME_POSITION), rs.getInt(QueryUtil.DATA_TYPE_POSITION)));
-			}
-			
-			// Generating UPSERT statement without column name information.
-			String upsertStmt = QueryUtil.constructUpsertStatement(null, tableName, columnMetadataList.size());
-			LOG.info("Phoenix Upsert Statement: " + upsertStmt);
-			statement = conn.prepareStatement(upsertStmt);
-
-		} catch (SQLException e) {
-			LOG.error("Error in constructing PreparedStatement: " + e);
-			throw new RuntimeException(e);
-		}
+		this.writer = (PhoenixRecordWriter)writer;
 	}
 
 	@Override
 	public void putNext(Tuple t) throws IOException {
-		Object upsertValue = null;
         ResourceFieldSchema[] fieldSchemas = (schema == null) ? null : schema.getFields();      
         
+        PhoenixRecord record = new PhoenixRecord(fieldSchemas);
         
-		try {
-			for (int i = 0; i < columnMetadataList.size(); i++) {
-				Object o = t.get(i);
-				byte type = (fieldSchemas == null) ? DataType.findType(t.get(i)) : fieldSchemas[i].getType();
-				upsertValue = convertTypeSpecificValue(o, type, columnMetadataList
-						.get(i).getSqlType());
-
-				if (upsertValue != null) {
-					statement.setObject(i + 1, upsertValue, columnMetadataList
-							.get(i).getSqlType());
-				} else {
-					statement.setNull(i + 1, columnMetadataList.get(i)
-							.getSqlType());
-				}
-			}
-
-			statement.execute();
-			// Commit when batch size is reached
-			if(++rowCount % batchSize == 0) {
-				conn.commit();
-				LOG.info("Rows upserted: "+rowCount);
-			}
-		} catch (SQLException e) {
-			LOG.error("Error during upserting to HBase table "+tableName, e);
+        for(int i=0; i<t.size(); i++) {
+        	record.add(t.get(i));
+        }
+        
+        try {
+			writer.write(null, record);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
 		}
-
-	}
-
-	private Object convertTypeSpecificValue(Object o, byte type, Integer sqlType) {
-		PDataType pDataType = PDataType.fromSqlType(sqlType);
-
-		return TypeUtil.castPigTypeToPhoenix(o, type, pDataType);
+        
 	}
 
 	@Override
@@ -227,15 +176,6 @@ public class PhoenixHBaseStorage implements StoreFuncInterface {
 
     @Override
     public void cleanupOnSuccess(String location, Job job) throws IOException {
-        // Commit the remaining executes after the last commit in putNext()
-        if (rowCount % batchSize != 0) {
-            try {
-                conn.commit();
-                LOG.info("Rows upserted: " + rowCount);
-            } catch (SQLException e) {
-                LOG.error("Error during upserting to HBase table " + tableName, e);
-            }
-        }
     }
 
 	@Override
@@ -244,32 +184,15 @@ public class PhoenixHBaseStorage implements StoreFuncInterface {
 		return location;
 	}
 
-	/**
-	 * This method sets {@link OutputFormat} to be used while writing data. Note
-	 * we do not need an OutputFormat as Phoenix encapsulates the writes to
-	 * HBase. Pig needs an OutputFormat to be specified, using
-	 * {@link NullOutputFormat}
-	 */
 	@Override
 	public OutputFormat getOutputFormat() throws IOException {
-		return new NullOutputFormat();
+		return outputFormat;
 	}
 
 	@Override
 	public void checkSchema(ResourceSchema s) throws IOException {
 		schema = s;
-		getUDFProperties().setProperty(contextSignature + SCHEMA,
-				ObjectSerializer.serialize(schema));
+		getUDFProperties().setProperty(contextSignature + SCHEMA, ObjectSerializer.serialize(schema));
 	}
 
-	private String[] getTableMetadata(String table) {
-		String[] schemaAndTable = table.split("\\.");
-		assert schemaAndTable.length >= 1;
-
-		if (schemaAndTable.length == 1) {
-			return new String[] { "", schemaAndTable[0] };
-		}
-
-		return new String[] { schemaAndTable[0], schemaAndTable[1] };
-	}
 }

--- a/src/main/java/com/salesforce/phoenix/pig/PhoenixPigConfiguration.java
+++ b/src/main/java/com/salesforce/phoenix/pig/PhoenixPigConfiguration.java
@@ -28,19 +28,32 @@
 
 package com.salesforce.phoenix.pig;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 
+import com.salesforce.phoenix.jdbc.PhoenixConnection;
+import com.salesforce.phoenix.util.ColumnInfo;
+import com.salesforce.phoenix.util.QueryUtil;
+
 /**
- * A container for configuration to be used with #{@link PhoenixHBaseStorage}
+ * A container for configuration to be used with {@link PhoenixHBaseStorage}
  * 
  * @author pkommireddi
  * 
  */
 public class PhoenixPigConfiguration {
-
-	private PhoenixPigConfiguration() {
-	}
-
+	
+	private static final Log LOG = LogFactory.getLog(PhoenixPigConfiguration.class);
+	
 	/**
 	 * Speculative execution of Map tasks
 	 */
@@ -50,10 +63,113 @@ public class PhoenixPigConfiguration {
 	 * Speculative execution of Reduce tasks
 	 */
 	public static final String REDUCE_SPECULATIVE_EXEC = "mapred.reduce.tasks.speculative.execution";
-
-	public static void configure(Configuration conf) {
+	
+	public static final String SERVER_NAME = "phoenix.hbase.server.name";
+	
+	public static final String TABLE_NAME = "phoenix.hbase.table.name";
+	
+	public static final String UPSERT_STATEMENT = "phoenix.upsert.stmt";
+	
+	public static final String UPSERT_BATCH_SIZE = "phoenix.upsert.batch.size";
+	
+	public static final long DEFAULT_UPSERT_BATCH_SIZE = 1000;
+	
+	private final Configuration conf;
+	
+	private Connection conn;
+	private List<ColumnInfo> columnMetadataList;
+		
+	public PhoenixPigConfiguration(Configuration conf) {
+		this.conf = conf;
+	}
+	
+	public void configure(String server, String tableName, long batchSize) {
+		conf.set(SERVER_NAME, server);
+		conf.set(TABLE_NAME, tableName);
+		conf.setLong(UPSERT_BATCH_SIZE, batchSize);
 		conf.setBoolean(MAP_SPECULATIVE_EXEC, false);
 		conf.setBoolean(REDUCE_SPECULATIVE_EXEC, false);
+	}
+	
+	/**
+	 * Creates a {@link Connection} and autoCommit to false.
+	 * 
+	 * @return 
+	 * @throws SQLException
+	 */
+	public Connection getConnection() throws SQLException {
+		Properties props = new Properties();
+		conn = DriverManager.getConnection(QueryUtil.getUrl(this.conf.get(SERVER_NAME)), props).unwrap(PhoenixConnection.class);
+		conn.setAutoCommit(false);
+		
+		setup(conn);
+		
+		return conn;
+	}
+	
+	/**
+	 * This method creates the Upsert statement and the Column Metadata
+	 * for the Pig query using {@link PhoenixHBaseStorage}. It also 
+	 * determines the batch size based on user provided options.
+	 * 
+	 * @param conn
+	 * @throws SQLException
+	 */
+	public void setup(Connection conn) throws SQLException {
+		// Reset batch size
+		long batchSize = getBatchSize() <= 0 ? ((PhoenixConnection) conn).getMutateBatchSize() : getBatchSize();
+		conf.setLong(UPSERT_BATCH_SIZE, batchSize);
+		
+		if (columnMetadataList == null) {
+			columnMetadataList = new ArrayList<ColumnInfo>();
+			String[] tableMetadata = getTableMetadata(getTableName());
+			ResultSet rs = conn.getMetaData().getColumns(null, tableMetadata[0], tableMetadata[1], null);
+			while (rs.next()) {
+				columnMetadataList.add(new ColumnInfo(rs.getString(QueryUtil.COLUMN_NAME_POSITION), rs.getInt(QueryUtil.DATA_TYPE_POSITION)));
+			}
+		}
+		
+		// Generating UPSERT statement without column name information.
+		String upsertStmt = QueryUtil.constructUpsertStatement(null, getTableName(), columnMetadataList.size());
+		LOG.info("Phoenix Upsert Statement: " + upsertStmt);
+		conf.set(UPSERT_STATEMENT, upsertStmt);
+	}
+	
+	public String getUpsertStatement() {
+		return conf.get(UPSERT_STATEMENT);
+	}
+
+	public long getBatchSize() {
+		return conf.getLong(UPSERT_BATCH_SIZE, DEFAULT_UPSERT_BATCH_SIZE);
+	}
+
+
+	public String getServer() {
+		return conf.get(SERVER_NAME);
+	}
+
+	public List<ColumnInfo> getColumnMetadataList() {
+		return columnMetadataList;
+	}
+	
+	public String getTableName() {
+		return conf.get(TABLE_NAME);
+	}
+
+	private String[] getTableMetadata(String table) {
+		String[] schemaAndTable = table.split("\\.");
+		assert schemaAndTable.length >= 1;
+
+		if (schemaAndTable.length == 1) {
+			return new String[] { "", schemaAndTable[0] };
+		}
+
+		return new String[] { schemaAndTable[0], schemaAndTable[1] };
+	}
+
+	
+	public Configuration getConfiguration() {
+		return this.conf;
 	}
 
 }

--- a/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixOutputFormat.java
+++ b/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixOutputFormat.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.salesforce.phoenix.pig.hadoop;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import com.salesforce.phoenix.pig.PhoenixPigConfiguration;
+
+/**
+ * {@link OutputFormat} implementation for Phoenix
+ * 
+ * @author pkommireddi
+ *
+ */
+public class PhoenixOutputFormat extends OutputFormat<NullWritable, PhoenixRecord> {
+	private static final Log LOG = LogFactory.getLog(PhoenixOutputFormat.class);
+	
+	private Connection connection;
+	private PhoenixPigConfiguration config;
+
+	@Override
+	public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {		
+	}
+
+	/**
+	 * TODO Implement {@link OutputCommitter} to rollback in case of task failure
+	 */
+	
+	@Override
+	public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException, InterruptedException {
+		return null;
+	}
+
+	@Override
+	public RecordWriter<NullWritable, PhoenixRecord> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+		try {
+			return new PhoenixRecordWriter(getConnection(context.getConfiguration()), config);
+		} catch (SQLException e) {
+			throw new IOException(e);
+		}
+	}
+	
+	/**
+	 * This method creates a database connection. A single instance is created
+	 * and passed around for re-use.
+	 * 
+	 * @param configuration
+	 * @return
+	 * @throws IOException
+	 */
+	synchronized Connection getConnection(Configuration configuration) throws IOException {
+	    if (connection != null) { 
+	    	return connection; 
+	    }
+	    
+	    config = new PhoenixPigConfiguration(configuration);	    
+		try {
+			LOG.info("Initializing new JDBC connection...");
+			connection = config.getConnection();
+			LOG.info("Initialized JDBC connection, autoCommit="+ connection.getAutoCommit());
+			return connection;
+		} catch (SQLException e) {
+			throw new IOException(e);
+		}
+	}
+}

--- a/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixRecord.java
+++ b/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixRecord.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.salesforce.phoenix.pig.hadoop;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.pig.ResourceSchema.ResourceFieldSchema;
+import org.apache.pig.data.DataType;
+
+import com.salesforce.phoenix.pig.TypeUtil;
+import com.salesforce.phoenix.schema.PDataType;
+import com.salesforce.phoenix.util.ColumnInfo;
+
+/**
+ * A {@link Writable} representing a Phoenix record. This class
+ * does a type mapping and sets the value accordingly in the 
+ * {@link PreparedStatement}
+ * 
+ * @author pkommireddi
+ *
+ */
+public class PhoenixRecord implements Writable {
+	
+	private final List<Object> values;
+	private final ResourceFieldSchema[] fieldSchemas;
+	
+	public PhoenixRecord(ResourceFieldSchema[] fieldSchemas) {
+		this.values = new ArrayList<Object>();
+		this.fieldSchemas = fieldSchemas;
+	}
+	
+	@Override
+	public void readFields(DataInput in) throws IOException {		
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {		
+	}
+	
+	public void write(PreparedStatement statement, List<ColumnInfo> columnMetadataList) throws SQLException {
+		for (int i = 0; i < columnMetadataList.size(); i++) {
+			Object o = values.get(i);
+			
+			byte type = (fieldSchemas == null) ? DataType.findType(o) : fieldSchemas[i].getType();
+			Object upsertValue = convertTypeSpecificValue(o, type, columnMetadataList.get(i).getSqlType());
+
+			if (upsertValue != null) {
+				statement.setObject(i + 1, upsertValue, columnMetadataList.get(i).getSqlType());
+			} else {
+				statement.setNull(i + 1, columnMetadataList.get(i).getSqlType());
+			}
+		}
+		
+		statement.execute();
+	}
+	
+	public void add(Object value) {
+		values.add(value);
+	}
+
+	private Object convertTypeSpecificValue(Object o, byte type, Integer sqlType) {
+		PDataType pDataType = PDataType.fromSqlType(sqlType);
+
+		return TypeUtil.castPigTypeToPhoenix(o, type, pDataType);
+	}
+}

--- a/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixRecordWriter.java
+++ b/src/main/java/com/salesforce/phoenix/pig/hadoop/PhoenixRecordWriter.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.salesforce.phoenix.pig.hadoop;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import com.salesforce.phoenix.pig.PhoenixPigConfiguration;
+
+/**
+ * 
+ * {@link RecordWriter} implementation for Phoenix
+ * 
+ * @author pkommireddi
+ *
+ */
+public class PhoenixRecordWriter extends RecordWriter<NullWritable, PhoenixRecord> {
+	
+	private static final Log LOG = LogFactory.getLog(PhoenixRecordWriter.class);
+	
+	private long numRecords = 0;
+	
+	private final Connection conn;
+	private final PreparedStatement statement;
+	private final PhoenixPigConfiguration config;
+	private final long batchSize;
+	
+	public PhoenixRecordWriter(Connection conn, PhoenixPigConfiguration config) throws SQLException {
+		this.conn = conn;
+		this.config = config;
+		this.batchSize = config.getBatchSize();
+		this.statement = this.conn.prepareStatement(config.getUpsertStatement());
+	}
+
+	/**
+	 * Commit only at the end of task. This should ideally reside in an implementation of
+	 * {@link OutputCommitter} since that will allow us to rollback in case of task failure.
+	 * 
+	 */
+	@Override
+	public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+		try {
+			if (conn == null || conn.isClosed()) {
+				throw new IOException("Trying to commit a connection that is null or closed: "+ conn);
+			}
+		} catch (SQLException e) {
+			throw new IOException("Exception calling isClosed on connection", e);
+		}
+		
+		LOG.info("commit called during close");
+		try {
+			conn.commit();
+		} catch (SQLException e) {
+			throw new IOException("Exception while committing to database." + e);
+		}
+		try {
+			conn.close();
+		} catch (SQLException e) {
+			throw new IOException("Exception while closing database connection." + e);
+		}
+	}
+
+	@Override
+	public void write(NullWritable n, PhoenixRecord record) throws IOException, InterruptedException {		
+		try {
+			record.write(statement, config.getColumnMetadataList());
+			numRecords++;
+			
+			if(numRecords % batchSize == 0) {
+				LOG.info("commit called on a batch of size : "+batchSize);
+				conn.commit();
+			}
+			
+		} catch (SQLException e) {
+			throw new IOException("Exception while committing to database.", e);
+		}		
+	}
+
+}


### PR DESCRIPTION
I made changes to the way we commit transactions to the database. The patch includes Hadoop's OutputFormat and RecordWriter implementations that give us a lot more control over how connections are opened, closed and transactions committed. PhoenixHBaseStorage is a lot better encapsulated now.

The next piece of work would be to implement an OutputCommitter that will allow us to rollback in case of MR task failures. Let's discuss more on how we would want to handle failure scenarios before moving to that.
