### PR TITLE
isFilterDone() not needed with nextRaw()

### DIFF
--- a/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
@@ -224,7 +224,7 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                     // Results are potentially returned even when the return value of s.next is false
                     // since this is an indication of whether or not there are more values after the
                     // ones returned
-                    hasMore = s.nextRaw(results, null) && !s.isFilterDone();
+                    hasMore = s.nextRaw(results, null);
                     if (!results.isEmpty()) {
                         result.setKeyValues(results);
                         ImmutableBytesWritable key = TupleUtil.getConcatenatedValue(result, expressions);
@@ -349,7 +349,7 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                         // Results are potentially returned even when the return value of s.next is false
                         // since this is an indication of whether or not there are more values after the
                         // ones returned
-                        hasMore = s.nextRaw(kvs, null) && !s.isFilterDone();
+                        hasMore = s.nextRaw(kvs, null);
                         if (!kvs.isEmpty()) {
                             result.setKeyValues(kvs);
                             key = TupleUtil.getConcatenatedValue(result, expressions);

--- a/src/main/java/com/salesforce/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/UngroupedAggregateRegionObserver.java
@@ -215,7 +215,7 @@ public class UngroupedAggregateRegionObserver extends BaseScannerRegionObserver 
                 // Results are potentially returned even when the return value of s.next is false
                 // since this is an indication of whether or not there are more values after the
                 // ones returned
-                hasMore = innerScanner.nextRaw(results, null) && !innerScanner.isFilterDone();
+                hasMore = innerScanner.nextRaw(results, null);
                 if (!results.isEmpty()) {
                 	rowCount++;
                     result.setKeyValues(results);

--- a/src/main/java/com/salesforce/phoenix/index/PhoenixIndexBuilder.java
+++ b/src/main/java/com/salesforce/phoenix/index/PhoenixIndexBuilder.java
@@ -70,7 +70,7 @@ public class PhoenixIndexBuilder extends CoveredColumnsIndexBuilder {
                 // Results are potentially returned even when the return value of s.next is false
                 // since this is an indication of whether or not there are more values after the
                 // ones returned
-                hasMore = scanner.nextRaw(results, null) && !scanner.isFilterDone();
+                hasMore = scanner.nextRaw(results, null);
             } while (hasMore);
         } finally {
             try {


### PR DESCRIPTION
Hey James,

just worked on https://issues.apache.org/jira/browse/HBASE-10117 and noticed that Phoenix unnecessarily calls RegionScaner.isFilterDone() in some (hot) places. isFilterDone() is synchronized and hence causes a noticeable slow down.
nextRaw() internally calls isFilterDone and only returns true if isFilterDone() returns false, so the extra call is unnecessary,
