### PR TITLE
Wrapping exceptions correctly and ensuring Indexer not unloaded.

### DIFF
--- a/src/main/java/com/salesforce/hbase/index/Indexer.java
+++ b/src/main/java/com/salesforce/hbase/index/Indexer.java
@@ -27,6 +27,8 @@
  ******************************************************************************/
 package com.salesforce.hbase.index;
 
+import static com.salesforce.hbase.index.util.IndexManagementUtil.rethrowIndexingException;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -67,11 +69,12 @@ import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Pair;
 
 import com.google.common.collect.Multimap;
+import com.salesforce.hbase.index.builder.IndexBuildManager;
 import com.salesforce.hbase.index.builder.IndexBuilder;
 import com.salesforce.hbase.index.builder.IndexBuildingFailureException;
-import com.salesforce.hbase.index.exception.IndexWriteException;
 import com.salesforce.hbase.index.table.HTableInterfaceReference;
 import com.salesforce.hbase.index.util.ImmutableBytesPtr;
+import com.salesforce.hbase.index.util.IndexManagementUtil;
 import com.salesforce.hbase.index.wal.IndexedKeyValue;
 import com.salesforce.hbase.index.write.IndexFailurePolicy;
 import com.salesforce.hbase.index.write.IndexWriter;
@@ -208,13 +211,24 @@ public class Indexer extends BaseRegionObserver {
   public void prePut(final ObserverContext<RegionCoprocessorEnvironment> c, final Put put,
       final WALEdit edit, final boolean writeToWAL) throws IOException {
     // just have to add a batch marker to the WALEdit so we get the edit again in the batch
-    // processing step
+    // processing step. We let it throw an exception here because something terrible has happened.
     edit.add(BATCH_MARKER);
   }
 
   @Override
   public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete,
       WALEdit edit, boolean writeToWAL) throws IOException {
+    try {
+      preDeleteWithExceptions(e, delete, edit, writeToWAL);
+    } catch (Throwable t) {
+      rethrowIndexingException(t);
+    }
+    throw new RuntimeException(
+        "Somehow didn't return an index update but also didn't propagate the failure to the client!");
+  }
+
+  public void preDeleteWithExceptions(ObserverContext<RegionCoprocessorEnvironment> e,
+      Delete delete, WALEdit edit, boolean writeToWAL) throws Exception {
     // if we are making the update as part of a batch, we need to add in a batch marker so the WAL
     // is retained
     if (this.builder.getBatchId(delete) != null) {
@@ -230,10 +244,19 @@ public class Indexer extends BaseRegionObserver {
     }
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   public void preBatchMutate(ObserverContext<RegionCoprocessorEnvironment> c,
       MiniBatchOperationInProgress<Pair<Mutation, Integer>> miniBatchOp) throws IOException {
+    try {
+      preBatchMutateWithExceptions(c, miniBatchOp);
+    } catch (Throwable t) {
+      rethrowIndexingException(t);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  public void preBatchMutateWithExceptions(ObserverContext<RegionCoprocessorEnvironment> c,
+      MiniBatchOperationInProgress<Pair<Mutation, Integer>> miniBatchOp) throws Throwable {
 
     // first group all the updates for a single row into a single update to be processed
     Map<ImmutableBytesPtr, MultiMutation> mutations =
@@ -307,7 +330,7 @@ public class Indexer extends BaseRegionObserver {
         if (this.stopped) {
           INDEX_UPDATE_LOCK.unlock();
           throw new IndexBuildingFailureException(
-              "Found server stop after obtaining the update lock, killing update attempt", null);
+              "Found server stop after obtaining the update lock, killing update attempt");
         }
         break;
       } catch (InterruptedException e) {
@@ -405,9 +428,9 @@ public class Indexer extends BaseRegionObserver {
       try {
         this.writer.write(indexUpdates);
         return false;
-      } catch (IndexWriteException e) {
+      } catch (Throwable e) {
         LOG.error("Failed to update index with entries:" + indexUpdates, e);
-        throw new IOException(e);
+        IndexManagementUtil.rethrowIndexingException(e);
       }
     }
 
@@ -438,12 +461,15 @@ public class Indexer extends BaseRegionObserver {
     // noop for the rest of the indexer - its handled by the first call to put/delete
   }
 
-  /**
-   * @param edit
-   * @param writeToWAL
- * @throws IOException 
-   */
   private void doPost(WALEdit edit, Mutation m, boolean writeToWAL) throws IOException {
+    try {
+      doPostWithExceptions(edit, m, writeToWAL);
+    } catch (Throwable e) {
+      rethrowIndexingException(e);
+    }
+  }
+
+  private void doPostWithExceptions(WALEdit edit, Mutation m, boolean writeToWAL) throws Exception {
     //short circuit, if we don't need to do any work
     if (!writeToWAL || !this.builder.isEnabled(m)) {
       // already did the index update in prePut, so we are done

--- a/src/main/java/com/salesforce/hbase/index/builder/IndexBuildingFailureException.java
+++ b/src/main/java/com/salesforce/hbase/index/builder/IndexBuildingFailureException.java
@@ -40,6 +40,15 @@ import org.apache.hadoop.hbase.DoNotRetryIOException;
 public class IndexBuildingFailureException extends DoNotRetryIOException {
 
   /**
+   * Constructor for over the wire propagation. Generally, shouldn't be used since index failure
+   * should have an underlying cause to propagate.
+   * @param msg reason for the failure
+   */
+  public IndexBuildingFailureException(String msg) {
+    super(msg);
+  }
+
+  /**
    * @param msg reason
    * @param cause underlying cause for the failure
    */

--- a/src/main/java/com/salesforce/hbase/index/covered/example/CoveredColumnIndexSpecifierBuilder.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/example/CoveredColumnIndexSpecifierBuilder.java
@@ -12,6 +12,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 
 import com.salesforce.hbase.index.Indexer;
 import com.salesforce.hbase.index.covered.CoveredColumnsIndexBuilder;
+import com.salesforce.hbase.index.covered.IndexCodec;
 
 /**
  * Helper to build the configuration for the {@link CoveredColumnIndexer}.
@@ -111,9 +112,13 @@ public class CoveredColumnIndexSpecifierBuilder {
   }
 
   public void build(HTableDescriptor desc) throws IOException {
+    build(desc, CoveredColumnIndexCodec.class);
+  }
+
+  void build(HTableDescriptor desc, Class<? extends IndexCodec> clazz) throws IOException {
     // add the codec for the index to the map of options
     Map<String, String> opts = this.convertToMap();
-    opts.put(CoveredColumnsIndexBuilder.CODEC_CLASS_NAME_KEY, CoveredColumnIndexCodec.class.getName());
+    opts.put(CoveredColumnsIndexBuilder.CODEC_CLASS_NAME_KEY, clazz.getName());
     Indexer.enableIndexing(desc, CoveredColumnIndexer.class, opts);
   }
 

--- a/src/main/java/com/salesforce/hbase/index/exception/IndexWriteException.java
+++ b/src/main/java/com/salesforce/hbase/index/exception/IndexWriteException.java
@@ -27,11 +27,13 @@
  ******************************************************************************/
 package com.salesforce.hbase.index.exception;
 
+import org.apache.hadoop.hbase.HBaseIOException;
+
 /**
  * Generic {@link Exception} that an index write has failed
  */
 @SuppressWarnings("serial")
-public class IndexWriteException extends Exception {
+public class IndexWriteException extends HBaseIOException {
 
   public IndexWriteException() {
     super();

--- a/src/main/java/com/salesforce/hbase/index/util/IndexManagementUtil.java
+++ b/src/main/java/com/salesforce/hbase/index/util/IndexManagementUtil.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
@@ -42,6 +44,7 @@ import org.apache.hadoop.hbase.regionserver.wal.WALEditCodec;
 
 import com.google.common.collect.Maps;
 import com.salesforce.hbase.index.ValueGetter;
+import com.salesforce.hbase.index.builder.IndexBuildingFailureException;
 import com.salesforce.hbase.index.covered.data.LazyValueGetter;
 import com.salesforce.hbase.index.covered.update.ColumnReference;
 import com.salesforce.hbase.index.scanner.Scanner;
@@ -55,6 +58,7 @@ public class IndexManagementUtil {
     // private ctor for util classes
   }
 
+  private static final Log LOG = LogFactory.getLog(IndexManagementUtil.class);
   public static String HLOG_READER_IMPL_KEY = "hbase.regionserver.hlog.reader.impl";
 
   public static void ensureMutableIndexingCorrectlyConfigured(Configuration conf)
@@ -203,5 +207,22 @@ public class IndexManagementUtil {
       }
       s.setMaxVersions();
       return s;
+  }
+
+  /**
+   * Propagate the given failure as a generic {@link IOException}, if it isn't already
+   * @param e reason indexing failed. If ,tt>null</tt>, throws a {@link NullPointerException}, which
+   *          should unload the coprocessor.
+   */
+  public static void rethrowIndexingException(Throwable e) throws IOException {
+    try {
+      throw e;
+    } catch (IOException e1) {
+      LOG.info("Rethrowing " + e);
+      throw e1;
+    } catch (Throwable e1) {
+      LOG.info("Rethrowing " + e1 + " as a " + IndexBuildingFailureException.class.getSimpleName());
+      throw new IndexBuildingFailureException("Failed to build index for unexpected reason!", e1);
+    }
   }
 }

--- a/src/test/java/com/salesforce/hbase/index/covered/example/TestFailWithoutRetries.java
+++ b/src/test/java/com/salesforce/hbase/index/covered/example/TestFailWithoutRetries.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.hbase.index.covered.example;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.MultiResponse;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.salesforce.hbase.index.IndexTestingUtils;
+import com.salesforce.hbase.index.Indexer;
+import com.salesforce.hbase.index.TableName;
+import com.salesforce.hbase.index.covered.IndexUpdate;
+import com.salesforce.hbase.index.covered.TableState;
+import com.salesforce.hbase.index.util.IndexManagementUtil;
+import com.salesforce.phoenix.index.BaseIndexCodec;
+
+/**
+ * If {@link DoNotRetryIOException} is not subclassed correctly (with the {@link String}
+ * constructor), {@link MultiResponse#readFields(java.io.DataInput)} will not correctly deserialize
+ * the exception, and just return <tt>null</tt> to the client, which then just goes and retries.
+ */
+public class TestFailWithoutRetries {
+
+  private static final Log LOG = LogFactory.getLog(TestFailWithoutRetries.class);
+  @Rule
+  public TableName table = new TableName();
+
+  private static final HBaseTestingUtility UTIL = new HBaseTestingUtility();
+
+  private String getIndexTableName() {
+    return Bytes.toString(table.getTableName()) + "_index";
+  }
+
+  public static class FailingTestCodec extends BaseIndexCodec {
+
+    @Override
+    public Iterable<IndexUpdate> getIndexDeletes(TableState state) throws IOException {
+      throw new RuntimeException("Intentionally failing deletes for "
+          + TestFailWithoutRetries.class.getName());
+    }
+
+    @Override
+    public Iterable<IndexUpdate> getIndexUpserts(TableState state) throws IOException {
+      throw new RuntimeException("Intentionally failing upserts for "
+          + TestFailWithoutRetries.class.getName());
+    }
+
+  }
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    // setup and verify the config
+    Configuration conf = UTIL.getConfiguration();
+    IndexTestingUtils.setupConfig(conf);
+    IndexManagementUtil.ensureMutableIndexingCorrectlyConfigured(conf);
+    // start the cluster
+    UTIL.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardownCluster() throws Exception {
+    UTIL.shutdownMiniCluster();
+  }
+
+  /**
+   * If this test times out, then we didn't fail quickly enough. {@link Indexer} maybe isn't
+   * rethrowing the exception correctly?
+   * <p>
+   * We use a custom codec to enforce the thrown exception.
+   * @throws Exception
+   */
+  @Test(timeout = 300000)
+  public void testQuickFailure() throws Exception {
+    // incorrectly setup indexing for the primary table - target index table doesn't exist, which
+    // should quickly return to the client
+    byte[] family = Bytes.toBytes("family");
+    ColumnGroup fam1 = new ColumnGroup(getIndexTableName());
+    // values are [col1]
+    fam1.add(new CoveredColumn(family, CoveredColumn.ALL_QUALIFIERS));
+    CoveredColumnIndexSpecifierBuilder builder = new CoveredColumnIndexSpecifierBuilder();
+    // add the index family
+    builder.addIndexGroup(fam1);
+    // usually, we would create the index table here, but we don't for the sake of the test.
+
+    // setup the primary table
+    String primaryTable = Bytes.toString(table.getTableName());
+    HTableDescriptor pTable = new HTableDescriptor(primaryTable);
+    pTable.addFamily(new HColumnDescriptor(family));
+    // override the codec so we can use our test one
+    builder.build(pTable, FailingTestCodec.class);
+
+    // create the primary table
+    HBaseAdmin admin = UTIL.getHBaseAdmin();
+    admin.createTable(pTable);
+    Configuration conf = new Configuration(UTIL.getConfiguration());
+    // up the number of retries/wait time to make it obvious that we are failing with retries here
+    conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 20);
+    conf.setLong(HConstants.HBASE_CLIENT_PAUSE, 1000);
+    HTable primary = new HTable(conf, primaryTable);
+    primary.setAutoFlush(false);
+
+    // do a simple put that should be indexed
+    Put p = new Put(Bytes.toBytes("row"));
+    p.add(family, null, Bytes.toBytes("value"));
+    primary.put(p);
+    try {
+      primary.flushCommits();
+      fail("Shouldn't have gotten a successful write to the primary table");
+    } catch (RetriesExhaustedWithDetailsException e) {
+      LOG.info("Correclty got a failure of the put!");
+    }
+  }
+}


### PR DESCRIPTION
- Wrapping exceptions consistently to ensure that we correctly have a DoNotRetryIOException (see comments on IndexBuildingFailureException).
- wrapping all the calls in Indexer to rethrow exceptions back to the client such that the Indexer is not unloaded if it gets a RuntimeException (in practice, wrapping any non-IOException)
