### PR TITLE
Removing the superflous setNanos()

### DIFF
--- a/src/main/java/com/salesforce/phoenix/schema/PDataType.java
+++ b/src/main/java/com/salesforce/phoenix/schema/PDataType.java
@@ -1586,7 +1586,6 @@ public enum PDataType {
             switch (actualType) {
             case TIMESTAMP:
                 Timestamp v = new Timestamp(Bytes.toLong(b, o, Bytes.SIZEOF_LONG));
-                v.setNanos(Bytes.toInt(b, o + Bytes.SIZEOF_LONG, Bytes.SIZEOF_INT));
                 return v;
             case DATE:
             case TIME:


### PR DESCRIPTION
newTimeStamp(long) - itself correctly initializes the nanos part so the following setNanos(int) call is not really needed. This should also take care of the issue: https://github.com/forcedotcom/phoenix/issues/547. 
