### PR TITLE
Adding short-circuit skip for indexing codecs.

### DIFF
--- a/src/main/java/com/salesforce/hbase/index/covered/CoveredColumnsIndexBuilder.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/CoveredColumnsIndexBuilder.java
@@ -109,6 +109,9 @@ public class CoveredColumnsIndexBuilder extends BaseIndexBuilder {
 
   @Override
   public Collection<Pair<Mutation, String>> getIndexUpdate(Put p) throws IOException {
+    if (!codec.isEnabled()) {
+      return null;
+    }
     // build the index updates for each group
     IndexUpdateManager updateMap = new IndexUpdateManager();
 
@@ -428,6 +431,9 @@ public class CoveredColumnsIndexBuilder extends BaseIndexBuilder {
 
   @Override
   public Collection<Pair<Mutation, String>> getIndexUpdate(Delete d) throws IOException {
+    if (!codec.isEnabled()) {
+      return null;
+    }
     // stores all the return values
     IndexUpdateManager updateMap = new IndexUpdateManager();
 

--- a/src/main/java/com/salesforce/hbase/index/covered/IndexCodec.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/IndexCodec.java
@@ -29,6 +29,7 @@ package com.salesforce.hbase.index.covered;
 
 import java.io.IOException;
 
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 
@@ -84,4 +85,18 @@ public interface IndexCodec {
  * @throws IOException 
    */
   public Iterable<IndexUpdate> getIndexUpserts(TableState state) throws IOException;
+
+  /**
+   * This allows the codec to dynamically change whether or not indexing should take place for a
+   * table. If it doesn't take place, we can save a lot of time on the regular Put patch. By making
+   * it dynamic, we can save offlining and then onlining a table just to turn indexing on.
+   * <p>
+   * We can also be smart about even indexing a given update here too - if the update doesn't
+   * contain any columns that we care about indexing, we can save the effort of analyzing the put
+   * and further.
+   * @param m mutation that should be indexed.
+   * @return <tt>true</tt> if indexing is enabled for the given table. This should be on a per-table
+   *         basis, as each codec is instantiated per-region.
+   */
+  public boolean isEnabled(Mutation m);
 }

--- a/src/main/java/com/salesforce/hbase/index/covered/example/CoveredColumnIndexCodec.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/example/CoveredColumnIndexCodec.java
@@ -20,12 +20,14 @@ package com.salesforce.hbase.index.covered.example;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -351,5 +353,12 @@ public class CoveredColumnIndexCodec implements IndexCodec {
     }
 
     return true;
+  }
+
+  @Override
+  public boolean isEnabled(Mutation m) {
+    // this could be a bit smarter, looking at the groups for the mutation, but we leave it at this
+    // simple check for the moment.
+    return groups.size() > 0;
   }
 }


### PR DESCRIPTION
Solves a perf problem where, if the index isn't enabled, it still spends a lot of time breaking up the Put/Delete, just for no work. This lets the codec specify if the indexing should even be attempted, on a per-mutation basis.
