### PR TITLE
fix for java.lang.NullPointerException

### DIFF
--- a/src/main/java/com/salesforce/phoenix/map/reduce/MapReduceJob.java
+++ b/src/main/java/com/salesforce/phoenix/map/reduce/MapReduceJob.java
@@ -92,8 +92,12 @@ public class MapReduceJob {
 				createDDL[0]		= context.getConfiguration().get("createTableDDL");
 				createDDL[1]		= context.getConfiguration().get("createIndexDDL");
 				ignoreUpsertError 	= context.getConfiguration().get("IGNORE.INVALID.ROW").equalsIgnoreCase("0") ? false : true;
-				
+
 				for(String s : createDDL){
+					if(s == null || s.trim().length() == 0) {
+						continue;
+					}
+
 					try {
 						PreparedStatement prepStmt = conn_none.prepareStatement(s);
 						prepStmt.execute();


### PR DESCRIPTION
This is a fix for:
java.lang.NullPointerException
        at java.io.StringReader.<init>(StringReader.java:33)
        at com.salesforce.phoenix.parse.SQLParser.<init>(SQLParser.java:62)
        at com.salesforce.phoenix.jdbc.PhoenixStatement$PhoenixStatementParser.<init>(PhoenixStatement.java:926)
        at com.salesforce.phoenix.jdbc.PhoenixStatement.parseStatement(PhoenixStatement.java:1003)
        at com.salesforce.phoenix.jdbc.PhoenixPreparedStatement.<init>(PhoenixPreparedStatement.java:84)
        at com.salesforce.phoenix.jdbc.PhoenixConnection.prepareStatement(PhoenixConnection.java:403)
        at com.salesforce.phoenix.map.reduce.MapReduceJob$PhoenixMapper.setup(MapReduceJob.java:98)
        at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:142)
        at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:763)
        at org.apache.hadoop.mapred.MapTask.run(MapTask.java:363)
        at org.apache.hadoop.mapred.Child$4.run(Child.java:255)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:396)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1232)
        at org.apache.hadoop.mapred.Child.main(Child.java:249)
