### PR TITLE
Adding PhoenixIndexBuilder to handle full index short-circuting.

### DIFF
--- a/src/main/java/com/salesforce/hbase/index/builder/IndexBuilder.java
+++ b/src/main/java/com/salesforce/hbase/index/builder/IndexBuilder.java
@@ -108,4 +108,18 @@ public interface IndexBuilder {
    * @param miniBatchOp the full batch operation to be written
    */
   public void batchStarted(MiniBatchOperationInProgress<Pair<Mutation, Integer>> miniBatchOp);
+
+  /**
+   * This allows the codec to dynamically change whether or not indexing should take place for a
+   * table. If it doesn't take place, we can save a lot of time on the regular Put patch. By making
+   * it dynamic, we can save offlining and then onlining a table just to turn indexing on.
+   * <p>
+   * We can also be smart about even indexing a given update here too - if the update doesn't
+   * contain any columns that we care about indexing, we can save the effort of analyzing the put
+   * and further.
+   * @param m mutation that should be indexed.
+   * @return <tt>true</tt> if indexing is enabled for the given table. This should be on a per-table
+   *         basis, as each codec is instantiated per-region.
+   */
+  public boolean isEnabled(Mutation m);
 }

--- a/src/main/java/com/salesforce/hbase/index/covered/CoveredColumnsIndexBuilder.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/CoveredColumnsIndexBuilder.java
@@ -82,7 +82,7 @@ public class CoveredColumnsIndexBuilder extends BaseIndexBuilder {
   public static final String CODEC_CLASS_NAME_KEY = "com.salesforce.hbase.index.codec.class";
 
   protected RegionCoprocessorEnvironment env;
-  private IndexCodec codec;
+  protected IndexCodec codec;
   protected LocalHBaseState localTable;
 
   @Override
@@ -109,9 +109,6 @@ public class CoveredColumnsIndexBuilder extends BaseIndexBuilder {
 
   @Override
   public Collection<Pair<Mutation, String>> getIndexUpdate(Put p) throws IOException {
-        if (!codec.isEnabled(p)) {
-      return null;
-    }
     // build the index updates for each group
     IndexUpdateManager updateMap = new IndexUpdateManager();
 
@@ -431,9 +428,6 @@ public class CoveredColumnsIndexBuilder extends BaseIndexBuilder {
 
   @Override
   public Collection<Pair<Mutation, String>> getIndexUpdate(Delete d) throws IOException {
-        if (!codec.isEnabled(d)) {
-      return null;
-    }
     // stores all the return values
     IndexUpdateManager updateMap = new IndexUpdateManager();
 

--- a/src/main/java/com/salesforce/phoenix/index/PhoenixIndexBuilder.java
+++ b/src/main/java/com/salesforce/phoenix/index/PhoenixIndexBuilder.java
@@ -25,54 +25,20 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
-package com.salesforce.hbase.index.builder;
-
-import java.io.IOException;
+package com.salesforce.phoenix.index;
 
 import org.apache.hadoop.hbase.client.Mutation;
-import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
-import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
-import org.apache.hadoop.hbase.util.Pair;
 
 import com.salesforce.hbase.index.covered.CoveredColumnsIndexBuilder;
 
 /**
- * Basic implementation of the {@link IndexBuilder} that doesn't do any actual work of indexing.
- * <p>
- * You should extend this class, rather than implementing IndexBuilder directly to maintain
- * compatability going forward.
- * <p>
- * Generally, you should consider using one of the implemented IndexBuilders (e.g
- * {@link CoveredColumnsIndexBuilder}) as there is a lot of work required to keep an index table
- * up-to-date.
+ * Index builder for covered-columns index that ties into phoenix for faster use.
  */
-public abstract class BaseIndexBuilder implements IndexBuilder {
+public class PhoenixIndexBuilder extends CoveredColumnsIndexBuilder {
 
-  @Override
-  public void extendBaseIndexBuilderInstead() { }
-  
-  @Override
-  public void setup(RegionCoprocessorEnvironment conf) throws IOException {
-    // noop
-  }
-
-  @Override
-  public void batchStarted(MiniBatchOperationInProgress<Pair<Mutation, Integer>> miniBatchOp) {
-    // noop
-  }
-
-  @Override
-  public void batchCompleted(MiniBatchOperationInProgress<Pair<Mutation, Integer>> miniBatchOp) {
-    // noop
-  }
-  
-  /**
-   * By default, we always attempt to index the mutation. Commonly this can be slow (because the
-   * framework spends the time to do the indexing, only to realize that you don't need it) or not
-   * ideal (if you want to turn on/off indexing on a table without completely reloading it).
-   */
   @Override
   public boolean isEnabled(Mutation m) {
-    return true; 
+    // ask the codec to see if we should even attempt indexing
+    return this.codec.isEnabled(m);
   }
 }

--- a/src/main/java/com/salesforce/phoenix/index/PhoenixIndexCodec.java
+++ b/src/main/java/com/salesforce/phoenix/index/PhoenixIndexCodec.java
@@ -160,7 +160,9 @@ public class PhoenixIndexCodec implements IndexCodec {
     
   @Override
   public boolean isEnabled(Mutation m) {
-    List<IndexMaintainer> maintainers = getIndexMaintainers(m.getAttributesMap());
-    return maintainers.size() > 0;
+      // TODO cache these maintainers so we don't need to rediscover them later (e.g. when building
+      // the index update)
+      List<IndexMaintainer> maintainers = getIndexMaintainers(m.getAttributesMap());
+      return maintainers.size() > 0;
   }
 }

--- a/src/main/java/com/salesforce/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/src/main/java/com/salesforce/phoenix/query/ConnectionQueryServicesImpl.java
@@ -104,6 +104,7 @@ import com.salesforce.phoenix.exception.PhoenixIOException;
 import com.salesforce.phoenix.exception.SQLExceptionCode;
 import com.salesforce.phoenix.exception.SQLExceptionInfo;
 import com.salesforce.phoenix.execute.MutationState;
+import com.salesforce.phoenix.index.PhoenixIndexBuilder;
 import com.salesforce.phoenix.index.PhoenixIndexCodec;
 import com.salesforce.phoenix.jdbc.PhoenixConnection;
 import com.salesforce.phoenix.jdbc.PhoenixDatabaseMetaData;
@@ -517,7 +518,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
             if (tableType != PTableType.INDEX && !descriptor.hasCoprocessor(Indexer.class.getName())) {
                 Map<String, String> opts = Maps.newHashMapWithExpectedSize(1);
                 opts.put(CoveredColumnsIndexBuilder.CODEC_CLASS_NAME_KEY, PhoenixIndexCodec.class.getName());
-                Indexer.enableIndexing(descriptor, CoveredColumnsIndexBuilder.class, opts);
+                Indexer.enableIndexing(descriptor, PhoenixIndexBuilder.class, opts);
             }
             
             // Setup split policy on Phoenix metadata table to ensure that the key values of a Phoenix table
@@ -834,7 +835,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                     } else if (!existingDesc.hasCoprocessor(Indexer.class.getName())) {
                         Map<String, String> opts = Maps.newHashMapWithExpectedSize(1);
                         opts.put(CoveredColumnsIndexBuilder.CODEC_CLASS_NAME_KEY, PhoenixIndexCodec.class.getName());
-                        Indexer.enableIndexing(existingDesc, CoveredColumnsIndexBuilder.class, opts);
+                        Indexer.enableIndexing(existingDesc, PhoenixIndexBuilder.class, opts);
                         wasModified = true;
                     }
                     if (wasModified) {

--- a/src/main/java/com/salesforce/phoenix/util/CSVLoader.java
+++ b/src/main/java/com/salesforce/phoenix/util/CSVLoader.java
@@ -121,7 +121,9 @@ public class CSVLoader {
     			    if (columnInfo[index] == null) {
     			        continue;
     			    }
-    				upsertValue = convertTypeSpecificValue(nextLine[index], columnInfo[index].getSqlType());
+                    String line = nextLine[index];
+                    Integer info = columnInfo[index].getSqlType();
+                    upsertValue = convertTypeSpecificValue(line, info);
     				if (upsertValue != null) {
     					stmt.setObject(index + 1, upsertValue, columnInfo[index].getSqlType());
     				} else {


### PR DESCRIPTION
Previously, short circuiting only work on the building the index side. However, that meant that
for every mutation we were still checking each KV to see if it was an index type. This lead to a
20% slowdown from the case where indexing codec wasn't even installed.

There is a little bit of work to be done here as we aren't completely smart about managing the
IndexMaintainers - we re-find the set of maintainers for each Mutation everytime we need them. Its
a little bit of an overhead, but not terrible. It can be fixed later if that's still a sticking point.
