### PR TITLE
Adding ClientKeyValue support to phoenix

### DIFF
--- a/src/main/java/com/salesforce/hbase/index/util/ImmutableBytesPtr.java
+++ b/src/main/java/com/salesforce/hbase/index/util/ImmutableBytesPtr.java
@@ -104,10 +104,13 @@ public class ImmutableBytesPtr extends ImmutableBytesWritable {
      * @return the backing byte array, copying only if necessary
      */
     public byte[] copyBytesIfNecessary() {
-        if (this.getOffset() == 0 && this.getLength() == this.get().length) {
-            return this.get();
-        }
-        return this.copyBytes();
+    return copyBytesIfNecessary(this);
     }
 
+  public static byte[] copyBytesIfNecessary(ImmutableBytesWritable ptr) {
+    if (ptr.getOffset() == 0 && ptr.getLength() == ptr.get().length) {
+      return ptr.get();
+    }
+    return ptr.copyBytes();
+  }
 }

--- a/src/main/java/com/salesforce/phoenix/client/ClientKeyValue.java
+++ b/src/main/java/com/salesforce/phoenix/client/ClientKeyValue.java
@@ -1,0 +1,496 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.phoenix.client;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * {@link KeyValue} that should only be used from the client side. Enables clients to be more
+ * flexible with the byte arrays they use when building a {@link KeyValue}, but still wire
+ * compatible.
+ * <p>
+ * All<tt> byte[]</tt> (or {@link ImmutableBytesWritable}) passed into the constructor are only ever
+ * read once - when writing <tt>this</tt> onto the wire. They are never copied into another array or
+ * reused. This has the advantage of being much more efficient than the usual {@link KeyValue}
+ * <p>
+ * The down side is that we no longer can support some of the usual methods like
+ * {@link #getBuffer()} or {@link #getKey()} since its is backed with multiple <tt>byte[]</tt> and
+ * <i>should only be used by the client to <b>send</b> information</i>
+ * <p>
+ * <b>WARNING:</b> should only be used by advanced users who know how to construct their own
+ * KeyValues
+ */
+public class ClientKeyValue extends KeyValue {
+
+  private static ImmutableBytesWritable NULL = new ImmutableBytesWritable(new byte[0]);
+  private ImmutableBytesWritable row;
+  private ImmutableBytesWritable family;
+  private ImmutableBytesWritable qualifier;
+  private Type type;
+  private long ts;
+  private ImmutableBytesWritable value;
+
+  /**
+   * @param row must not be <tt>null</tt>
+   * @param type must not be <tt>null</tt>
+   */
+  public ClientKeyValue(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, Type type, ImmutableBytesWritable value) {
+    this.row = row;
+    this.family = family == null ? NULL : family;
+    this.qualifier = qualifier == null ? NULL : qualifier;
+    this.type = type;
+    this.ts = ts;
+    this.value = value == null ? NULL : value;
+  }
+
+  /**
+   * Convenience constructor that just wraps all the bytes in {@link ImmutableBytesWritable}
+   */
+  public ClientKeyValue(byte[] row, byte[] family, byte[] qualifier, long ts, Type t, byte[] value) {
+    this(wrap(row), wrap(family), wrap(qualifier), ts, t, wrap(value));
+  }
+
+  /**
+   * Convenience constructor that just wraps all the bytes in {@link ImmutableBytesWritable}
+   */
+  public ClientKeyValue(byte[] row, byte[] family, byte[] qualifier, long ts, Type t) {
+    this(wrap(row), wrap(family), wrap(qualifier), ts, t, null);
+  }
+
+  private static ImmutableBytesWritable wrap(byte[] b) {
+    return b == null ? NULL : new ImmutableBytesWritable(b);
+  }
+
+  @Override
+  public KeyValue clone() {
+    return new ClientKeyValue(copy(row), copy(family), copy(qualifier), ts, type, copy(value));
+  }
+
+  private ImmutableBytesWritable copy(ImmutableBytesWritable bytes) {
+    return new ImmutableBytesWritable(bytes.copyBytes());
+  }
+
+  private static byte[] copyIfNecessary(ImmutableBytesWritable bytes) {
+    byte[] b = bytes.get();
+    if (bytes.getLength() == b.length && bytes.getOffset() == 0) {
+      return b;
+    }
+    return Arrays.copyOfRange(b, bytes.getOffset(), bytes.getOffset() + bytes.getLength());
+  }
+
+  @Override
+  public KeyValue shallowCopy() {
+    return new ClientKeyValue(row, family, qualifier, ts, type, value);
+  }
+
+  @Override
+  public int getValueOffset() {
+    return value.getOffset();
+  }
+
+  @Override
+  public int getValueLength() {
+    return value.getLength();
+  }
+
+  @Override
+  public int getRowOffset() {
+    return row.getOffset();
+  }
+
+  @Override
+  public short getRowLength() {
+    return (short) row.getLength();
+  }
+
+  @Override
+  public int getFamilyOffset() {
+    return family.getOffset();
+  }
+
+  @Override
+  public byte getFamilyLength() {
+    return (byte) family.getLength();
+  }
+
+  @Override
+  public byte getFamilyLength(int foffset) {
+    return this.getFamilyLength();
+  }
+
+  @Override
+  public int getQualifierOffset() {
+    return qualifier.getOffset();
+  }
+
+  @Override
+  public int getQualifierLength() {
+    return qualifier.getLength();
+  }
+
+  @Override
+  public int getQualifierLength(int rlength, int flength) {
+    return this.getQualifierLength();
+  }
+
+  @Override
+  public int getTotalColumnLength(int rlength, int foffset) {
+    return this.getFamilyLength() + this.getQualifierLength();
+  }
+
+  @Override
+  public int getTotalColumnLength() {
+    return qualifier.getLength() + family.getLength();
+  }
+
+  @Override
+  public byte[] getValue() {
+    return copyIfNecessary(value);
+  }
+
+  @Override
+  public byte[] getRow() {
+    return copyIfNecessary(row);
+  }
+
+  @Override
+  public long getTimestamp() {
+    return ts;
+  }
+
+  @Override
+  public byte[] getFamily() {
+    return copyIfNecessary(family);
+  }
+
+  @Override
+  public byte[] getQualifier() {
+    return copyIfNecessary(qualifier);
+  }
+
+  @Override
+  public byte getType() {
+    return this.type.getCode();
+  }
+
+  @Override
+  public boolean matchingFamily(byte[] family) {
+    if (family == null) {
+      if (this.family.getLength() == 0) {
+        return true;
+      }
+      return false;
+    }
+    return matchingFamily(family, 0, family.length);
+  }
+
+  @Override
+  public boolean matchingFamily(byte[] family, int offset, int length) {
+    if (family == null) {
+      if (this.family.getLength() == 0) {
+        return true;
+      }
+      return false;
+    }
+    return matches(family, offset, length, this.family);
+  }
+
+  @Override
+  public boolean matchingFamily(KeyValue other) {
+    if(other == null) {
+      return false;
+    }
+    if(other instanceof ClientKeyValue) {
+      ClientKeyValue kv = (ClientKeyValue)other;
+      return this.family.compareTo(kv.family) == 0;
+    }
+    return matchingFamily(other.getBuffer(), other.getFamilyOffset(), other.getFamilyLength());
+  }
+
+  private boolean matches(byte[] b, int offset, int length, ImmutableBytesWritable bytes) {
+    return Bytes.equals(b, offset, length, bytes.get(), bytes.getOffset(), bytes.getLength());
+  }
+
+  @Override
+  public boolean matchingQualifier(byte[] qualifier) {
+    if (qualifier == null) {
+      if (this.qualifier.getLength() == 0) {
+        return true;
+      }
+      return false;
+    }
+    return matchingQualifier(qualifier, 0, qualifier.length);
+  }
+
+  @Override
+  public boolean matchingQualifier(byte[] qualifier, int offset, int length) {
+    if (qualifier == null) {
+      if (this.qualifier.getLength() == 0) {
+        return true;
+      }
+      return false;
+    }
+    return matches(qualifier, offset, length, this.qualifier);
+  }
+
+  @Override
+  public boolean matchingQualifier(KeyValue other) {
+    if (other == null) {
+      return false;
+    }
+    if (other instanceof ClientKeyValue) {
+      ClientKeyValue kv = (ClientKeyValue) other;
+      return this.row.compareTo(kv.row) == 0;
+    }
+    return matchingQualifier(other.getBuffer(), other.getQualifierOffset(),
+      other.getQualifierLength());
+  }
+
+
+  @Override
+  public boolean matchingRow(byte[] row, int offset, int length) {
+    if (row == null) {
+      return false;
+    }
+    return matches(row, offset, length, this.row);
+  }
+
+  @Override
+  public boolean matchingRow(KeyValue other) {
+    return matchingRow(other.getBuffer(), other.getRowOffset(), other.getRowLength());
+  }
+
+  @Override
+  public boolean matchingColumnNoDelimiter(byte[] column) {
+    // match both the family and qualifier
+    if (matchingFamily(column, 0, this.family.getLength())) {
+      return matchingQualifier(column, family.getLength(), column.length - family.getLength());
+    }
+    return false;
+  }
+
+  @Override
+  public boolean matchingColumn(byte[] family, byte[] qualifier) {
+    return this.matchingFamily(family) && matchingQualifier(qualifier);
+  }
+
+  @Override
+  public boolean nonNullRowAndColumn() {
+    return (this.row != null && row.getLength() > 0) && !isEmptyColumn();
+  }
+
+  @Override
+  public boolean isEmptyColumn() {
+    return this.qualifier != null && this.qualifier.getLength() > 0;
+  }
+
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    // we need to simulate the keyvalue writing, but actually step through each buffer.
+    //start with keylength
+    long longkeylength = KeyValue.KEY_INFRASTRUCTURE_SIZE + row.getLength() + family.getLength()
+        + qualifier.getLength();
+    if (longkeylength > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("keylength " + longkeylength + " > " + Integer.MAX_VALUE);
+    }
+    // need to figure out the max length before we start
+    int length = this.getLength();
+    out.writeInt(length);
+
+    // write the actual data
+    int keylength = (int) longkeylength;
+    out.writeInt(keylength);
+    int vlength = value == null ? 0 : value.getLength();
+    out.writeInt(vlength);
+    out.writeShort((short) (row.getLength() & 0x0000ffff));
+    out.write(this.row.get(), this.row.getOffset(), this.row.getLength());
+    out.writeByte((byte) (family.getLength() & 0x0000ff));
+    if (family.getLength() != 0) {
+      out.write(this.family.get(), this.family.getOffset(), this.family.getLength());
+    }
+    if (qualifier != NULL) {
+      out.write(this.qualifier.get(), this.qualifier.getOffset(), this.qualifier.getLength());
+    }
+    out.writeLong(ts);
+    out.writeByte(this.type.getCode());
+    if (this.value != NULL) {
+      out.write(this.value.get(), this.value.getOffset(), this.value.getLength());
+    }
+  }
+
+  @Override
+  public int getLength() {
+    return KEYVALUE_INFRASTRUCTURE_SIZE + KeyValue.ROW_LENGTH_SIZE + row.getLength()
+        + KeyValue.FAMILY_LENGTH_SIZE + family.getLength() + qualifier.getLength()
+        + KeyValue.TIMESTAMP_SIZE + KeyValue.TYPE_SIZE + value.getLength();
+  }
+
+  @Override
+  public String toString() {
+    return keyToString() + "/vlen=" + getValueLength() + "/ts=" + getMemstoreTS();
+  }
+
+  private String keyToString() {
+    String row = Bytes.toStringBinary(this.row.get(), this.row.getOffset(), this.row.getLength());
+    String family = this.family.getLength() == 0 ? "" : Bytes.toStringBinary(this.family.get(),
+      this.family.getOffset(), this.family.getLength());
+    String qualifier = this.qualifier.getLength() == 0 ? "" : Bytes.toStringBinary(
+      this.qualifier.get(), this.qualifier.getOffset(), this.qualifier.getLength());
+    String timestampStr = Long.toString(ts);
+    byte type = this.type.getCode();
+    return row + "/" + family + (family != null && family.length() > 0 ? ":" : "") + qualifier
+        + "/" + timestampStr + "/" + Type.codeToType(type);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!super.equals(obj)) return false;
+    if (getClass() != obj.getClass()) return false;
+    ClientKeyValue other = (ClientKeyValue) obj;
+    if (family == null) {
+      if (other.family != null) return false;
+    } else if (!family.equals(other.family)) return false;
+    if (qualifier == null) {
+      if (other.qualifier != null) return false;
+    } else if (!qualifier.equals(other.qualifier)) return false;
+    if (row == null) {
+      if (other.row != null) return false;
+    } else if (!row.equals(other.row)) return false;
+    if (ts != other.ts) return false;
+    if (type != other.type) return false;
+    if (value == null) {
+      if (other.value != null) return false;
+    } else if (!value.equals(other.value)) return false;
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    // TODO do we need to keep the same hashcode logic as KeyValue? Everywhere else we don't keep
+    // them by reference, but presumably clients might hash them.
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + family.hashCode();
+    result = prime * result + qualifier.hashCode();
+    result = prime * result + row.hashCode();
+    result = prime * result + (int) (ts ^ (ts >>> 32));
+    result = prime * result + type.hashCode();
+    result = prime * result + value.hashCode();
+    return result;
+  }
+
+  @Override
+  public void readFields(int length, DataInput in) throws IOException {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " should not be used for server-side operations");
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " should not be used for server-side operations");
+  }
+
+  @Override
+  public int getKeyOffset() {
+    return 0;
+  }
+
+
+  @Override
+  public int getFamilyOffset(int rlength) {
+    return 0;
+  }
+
+  @Override
+  public int getQualifierOffset(int foffset) {
+    return 0;
+  }
+
+  @Override
+  public int getTimestampOffset() {
+    return 0;
+  }
+
+  @Override
+  public int getTimestampOffset(int keylength) {
+    return 0;
+  }
+
+  @Override
+  public int getOffset() {
+    return 0;
+  }
+
+  @Override
+  public boolean updateLatestStamp(byte[] now) {
+    if (this.isLatestTimestamp()) {
+      // unfortunately, this is a bit slower than the usual kv, but we don't expect this to happen
+      // all that often on the client (unless users are updating the ts this way), as it generally
+      // happens on the server
+      this.ts = Bytes.toLong(now);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isLatestTimestamp() {
+    return this.ts == HConstants.LATEST_TIMESTAMP;
+  }
+
+  @Override
+  public int getKeyLength() {
+    return KEY_INFRASTRUCTURE_SIZE + getRowLength() + getFamilyLength() + getQualifierLength();
+  }
+
+  @Override
+  public byte[] getKey() {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " does not support a single backing buffer.");
+  }
+
+  @Override
+  public String getKeyString() {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " does not support a single backing buffer.");
+  }
+
+  @Override
+  public SplitKeyValue split() {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " should not be used for server-side operations");
+  }
+
+  @Override
+  public byte[] getBuffer() {
+    throw new UnsupportedOperationException(ClientKeyValue.class.getSimpleName()
+        + " does not support a single backing buffer.");
+  }
+}

--- a/src/main/java/com/salesforce/phoenix/client/ClientKeyValueBuilder.java
+++ b/src/main/java/com/salesforce/phoenix/client/ClientKeyValueBuilder.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.client;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValue.Type;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+
+import com.salesforce.phoenix.jdbc.PhoenixDatabaseMetaData;
+
+/**
+ * A {@link KeyValueBuilder} that builds {@link ClientKeyValue}, eliminating the extra byte copies
+ * inherent in the standard {@link KeyValue} implementation.
+ * <p>
+ * This {@link KeyValueBuilder} is only supported in HBase 0.94.14+ (
+ * {@link PhoenixDatabaseMetaData#CLIENT_KEY_VALUE_BUILDER_THRESHOLD}), with the addition of
+ * HBASE-9834.
+ */
+public class ClientKeyValueBuilder extends KeyValueBuilder {
+
+  public static final KeyValueBuilder INSTANCE = new ClientKeyValueBuilder();
+
+  private ClientKeyValueBuilder() {
+    // private ctor for singleton
+  }
+
+  @Override
+  public KeyValue buildPut(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return new ClientKeyValue(row, family, qualifier, ts, Type.Put, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteFamily(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return new ClientKeyValue(row, family, qualifier, ts, Type.DeleteFamily, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteColumns(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return new ClientKeyValue(row, family, qualifier, ts, Type.DeleteColumn, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteColumn(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return new ClientKeyValue(row, family, qualifier, ts, Type.Delete, value);
+  }
+}

--- a/src/main/java/com/salesforce/phoenix/client/GenericKeyValueBuilder.java
+++ b/src/main/java/com/salesforce/phoenix/client/GenericKeyValueBuilder.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.client;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValue.Type;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+
+import static com.salesforce.hbase.index.util.ImmutableBytesPtr.copyBytesIfNecessary;
+
+/**
+ * {@link KeyValueBuilder} that does simple byte[] copies to build the underlying key-value.
+ */
+public class GenericKeyValueBuilder extends KeyValueBuilder {
+
+  public static final KeyValueBuilder INSTANCE = new GenericKeyValueBuilder();
+
+  private GenericKeyValueBuilder() {
+    // private ctor for singleton
+  }
+
+  @Override
+  public KeyValue buildPut(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return build(row, family, qualifier, ts, Type.Put, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteFamily(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return build(row, family, qualifier, ts, Type.DeleteFamily, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteColumns(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return build(row, family, qualifier, ts, Type.DeleteColumn, value);
+  }
+
+  @Override
+  public KeyValue buildDeleteColumn(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value) {
+    return build(row, family, qualifier, ts, Type.Delete, value);
+  }
+
+  private KeyValue build(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, KeyValue.Type type, ImmutableBytesWritable value) {
+    return new KeyValue(copyBytesIfNecessary(row), copyBytesIfNecessary(family),
+        copyBytesIfNecessary(qualifier), ts, type, copyBytesIfNecessary(value));
+  }
+}

--- a/src/main/java/com/salesforce/phoenix/client/KeyValueBuilder.java
+++ b/src/main/java/com/salesforce/phoenix/client/KeyValueBuilder.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.client;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+
+/**
+ * Build {@link KeyValue} in an efficient way
+ */
+public abstract class KeyValueBuilder {
+
+  public static KeyValueBuilder get(Configuration conf) {
+    // TODO Implement builder creation based on correct HBase version
+    return null;
+  }
+
+  public KeyValue buildPut(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, ImmutableBytesWritable value) {
+    return buildPut(row, family, qualifier, HConstants.LATEST_TIMESTAMP, value);
+  }
+
+  public abstract KeyValue buildPut(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, long ts, ImmutableBytesWritable value);
+
+  public KeyValue buildDeleteFamily(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, ImmutableBytesWritable value) {
+    return buildDeleteFamily(row, family, qualifier, HConstants.LATEST_TIMESTAMP, value);
+  }
+
+  public abstract KeyValue buildDeleteFamily(ImmutableBytesWritable row,
+      ImmutableBytesWritable family, ImmutableBytesWritable qualifier, long ts,
+      ImmutableBytesWritable value);
+
+  public KeyValue buildDeleteColumns(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, ImmutableBytesWritable value) {
+    return buildDeleteColumns(row, family, qualifier, HConstants.LATEST_TIMESTAMP, value);
+  }
+
+  public abstract KeyValue buildDeleteColumns(ImmutableBytesWritable row,
+      ImmutableBytesWritable family, ImmutableBytesWritable qualifier, long ts,
+      ImmutableBytesWritable value);
+
+  public KeyValue buildDeleteColumn(ImmutableBytesWritable row, ImmutableBytesWritable family,
+      ImmutableBytesWritable qualifier, ImmutableBytesWritable value) {
+    return buildDeleteColumn(row, family, qualifier, HConstants.LATEST_TIMESTAMP, value);
+  }
+
+  public abstract KeyValue buildDeleteColumn(ImmutableBytesWritable row,
+      ImmutableBytesWritable family, ImmutableBytesWritable qualifier, long ts,
+      ImmutableBytesWritable value);
+}

--- a/src/main/java/com/salesforce/phoenix/jdbc/PhoenixDatabaseMetaData.java
+++ b/src/main/java/com/salesforce/phoenix/jdbc/PhoenixDatabaseMetaData.java
@@ -178,6 +178,8 @@ public class PhoenixDatabaseMetaData implements DatabaseMetaData, com.salesforce
     public static final int ESSENTIAL_FAMILY_VERSION_THRESHOLD = MetaDataUtil.encodeVersion("0", "94", "7");
     // Version below which we should disallow usage of mutable secondary indexing.
     public static final int MUTABLE_SI_VERSION_THRESHOLD = MetaDataUtil.encodeVersion("0", "94", "10");
+    /** Version below which we fall back on the generic KeyValueBuilder */
+    public static final int CLIENT_KEY_VALUE_BUILDER_THRESHOLD = MetaDataUtil.encodeVersion("0", "94", "14");
 
     PhoenixDatabaseMetaData(PhoenixConnection connection) throws SQLException {
         this.emptyResultSet = new PhoenixResultSet(EMPTY_SCANNER, new PhoenixStatement(connection));

--- a/src/test/java/com/salesforce/phoenix/client/TestClientKeyValue.java
+++ b/src/test/java/com/salesforce/phoenix/client/TestClientKeyValue.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValue.Type;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class TestClientKeyValue {
+  private final static HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+  private static byte[] ROW = Bytes.toBytes("testRow");
+  private static byte[] FAMILY = Bytes.toBytes("testFamily");
+  private static byte[] QUALIFIER = Bytes.toBytes("testQualifier");
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TEST_UTIL.startMiniCluster();
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  /**
+   * Simple test that a {@link ClientKeyValue} works as expected on a real table
+   * @throws Exception
+   */
+  @Test
+  public void testClientKeyValue() throws Exception {
+    byte[] TABLE = Bytes.toBytes("testClientKeyValue");
+    HTable table = TEST_UTIL.createTable(TABLE, new byte[][] { FAMILY });
+
+    // create several rows
+    Put p = new Put(ROW);
+    byte[] v = Bytes.toBytes("v1");
+    KeyValue kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 10, Type.Put, v);
+    p.add(kv);
+    byte[] v2 = Bytes.toBytes("v2");
+    kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 11, Type.Put, v2);
+    p.add(kv);
+    byte[] v3 = Bytes.toBytes("v3");
+    kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 12, Type.Put, v3);
+    p.add(kv);
+
+    table.put(p);
+    table.flushCommits();
+
+    byte[][] values = new byte[][] { v, v2, v3 };
+    long[] times = new long[] { 10, 11, 12 };
+    scanAllVersionsAndVerify(table, ROW, FAMILY, QUALIFIER, times, values, 0, 2);
+
+    // do a delete of the row as well
+    Delete d = new Delete(ROW);
+    // start with a point delete
+    kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 10, Type.Delete);
+    d.addDeleteMarker(kv);
+    table.delete(d);
+    scanAllVersionsAndVerify(table, ROW, FAMILY, QUALIFIER, times, values, 1, 2);
+
+    // delete just that column
+    d = new Delete(ROW);
+    kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 11, Type.DeleteColumn);
+    d.addDeleteMarker(kv);
+    table.delete(d);
+    scanAllVersionsAndVerify(table, ROW, FAMILY, QUALIFIER, times, values, 2, 2);
+
+    // delete the whole family
+    kv = new ClientKeyValue(ROW, FAMILY, QUALIFIER, 12, Type.DeleteFamily);
+    d.addDeleteMarker(kv);
+    table.delete(d);
+    scanVersionAndVerifyMissing(table, ROW, FAMILY, QUALIFIER, 12);
+
+    // cleanup
+    table.close();
+  }
+
+  private void scanAllVersionsAndVerify(HTable ht, byte[] row, byte[] family, byte[] qualifier,
+      long[] stamps, byte[][] values, int start, int end) throws IOException {
+    Scan scan = new Scan(row);
+    scan.addColumn(family, qualifier);
+    scan.setMaxVersions(Integer.MAX_VALUE);
+    Result result = getSingleScanResult(ht, scan);
+    assertNResult(result, row, family, qualifier, stamps, values, start, end);
+  }
+
+  private void scanVersionAndVerifyMissing(HTable ht, byte[] row, byte[] family, byte[] qualifier,
+      long stamp) throws Exception {
+    Scan scan = new Scan(row);
+    scan.addColumn(family, qualifier);
+    scan.setTimeStamp(stamp);
+    scan.setMaxVersions(Integer.MAX_VALUE);
+    Result result = getSingleScanResult(ht, scan);
+    assertNullResult(result);
+  }
+
+  private void assertNullResult(Result result) throws Exception {
+    assertTrue("expected null result but received a non-null result", result == null);
+  }
+
+  private Result getSingleScanResult(HTable ht, Scan scan) throws IOException {
+    ResultScanner scanner = ht.getScanner(scan);
+    Result result = scanner.next();
+    scanner.close();
+    return result;
+  }
+
+  private void assertNResult(Result result, byte[] row, byte[] family, byte[] qualifier,
+      long[] stamps, byte[][] values, int start, int end) throws IOException {
+    assertTrue(
+      "Expected row [" + Bytes.toString(row) + "] " + "Got row [" + Bytes.toString(result.getRow())
+          + "]", equals(row, result.getRow()));
+    int expectedResults = end - start + 1;
+    assertEquals(expectedResults, result.size());
+
+    KeyValue[] keys = result.raw();
+
+    for (int i = 0; i < keys.length; i++) {
+      byte[] value = values[end - i];
+      long ts = stamps[end - i];
+      KeyValue key = keys[i];
+
+      assertTrue("(" + i + ") Expected family [" + Bytes.toString(family) + "] " + "Got family ["
+          + Bytes.toString(key.getFamily()) + "]", equals(family, key.getFamily()));
+      assertTrue("(" + i + ") Expected qualifier [" + Bytes.toString(qualifier) + "] "
+          + "Got qualifier [" + Bytes.toString(key.getQualifier()) + "]",
+        equals(qualifier, key.getQualifier()));
+      assertTrue("Expected ts [" + ts + "] " + "Got ts [" + key.getTimestamp() + "]",
+        ts == key.getTimestamp());
+      assertTrue("(" + i + ") Expected value [" + Bytes.toString(value) + "] " + "Got value ["
+          + Bytes.toString(key.getValue()) + "]", equals(value, key.getValue()));
+    }
+  }
+
+  private boolean equals(byte[] left, byte[] right) {
+    if (left == null && right == null) return true;
+    if (left == null && right.length == 0) return true;
+    if (right == null && left.length == 0) return true;
+    return Bytes.equals(left, right);
+  }
+}

--- a/src/test/java/com/salesforce/phoenix/client/TestClientKeyValueLocal.java
+++ b/src/test/java/com/salesforce/phoenix/client/TestClientKeyValueLocal.java
@@ -1,0 +1,267 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.phoenix.client;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TestKeyValue;
+import org.apache.hadoop.hbase.KeyValue.Type;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.junit.Test;
+
+import com.salesforce.phoenix.client.ClientKeyValue;
+
+/**
+ * Ensure that we can accss a {@link ClientKeyValue} as expected. For instance, write it to bytes
+ * and then read it back into a {@link KeyValue} as expected or compare columns to other
+ * {@link KeyValue}s.
+ */
+public class TestClientKeyValueLocal {
+
+  @Test
+  public void testReadWrite() throws IOException {
+    byte[] row = Bytes.toBytes("row");
+    byte[] family = Bytes.toBytes("family");
+    byte[] qualifier = Bytes.toBytes("qualifier");
+    byte[] value = Bytes.toBytes("value");
+    long ts = 10;
+    Type type = KeyValue.Type.Put;
+    ClientKeyValue kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type,
+        wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+
+    type = Type.Delete;
+    kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+
+    type = Type.DeleteColumn;
+    kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+
+    type = Type.DeleteFamily;
+    kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+
+    type = Type.Maximum;
+    kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+
+    // test a couple different variables, to make sure we aren't faking it
+    row = Bytes.toBytes("row-never-seen-before1234");
+    family = Bytes.toBytes("family-to-test-more");
+    qualifier = Bytes.toBytes("untested-qualifier");
+    value = Bytes.toBytes("value-that-we-haven't_tested");
+    ts = System.currentTimeMillis();
+    kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, family, qualifier, ts, type, value);
+  }
+
+  /**
+   * Corner case where values can be null
+   * @throws IOException
+   */
+  @Test
+  public void testNullValues() throws IOException {
+    byte[] row = Bytes.toBytes("row");
+    byte[] family = Bytes.toBytes("family");
+    byte[] qualifier = Bytes.toBytes("qualifier");
+    long ts = 10;
+    Type type = KeyValue.Type.Put;
+    byte[] empty = new byte[0];
+    // values can be null
+    ClientKeyValue kv = new ClientKeyValue(wrap(row), wrap(family), wrap(qualifier), ts, type, null);
+    validate(kv, row, family, qualifier, ts, type, empty);
+    kv = new ClientKeyValue(row, family, qualifier, ts, type, null);
+    validate(kv, row, family, qualifier, ts, type, empty);
+    kv = new ClientKeyValue(row, family, qualifier, ts, type);
+    validate(kv, row, family, qualifier, ts, type, empty);
+
+    // qualifiers can also be null and have null values
+    kv = new ClientKeyValue(wrap(row), wrap(family), null, ts, type, null);
+    validate(kv, row, family, empty, ts, type, empty);
+    kv = new ClientKeyValue(row, family, null, ts, type, null);
+    validate(kv, row, family, empty, ts, type, empty);
+    kv = new ClientKeyValue(row, family, null, ts, type);
+    validate(kv, row, family, empty, ts, type, empty);
+    // and also have values
+    byte[] value = Bytes.toBytes("value");
+    kv = new ClientKeyValue(wrap(row), wrap(family), null, ts, type, wrap(value));
+    validate(kv, row, family, empty, ts, type, value);
+    kv = new ClientKeyValue(row, family, null, ts, type, value);
+    validate(kv, row, family, empty, ts, type, value);
+
+    // families can also be null
+    kv = new ClientKeyValue(wrap(row), null, null, ts, type, null);
+    validate(kv, row, empty, empty, ts, type, empty);
+    kv = new ClientKeyValue(row, null, null, ts, type, null);
+    validate(kv, row, empty, empty, ts, type, empty);
+    kv = new ClientKeyValue(row, null, null, ts, type);
+    validate(kv, row, empty, empty, ts, type, empty);
+    // but we could have a qualifier
+    kv = new ClientKeyValue(wrap(row), null, wrap(qualifier), ts, type, null);
+    validate(kv, row, empty, qualifier, ts, type, empty);
+    kv = new ClientKeyValue(row, null, qualifier, ts, type, null);
+    validate(kv, row, empty, qualifier, ts, type, empty);
+    kv = new ClientKeyValue(row, null, qualifier, ts, type);
+    validate(kv, row,  empty, qualifier, ts, type, empty);
+    // or a real value
+    kv = new ClientKeyValue(wrap(row), null, wrap(qualifier), ts, type, wrap(value));
+    validate(kv, row, empty, qualifier, ts, type, value);
+    kv = new ClientKeyValue(row, null, qualifier, ts, type, value);
+    validate(kv, row, empty, qualifier, ts, type, value);
+  }
+
+  private void validate(KeyValue kv, byte[] row, byte[] family, byte[] qualifier, long ts,
+      Type type, byte[] value) throws IOException {
+    DataOutputBuffer out = new DataOutputBuffer();
+    kv.write(out);
+    out.close();
+    byte[] data = out.getData();
+    // read it back in
+    KeyValue read = new KeyValue();
+    DataInputBuffer in = new DataInputBuffer();
+    in.reset(data, data.length);
+    read.readFields(in);
+    in.close();
+
+    // validate that its the same
+    assertTrue("Row didn't match!", Bytes.equals(row, read.getRow()));
+    assertTrue("Family didn't match!", Bytes.equals(family, read.getFamily()));
+    assertTrue("Qualifier didn't match!", Bytes.equals(qualifier, read.getQualifier()));
+    assertTrue("Value didn't match!", Bytes.equals(value, read.getValue()));
+    assertEquals("Timestamp didn't match", ts, read.getTimestamp());
+    assertEquals("Type didn't match", type.getCode(), read.getType());
+  }
+
+  /**
+   * Copied from {@link TestKeyValue}
+   * @throws Exception
+   */
+  @Test
+  public void testColumnCompare() throws Exception {
+    final byte [] a = Bytes.toBytes("aaa");
+    byte [] family1 = Bytes.toBytes("abc");
+    byte [] qualifier1 = Bytes.toBytes("def");
+    byte [] family2 = Bytes.toBytes("abcd");
+    byte [] qualifier2 = Bytes.toBytes("ef");
+
+    KeyValue aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.Put, a);
+    assertFalse(aaa.matchingColumn(family2, qualifier2));
+    assertTrue(aaa.matchingColumn(family1, qualifier1));
+    aaa = new ClientKeyValue(a, family2, qualifier2, 0L, Type.Put, a);
+    assertFalse(aaa.matchingColumn(family1, qualifier1));
+    assertTrue(aaa.matchingColumn(family2,qualifier2));
+    byte [] nullQualifier = new byte[0];
+    aaa = new ClientKeyValue(a, family1, nullQualifier, 0L, Type.Put, a);
+    assertTrue(aaa.matchingColumn(family1,null));
+    assertFalse(aaa.matchingColumn(family2,qualifier2));
+  }
+
+  /**
+   * Test a corner case when the family qualifier is a prefix of the column qualifier.
+   */
+  @Test
+  public void testColumnCompare_prefix() throws Exception {
+    final byte[] a = Bytes.toBytes("aaa");
+    byte[] family1 = Bytes.toBytes("abc");
+    byte[] qualifier1 = Bytes.toBytes("def");
+    byte[] family2 = Bytes.toBytes("ab");
+    byte[] qualifier2 = Bytes.toBytes("def");
+
+    KeyValue aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.Put, a);
+    assertFalse(aaa.matchingColumn(family2, qualifier2));
+  }
+
+  /**
+   * Test that we have the expected behavior when adding to a {@link Put}
+   * @throws Exception
+   */
+  @Test
+  public void testUsableWithPut() throws Exception {
+    final byte[] a = Bytes.toBytes("aaa");
+    byte[] family1 = Bytes.toBytes("abc");
+    byte[] qualifier1 = Bytes.toBytes("def");
+
+    // works fine - matching row
+    KeyValue aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.Put, a);
+    Put p = new Put(a);
+    p.add(aaa);
+
+    // fails, not a matching row
+    try {
+      aaa = new ClientKeyValue(family1, family1, qualifier1, 0L, Type.Put, a);
+      p.add(aaa);
+      fail("Shouldn't have been able to add  a KV with a row mismatch");
+    } catch (IOException e) {
+      // noop - as expected
+    }
+  }
+
+  /**
+   * Test that we have the expected behavior when adding to a {@link Delete}
+   * @throws Exception
+   */
+  @Test
+  public void testUsableWithDelete() throws Exception {
+    final byte[] a = Bytes.toBytes("aaa");
+    byte[] family1 = Bytes.toBytes("abc");
+    byte[] qualifier1 = Bytes.toBytes("def");
+
+    KeyValue aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.Delete, a);
+    Delete d = new Delete(a);
+    // simple cases should work fine
+    d.addDeleteMarker(aaa);
+    aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.DeleteColumn, a);
+    d.addDeleteMarker(aaa);
+    aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.DeleteFamily, a);
+    d.addDeleteMarker(aaa);
+
+    // fails, not a matching row
+    try {
+      aaa = new ClientKeyValue(family1, family1, qualifier1, 0L, Type.DeleteFamily, a);
+      d.addDeleteMarker(aaa);
+      fail("Shouldn't have been able to add  a KV with a row mismatch");
+    } catch (IOException e) {
+      // noop - as expected
+    }
+
+    aaa = new ClientKeyValue(a, family1, qualifier1, 0L, Type.Put, a);
+    try {
+      d.addDeleteMarker(aaa);
+      fail("Shouldn't have been able to add a KV of type Put");
+    } catch (IOException e) {
+      // noop
+    }
+  }
+
+  private static ImmutableBytesWritable wrap(byte[] b) {
+    return new ImmutableBytesWritable(b);
+  }
+}


### PR DESCRIPTION
This allow us to do zero-copy KV creation.
 We only support HBASE 0.94.14+ (currently in development) for the custom KV building.
