### PR TITLE
Fixing handling of deletes in ApplyAndFilterDeletesFilter

### DIFF
--- a/src/main/java/com/salesforce/hbase/index/covered/LocalTableState.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/LocalTableState.java
@@ -78,7 +78,7 @@ public class LocalTableState implements TableState {
     this.env = environment;
     this.table = table;
     this.update = update;
-    this.memstore = new IndexMemStore(IndexMemStore.COMPARATOR);
+    this.memstore = new IndexMemStore();
     this.scannerBuilder = new ScannerBuilder(memstore, update);
     this.columnSet = new CoveredColumns();
   }

--- a/src/main/java/com/salesforce/hbase/index/covered/data/IndexMemStore.java
+++ b/src/main/java/com/salesforce/hbase/index/covered/data/IndexMemStore.java
@@ -105,12 +105,18 @@ public class IndexMemStore implements KeyValueStore {
     }
   };
 
+  public IndexMemStore() {
+    this(COMPARATOR);
+  }
+
   /**
    * Create a store with the given comparator. This comparator is used to determine both sort order
    * <b>as well as equality of {@link KeyValue}s</b>.
+   * <p>
+   * Exposed for subclassing/testing.
    * @param comparator to use
    */
-  public IndexMemStore(Comparator<KeyValue> comparator) {
+  IndexMemStore(Comparator<KeyValue> comparator) {
     this.comparator = comparator;
     this.kvset = IndexKeyValueSkipListSet.create(comparator);
   }

--- a/src/main/java/com/salesforce/hbase/index/scanner/ScannerBuilder.java
+++ b/src/main/java/com/salesforce/hbase/index/scanner/ScannerBuilder.java
@@ -1,9 +1,10 @@
 package com.salesforce.hbase.index.scanner;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Mutation;
@@ -22,6 +23,7 @@ import com.salesforce.hbase.index.covered.filter.ColumnTrackingNextLargestTimest
 import com.salesforce.hbase.index.covered.filter.MaxTimestampFilter;
 import com.salesforce.hbase.index.covered.update.ColumnReference;
 import com.salesforce.hbase.index.covered.update.ColumnTracker;
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 
 /**
  *
@@ -66,7 +68,7 @@ public class ScannerBuilder {
     // filter out things with a newer timestamp
     filters.addFilter(new MaxTimestampFilter(ts));
     // filter out kvs based on deletes
-    List<byte[]> families = getAllFamilies(columns);
+    Set<ImmutableBytesPtr> families = getAllFamilies(columns);
     filters.addFilter(new ApplyAndFilterDeletesFilter(families));
     return getFilteredScanner(filters);
   }
@@ -96,10 +98,11 @@ public class ScannerBuilder {
     return columnFilters;
   }
 
-  private List<byte[]> getAllFamilies(Collection<? extends ColumnReference> columns) {
-    List<byte[]> families = new ArrayList<byte[]>(columns.size());
+  private Set<ImmutableBytesPtr>
+      getAllFamilies(Collection<? extends ColumnReference> columns) {
+    Set<ImmutableBytesPtr> families = new HashSet<ImmutableBytesPtr>();
     for (ColumnReference ref : columns) {
-      families.add(ref.getFamily());
+      families.add(new ImmutableBytesPtr(ref.getFamily()));
     }
     return families;
   }

--- a/src/test/java/com/salesforce/hbase/index/covered/TestLocalTableState.java
+++ b/src/test/java/com/salesforce/hbase/index/covered/TestLocalTableState.java
@@ -200,4 +200,7 @@ public class TestLocalTableState {
     Mockito.verify(env, Mockito.times(1)).getRegion();
     Mockito.verify(region, Mockito.times(1)).getScanner(Mockito.any(Scan.class));
   }
+
+  // TODO add test here for making sure multiple column references with the same column family don't
+  // cause an infinite loop
 }

--- a/src/test/java/com/salesforce/hbase/index/covered/filter/TestApplyAndFilterDeletesFilter.java
+++ b/src/test/java/com/salesforce/hbase/index/covered/filter/TestApplyAndFilterDeletesFilter.java
@@ -31,6 +31,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValue.Type;
@@ -38,11 +40,15 @@ import org.apache.hadoop.hbase.filter.Filter.ReturnCode;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
+
 /**
  * Test filter to ensure that it correctly handles KVs of different types correctly
  */
 public class TestApplyAndFilterDeletesFilter {
 
+  private static final Set<ImmutableBytesPtr> EMPTY_SET = Collections
+      .<ImmutableBytesPtr> emptySet();
   private byte[] row = Bytes.toBytes("row");
   private byte[] family = Bytes.toBytes("family");
   private byte[] qualifier = Bytes.toBytes("qualifier");
@@ -51,20 +57,17 @@ public class TestApplyAndFilterDeletesFilter {
 
   @Test
   public void testDeletesAreNotReturned() {
-    KeyValue kv =createKvForType(Type.Delete);
-    ApplyAndFilterDeletesFilter filter =
-        new ApplyAndFilterDeletesFilter(Collections.<byte[]> emptyList());
+    KeyValue kv = createKvForType(Type.Delete);
+    ApplyAndFilterDeletesFilter filter = new ApplyAndFilterDeletesFilter(EMPTY_SET);
     assertEquals("Didn't skip point delete!", ReturnCode.SKIP, filter.filterKeyValue(kv));
 
     filter.reset();
     kv = createKvForType(Type.DeleteColumn);
-    assertEquals("Didn't seek from column delete!", ReturnCode.SEEK_NEXT_USING_HINT,
-      filter.filterKeyValue(kv));
+    assertEquals("Didn't skip from column delete!", ReturnCode.SKIP, filter.filterKeyValue(kv));
 
     filter.reset();
     kv = createKvForType(Type.DeleteFamily);
-    assertEquals("Didn't seek from family delete!", ReturnCode.SEEK_NEXT_USING_HINT,
-      filter.filterKeyValue(kv));
+    assertEquals("Didn't skip from family delete!", ReturnCode.SKIP, filter.filterKeyValue(kv));
   }
 
   /**
@@ -75,26 +78,33 @@ public class TestApplyAndFilterDeletesFilter {
   public void testHintCorrectlyToNextFamily() {
     // start with doing a family delete, so we will seek to the next column
     KeyValue kv = createKvForType(Type.DeleteFamily);
-    ApplyAndFilterDeletesFilter filter =
-        new ApplyAndFilterDeletesFilter(Collections.<byte[]> emptyList());
-    filter.filterKeyValue(kv);
+    ApplyAndFilterDeletesFilter filter = new ApplyAndFilterDeletesFilter(EMPTY_SET);
+    assertEquals(ReturnCode.SKIP, filter.filterKeyValue(kv));
+    KeyValue next = createKvForType(Type.Put);
     // make sure the hint is our attempt at the end key, because we have no more families to seek
+    assertEquals("Didn't get a hint from a family delete", ReturnCode.SEEK_NEXT_USING_HINT,
+      filter.filterKeyValue(next));
     assertEquals("Didn't get END_KEY with no families to match", KeyValue.LOWESTKEY,
-      filter.getNextKeyHint(kv));
+      filter.getNextKeyHint(next));
 
     // check for a family that comes before our family, so we always seek to the end as well
-    filter = new ApplyAndFilterDeletesFilter(Collections.singletonList(Bytes.toBytes("afamily")));
-    filter.filterKeyValue(kv);
+    filter = new ApplyAndFilterDeletesFilter(asSet(Bytes.toBytes("afamily")));
+    assertEquals(ReturnCode.SKIP, filter.filterKeyValue(kv));
     // make sure the hint is our attempt at the end key, because we have no more families to seek
+    assertEquals("Didn't get a hint from a family delete", ReturnCode.SEEK_NEXT_USING_HINT,
+      filter.filterKeyValue(next));
     assertEquals("Didn't get END_KEY with no families to match", KeyValue.LOWESTKEY,
-      filter.getNextKeyHint(kv));
+      filter.getNextKeyHint(next));
 
     // check that we seek to the correct family that comes after our family
     byte[] laterFamily = Bytes.toBytes("zfamily");
-    filter = new ApplyAndFilterDeletesFilter(Collections.singletonList(laterFamily));
-    filter.filterKeyValue(kv);
-    KeyValue next = KeyValue.createFirstOnRow(kv.getRow(), laterFamily, new byte[0]);
-    assertEquals("Didn't get correct next key with a next family", next, filter.getNextKeyHint(kv));
+    filter = new ApplyAndFilterDeletesFilter(asSet(laterFamily));
+    assertEquals(ReturnCode.SKIP, filter.filterKeyValue(kv));
+    KeyValue expected = KeyValue.createFirstOnRow(kv.getRow(), laterFamily, new byte[0]);
+    assertEquals("Didn't get a hint from a family delete", ReturnCode.SEEK_NEXT_USING_HINT,
+      filter.filterKeyValue(next));
+    assertEquals("Didn't get correct next key with a next family", expected,
+      filter.getNextKeyHint(next));
   }
 
   /**
@@ -105,8 +115,7 @@ public class TestApplyAndFilterDeletesFilter {
   public void testCoveringPointDelete() {
     // start with doing a family delete, so we will seek to the next column
     KeyValue kv = createKvForType(Type.Delete);
-    ApplyAndFilterDeletesFilter filter =
-        new ApplyAndFilterDeletesFilter(Collections.<byte[]> emptyList());
+    ApplyAndFilterDeletesFilter filter = new ApplyAndFilterDeletesFilter(EMPTY_SET);
     filter.filterKeyValue(kv);
     KeyValue put = createKvForType(Type.Put);
     assertEquals("Didn't filter out put with same timestamp!", ReturnCode.SKIP,
@@ -138,15 +147,46 @@ public class TestApplyAndFilterDeletesFilter {
    */
   @Test
   public void testCoverForDeleteColumn() throws Exception {
-    ApplyAndFilterDeletesFilter filter =
-        new ApplyAndFilterDeletesFilter(Collections.<byte[]> emptyList());
+    ApplyAndFilterDeletesFilter filter = new ApplyAndFilterDeletesFilter(EMPTY_SET);
     KeyValue dc = createKvForType(Type.DeleteColumn, 11);
     KeyValue put = createKvForType(Type.Put, 10);
-    assertEquals("Didn't filter out delete column.", ReturnCode.SEEK_NEXT_USING_HINT,
-      filter.filterKeyValue(dc));
+    assertEquals("Didn't filter out delete column.", ReturnCode.SKIP, filter.filterKeyValue(dc));
+    assertEquals("Didn't get a seek hint for the deleted column", ReturnCode.SEEK_NEXT_USING_HINT,
+      filter.filterKeyValue(put));
     // seek past the given put
-    KeyValue seek = filter.getNextKeyHint(dc);
+    KeyValue seek = filter.getNextKeyHint(put);
     assertTrue("Seeked key wasn't past the expected put - didn't skip the column",
       KeyValue.COMPARATOR.compare(seek, put) > 0);
+  }
+
+  /**
+   * DeleteFamily markers should delete everything from that timestamp backwards, but not hide
+   * anything forwards
+   */
+  @Test
+  public void testDeleteFamilyCorrectlyCoversColumns() {
+    ApplyAndFilterDeletesFilter filter = new ApplyAndFilterDeletesFilter(EMPTY_SET);
+    KeyValue df = createKvForType(Type.DeleteFamily, 11);
+    KeyValue put = createKvForType(Type.Put, 12);
+
+    assertEquals("Didn't filter out delete family", ReturnCode.SKIP, filter.filterKeyValue(df));
+    assertEquals("Filtered out put with newer TS than delete family", ReturnCode.INCLUDE,
+      filter.filterKeyValue(put));
+
+    // older kv shouldn't be visible
+    put = createKvForType(Type.Put, 10);
+    assertEquals("Didn't filter out older put, covered by DeleteFamily marker",
+      ReturnCode.SEEK_NEXT_USING_HINT, filter.filterKeyValue(put));
+
+    // next seek should be past the families
+    assertEquals(KeyValue.LOWESTKEY, filter.getNextKeyHint(put));
+  }
+
+  private static Set<ImmutableBytesPtr> asSet(byte[]... strings) {
+    Set<ImmutableBytesPtr> set = new HashSet<ImmutableBytesPtr>();
+    for (byte[] s : strings) {
+      set.add(new ImmutableBytesPtr(s));
+    }
+    return set;
   }
 }

--- a/src/test/java/com/salesforce/phoenix/end2end/index/MutableIndexTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/index/MutableIndexTest.java
@@ -14,15 +14,10 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableNotFoundException;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
-import com.salesforce.phoenix.jdbc.PhoenixConnection;
-import com.salesforce.phoenix.query.ConnectionQueryServices;
 import com.salesforce.phoenix.query.QueryServices;
 import com.salesforce.phoenix.util.QueryUtil;
 import com.salesforce.phoenix.util.ReadOnlyProps;
@@ -38,28 +33,6 @@ public class MutableIndexTest extends BaseMutableIndexTest {
         props.put(QueryServices.INDEX_MUTATE_BATCH_SIZE_THRESHOLD_ATTRIB, Integer.toString(2));
         // Must update config before starting server
         startServer(getUrl(), new ReadOnlyProps(props.entrySet().iterator()));
-    }
-        
-    @Before // FIXME: this shouldn't be necessary, but the tests hang without it.
-    public void destroyTables() throws Exception {
-        // Physically delete HBase table so that splits occur as expected for each test
-        Properties props = new Properties(TEST_PROPERTIES);
-        ConnectionQueryServices services = DriverManager.getConnection(getUrl(), props).unwrap(PhoenixConnection.class).getQueryServices();
-        HBaseAdmin admin = services.getAdmin();
-        try {
-            try {
-                admin.disableTable(INDEX_TABLE_FULL_NAME);
-                admin.deleteTable(INDEX_TABLE_FULL_NAME);
-            } catch (TableNotFoundException e) {
-            }
-            try {
-                admin.disableTable(DATA_TABLE_FULL_NAME);
-                admin.deleteTable(DATA_TABLE_FULL_NAME);
-            } catch (TableNotFoundException e) {
-            }
-       } finally {
-                admin.close();
-        }
     }
     
     @Test


### PR DESCRIPTION
It was causing an infinite loop when there were duplicate CFs added to the filter.
Further, it wasn't handling the delete/put ordering correctly, which later lead
to incorrect indexes being constructed in the tests.

Allows removal of the "destroy tables" stuff in MutableIndexTest, since handle the Phoenix 'table delete' tombstones properly.
