### PR TITLE
add configuration to max spool to disk

### DIFF
--- a/src/main/java/com/salesforce/phoenix/iterate/SpoolTooBigToDiskException.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/SpoolTooBigToDiskException.java
@@ -1,0 +1,17 @@
+package com.salesforce.phoenix.iterate;
+
+/**
+ * Thrown by {@link com.salesforce.phoenix.iterate.SpoolingResultIterator } when
+ * result is too big to fit into memory and too big to spool to disk.
+ * 
+ * @author haitaoyao
+ * 
+ */
+public class SpoolTooBigToDiskException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public SpoolTooBigToDiskException(String msg) {
+		super(msg);
+	}
+}

--- a/src/main/java/com/salesforce/phoenix/query/QueryServices.java
+++ b/src/main/java/com/salesforce/phoenix/query/QueryServices.java
@@ -143,6 +143,17 @@ public interface QueryServices extends SQLCloseable {
     public static final String THREAD_TIMEOUT_MS_ATTRIB = "phoenix.query.timeoutMs";
     public static final String SPOOL_THRESHOLD_BYTES_ATTRIB = "phoenix.query.spoolThresholdBytes";
     
+    /**
+	 * max size to spool the the result into
+	 * ${java.io.tmpdir}/ResultSpoolerXXX.bin if
+	 * {@link QueryServices#SPOOL_THRESHOLD_BYTES_ATTRIB } is reached.
+	 * <p>
+	 * default is unlimited(-1)
+	 * <p>
+	 * if the threshold is reached, a {@link SpoolTooBigToDiskException } will be thrown 
+	 */
+	public static final String MAX_SPOOL_TO_DISK_BYTES_ATTRIB = "phoenix.query.maxSpoolToDiskBytes";
+    
     public static final String MAX_MEMORY_PERC_ATTRIB = "phoenix.query.maxGlobalMemoryPercentage";
     public static final String MAX_MEMORY_WAIT_MS_ATTRIB = "phoenix.query.maxGlobalMemoryWaitMs";
     public static final String MAX_TENANT_MEMORY_PERC_ATTRIB = "phoenix.query.maxTenantMemoryPercentage";

--- a/src/main/java/com/salesforce/phoenix/query/QueryServicesOptions.java
+++ b/src/main/java/com/salesforce/phoenix/query/QueryServicesOptions.java
@@ -72,6 +72,8 @@ public class QueryServicesOptions {
     public static final int DEFAULT_SCAN_CACHE_SIZE = 1000;
     public static final int DEFAULT_MAX_INTRA_REGION_PARALLELIZATION = DEFAULT_MAX_QUERY_CONCURRENCY;
     
+    public static final long DEFAULT_SPOOL_TO_DISK_BYTES = -1;
+    
     private final Configuration config;
     
     private QueryServicesOptions(Configuration config) {
@@ -119,6 +121,7 @@ public class QueryServicesOptions {
             .setIfUnset(ROW_KEY_ORDER_SALTED_TABLE_ATTRIB, DEFAULT_ROW_KEY_ORDER_SALTED_TABLE)
             .setIfUnset(USE_INDEXES_ATTRIB, DEFAULT_USE_INDEXES)
             .setIfUnset(IMMUTABLE_ROWS_ATTRIB, DEFAULT_IMMUTABLE_ROWS)
+            .setIfUnset(MAX_SPOOL_TO_DISK_BYTES_ATTRIB, DEFAULT_SPOOL_TO_DISK_BYTES);
             ;
         // HBase sets this to 1, so we reset it to something more appropriate.
         // Hopefully HBase will change this, because we can't know if a user set


### PR DESCRIPTION
As the discussion in Dev groups [here](https://groups.google.com/forum/#!topic/phoenix-hbase-dev/QIU40cDWk5k) 
Add another configuration parameter to constrain the size to spool to disk every time. -1 means no limit.
