### PR TITLE
Enable a minimal jar and a minimal client jar on calls to mvn package.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,23 @@
               </descriptors>
             </configuration>
           </execution>
+          <execution>
+            <id>client-minimal</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <attach>false</attach>
+              <appendAssemblyId>true</appendAssemblyId>
+              <descriptors>
+                <!-- build the phoenix client jar, but without HBase code. -->
+                <descriptor>src/build/client-without-hbase.xml</descriptor>
+                <!-- build the phoenix client jar, but without HBase (or its depenencies). -->
+                <descriptor>src/build/client-minimal.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/src/build/client-minimal.xml
+++ b/src/build/client-minimal.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <!-- Often clients want to use Phoenix in an existing HBase environment (they have 
+    their own HBase version already built), so the standard HBase jar shouldn't be included 
+    (as with the regular client jar) as it will conflict the installed version. This 
+    profile does the same thing as the client.xml build, but excludes the hbase stuff. -->
+  <id>client-minimal</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <componentDescriptors>
+    <componentDescriptor>src/build/components-minimal.xml</componentDescriptor>
+  </componentDescriptors>
+</assembly>

--- a/src/build/client-without-hbase.xml
+++ b/src/build/client-without-hbase.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <!-- Often clients want to use Phoenix in an existing HBase environment (they have 
+    their own HBase version already built), so the standard HBase jar shouldn't be included 
+    (as with the regular client jar) as it will conflict the installed version. This 
+    profile does the same thing as the client.xml build, but excludes the hbase stuff. -->
+  <id>client-without-hbase</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <componentDescriptors>
+    <componentDescriptor>src/build/components-minimal.xml</componentDescriptor>
+    <componentDescriptor>src/build/components-major-client.xml</componentDescriptor>
+  </componentDescriptors>
+</assembly>

--- a/src/build/client.xml
+++ b/src/build/client.xml
@@ -2,10 +2,17 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
   <id>client</id>
+  <!-- All the dependencies (unpacked) necessary to run phoenix from a single, stand-alone jar -->
   <formats>
     <format>jar</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
+  
+  <componentDescriptors>
+    <componentDescriptor>src/build/components-minimal.xml</componentDescriptor>
+    <componentDescriptor>src/build/components-major-client.xml</componentDescriptor>
+  </componentDescriptors>
+
   <dependencySets>
     <dependencySet>
       <!-- Unpack all the dependencies to class files, since java doesn't support 
@@ -13,72 +20,11 @@
       <unpack>true</unpack>
       <!-- save these dependencies to the top-level -->
       <outputDirectory>/</outputDirectory>
-      <!-- Maybe a blacklist is easier? -->
       <includes>
-        <include>commons-configuration:commons-configuration</include>
-        <include>commons-io:commons-io</include>
-        <include>commons-lang:commons-lang</include>
-        <include>commons-logging:commons-logging</include>
-	<include>commons-cli:commons-cli</include>
-        <include>com.google.guava:guava</include>
-        <include>org.apache.hadoop:hadoop*</include>
-        <include>com.google.protobuf:protobuf-java</include>
-        <include>org.slf4j:slf4j-api</include>
-        <include>org.slf4j:slf4j-log4j12</include>
-        <include>org.apache.zookeeper:zookeeper</include>
-        <include>log4j:log4j</include>
-        <include>org.apache.hbase:hbase*</include>
-        <include>net.sf.opencsv:opencsv</include>
-        <include>org.antlr:antlr*</include>
         <include>jline:jline</include>
         <include>sqlline:sqlline</include>
-	<include>org.codehaus.jackson:jackson-mapper-asl</include>
-	<include>org.codehaus.jackson:jackson-core-asl</include>
-            
-        <!-- <include>*:jar:*</include> -->
+        <include>org.apache.hbase:hbase*</include>
       </includes>
-    </dependencySet>
-
-    <dependencySet>
-        <outputDirectory>/</outputDirectory>
-        <unpack>true</unpack>
-        <scope>system</scope>
     </dependencySet>
   </dependencySets>
-
-  <fileSets>
-    <!-- Add the compiled classes so we can just run the jar immediately -->
-    <fileSet>
-      <directory>${project.build.directory}/classes/com</directory>
-      <outputDirectory>/com</outputDirectory>
-      <fileMode>0755</fileMode>
-      <directoryMode>0755</directoryMode>
-    </fileSet>
-    <fileSet>
-      <!--Get application resources -->
-      <directory>src/main/external_resources</directory>
-      <outputDirectory>/</outputDirectory>
-    </fileSet>
-    <fileSet>
-    <!--Get misc project files -->
-      <directory>${project.basedir}</directory>
-      <outputDirectory>/</outputDirectory>
-      <includes>
-        <include>*.txt*</include>
-        <include>*.md</include>
-        <include>NOTICE*</include>
-      </includes>
-      <excludes>
-        <exclude>build.txt</exclude>
-      </excludes>
-    </fileSet>
-    <fileSet>
-    <!--Get map-red-config properties files -->
-      <directory>${project.basedir}/src/main/config</directory>
-      <outputDirectory>/</outputDirectory>
-      <includes>
-	<include>csv-bulk-load-config.properties</include>
-      </includes>
-    </fileSet>
-  </fileSets>
 </assembly>

--- a/src/build/components-major-client.xml
+++ b/src/build/components-major-client.xml
@@ -1,0 +1,31 @@
+<component>
+  <!-- Components that the client needs (except for HBase) -->
+  <dependencySets>
+    <dependencySet>
+      <!-- Unpack all the dependencies to class files, since java doesn't support 
+        jar of jars for running -->
+      <unpack>true</unpack>
+      <!-- save these dependencies to the top-level -->
+      <outputDirectory>/</outputDirectory>
+      <!-- Maybe a blacklist is easier? -->
+      <includes>
+        <!-- We use a newer version of guava than HBase - this might be an issue? -->
+        <include>com.google.guava:guava</include>
+        <!-- HBase also pulls in these dependencies on its own, should we include-them? -->
+        <include>com.google.protobuf:protobuf-java</include>
+        <include>org.slf4j:slf4j-api</include>
+        <include>org.slf4j:slf4j-log4j12</include>
+        <include>org.apache.zookeeper:zookeeper</include>
+        <include>log4j:log4j</include>
+        <include>org.apache.hadoop:hadoop*</include>
+        <include>commons-configuration:commons-configuration</include>
+        <include>commons-io:commons-io</include>
+        <include>commons-logging:commons-logging</include>
+        <include>commons-lang:commons-lang</include>
+        <include>commons-cli:commons-cli</include>
+        <include>org.codehaus.jackson:jackson-mapper-asl</include>
+        <include>org.codehaus.jackson:jackson-core-asl</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+</component>

--- a/src/build/components-minimal.xml
+++ b/src/build/components-minimal.xml
@@ -1,0 +1,59 @@
+<component>
+  <!-- Just the basic components that Phoenix pulls in, that is not a transitive dependency from Hadoop/HBase/Pig -->
+  <dependencySets>
+    <dependencySet>
+      <!-- Unpack all the dependencies to class files, since java doesn't support 
+        jar of jars for running -->
+      <unpack>true</unpack>
+      <!-- save these dependencies to the top-level -->
+      <outputDirectory>/</outputDirectory>
+      <!-- Just include the extra things that phoenix needs -->
+      <includes>
+        <include>net.sf.opencsv:opencsv</include>
+        <include>org.antlr:antlr*</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <unpack>true</unpack>
+      <scope>system</scope>
+    </dependencySet>
+  </dependencySets>
+
+  <fileSets>
+    <!-- Add the compiled classes so we can just run the jar immediately -->
+    <fileSet>
+      <directory>${project.build.directory}/classes/com</directory>
+      <outputDirectory>/com</outputDirectory>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
+    <fileSet>
+      <!--Get application resources -->
+      <directory>src/main/external_resources</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <!--Get misc project files -->
+      <directory>${project.basedir}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>*.txt*</include>
+        <include>*.md</include>
+        <include>NOTICE*</include>
+      </includes>
+      <excludes>
+        <exclude>build.txt</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <!--Get map-red-config properties files -->
+      <directory>${project.basedir}/src/main/config</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>csv-bulk-load-config.properties</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</component>


### PR DESCRIPTION
This also does some cleanup of the build specs to reuse the dependencies
in component descriptors. Means less duplication across the different
assembly descriptors, and less chance for mistake
