### PR TITLE
Fix usage examples

### DIFF
--- a/src/main/java/com/salesforce/phoenix/util/PhoenixRuntime.java
+++ b/src/main/java/com/salesforce/phoenix/util/PhoenixRuntime.java
@@ -109,8 +109,8 @@ public class PhoenixRuntime {
                 "Examples:\n" +
                 "  psql localhost my_ddl.sql\n" +
                 "  psql localhost my_ddl.sql my_table.csv\n" +
-                "  psql my_cluster:1825 -t my_table my_table2012-Q3.csv\n" +
-                "  psql my_cluster -t my_table -h col1,col2,col3 my_table2012-Q3.csv\n"
+                "  psql -t my_table my_cluster:1825 my_table2012-Q3.csv\n" +
+                "  psql -t my_table -h col1,col2,col3 my_cluster:1825 my_table2012-Q3.csv\n"
         );
         System.exit(-1);
     }


### PR DESCRIPTION
I noticed that the usage examples for psql didn't match the actual order of command line parameters. The zookeeper quorum needs to be just before any csv or sql files.
