### PR TITLE
Spillable GroupBy implementation, initial commit

### DIFF
--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
@@ -54,7 +54,7 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
      * @param ctxt
      */
     public GroupByCache( long estSize, int estValueSize, ServerAggregators aggs,
-                         ObserverContext<RegionCoprocessorEnvironment> ctxt ) {
+                         final ObserverContext<RegionCoprocessorEnvironment> ctxt ) {
         context = ctxt; 
         this.estValueSize = estValueSize;
         curNumCacheElements = 0;
@@ -79,7 +79,7 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
                                         // Lazy instantiation of spillable data structures
                                         //
                                         // Only create spill data structs if LRU cache is too small
-                                        spillManager = new SpillManager(NUM_SPILLFILES, aggregators);
+                                        spillManager = new SpillManager(NUM_SPILLFILES, aggregators, context.getEnvironment().getConfiguration());
                                     }
                                     spillManager.spill(notification.getKey(), notification.getValue());
                                     // keep track of elements in cache       

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
@@ -1,0 +1,274 @@
+package com.salesforce.phoenix.cache.aggcache;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.io.Closeables;
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
+import com.salesforce.phoenix.cache.aggcache.SpillManager.CacheEntry;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.ServerAggregators;
+
+/**
+ * Class that implements an LRU cache for key/Aggregator[] tuples.
+ * Keys that do not yet exists are loaded into the cache automatically.
+ * Eviction happens on a size limit basis. Evicted elements are spilled to disk.
+ */
+public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
+    private static final Logger logger = LoggerFactory.getLogger(SpillManager.class);
+    
+    private static final int NUM_SPILLFILES = 5;
+    // TODO what are proper defaults?
+    private static final int CACHE_MIN_SIZE = 10;
+    private static final int CACHE_MAX_SIZE = 10000;
+    // TODO Generally better to use Collection API with generics instead of array types
+    public final LoadingCache<ImmutableBytesPtr, Aggregator[]> cache;
+    private SpillManager spillManager = null;
+    private final ObserverContext<RegionCoprocessorEnvironment> context;
+    private int curNumCacheElements;
+    private final int estValueSize;
+    private final ServerAggregators aggregators;
+       
+    
+    /**
+     * Instantiates a Loading LRU Cache that stores key / aggregator[] tuples
+     * used for group by queries
+     * @param estSize
+     * @param estValueSize
+     * @param aggs
+     * @param ctxt
+     */
+    public GroupByCache( long estSize, int estValueSize, ServerAggregators aggs,
+                         ObserverContext<RegionCoprocessorEnvironment> ctxt ) {
+        context = ctxt; 
+        this.estValueSize = estValueSize;
+        curNumCacheElements = 0;
+        this.aggregators = aggs;
+        
+        // use upper and lower bounds for the cache size 
+        int maxCacheSize = Math.max(CACHE_MIN_SIZE, Math.min(CACHE_MAX_SIZE,((int)estSize / estValueSize )));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Instantiating LRU groupby cache of element size: " + maxCacheSize);
+        }
+        // Cache is element number bounded. Using the max of CACHE_MIN_SIZE and the est MapSize
+        cache = CacheBuilder.newBuilder().maximumSize(maxCacheSize)
+                .removalListener( 
+                        new RemovalListener<ImmutableBytesPtr, Aggregator[]>() {
+                            /*
+                             * CacheRemoval listener implementation
+                             */
+                            @Override
+                            public void onRemoval(RemovalNotification<ImmutableBytesPtr, Aggregator[]> notification) {
+                                try {
+                                    if(spillManager == null) {
+                                        // Lazy instantiation of spillable data structures
+                                        //
+                                        // Only create spill data structs if LRU cache is too small
+                                        spillManager = new SpillManager(NUM_SPILLFILES, aggregators);
+                                    }
+                                    spillManager.spill(notification.getKey(), notification.getValue());
+                                    // keep track of elements in cache       
+                                    curNumCacheElements--;
+                                }
+                                catch(IOException ioe) {
+                                    // TODO rework error handling
+                                    throw new RuntimeException(ioe);
+                                }
+                            }                            
+                        })                
+                .build(
+                       new CacheLoader<ImmutableBytesPtr, Aggregator[]>() {
+                           /*
+                            * CacheLoader implementation
+                            */
+                           @Override
+                           public Aggregator[] load(ImmutableBytesPtr key) throws Exception {
+                               
+                               Aggregator[] aggs = null;
+                               if(spillManager == null) {
+                                   // No spill Manager, always assume this key is new!
+                                   aggs = aggregators.newAggregators(context.getEnvironment().getConfiguration());
+                               }
+                               else {
+                                   // Spill manager present, check if key has been spilled before
+                                   aggs = spillManager.loadEntry(key);
+                                    if(aggs == null) {
+                                        // No, key never spilled before, create a new tuple
+                                        if (logger.isDebugEnabled()) {
+                                            logger.debug("Adding new aggregate bucket for row key " + Bytes.toStringBinary( key.get(),
+                                                                                                                            key.getOffset(),
+                                                                                                                            key.getLength()) );
+                                        }                                                                                
+                                        aggs = aggregators.newAggregators(context.getEnvironment().getConfiguration());                                 
+                                    }
+                               }
+                               // keep track of elements in cache       
+                               curNumCacheElements++;
+                               return aggs;
+                           }
+                       });
+    }
+    
+    
+    /**
+     * Size function returns the estimate LRU cache size in bytes
+     */
+    @Override
+    public int size() {
+        return curNumCacheElements * estValueSize;
+    }       
+    
+    /**
+     * put function of Map interface
+     * DO NOT USE
+     * Cache takes automatically care of loading non-existing elements
+     */
+    @Override
+    public Aggregator[] put(ImmutableBytesPtr key, Aggregator[] value) {
+        // Loading cache implicitly implements a put when a cache hit has occurred
+        // Disable the map interface
+        throw new IllegalAccessError("put is not supported for a loading cache");
+    }
+
+    /**
+     * Extract an element from the Cache
+     * If element is not present in in-memory cache / or in spill files
+     * cache implements an implicit put() of a new key/value tuple and loads it into the cache
+     */
+    @Override
+    public Aggregator[] get(Object key) { 
+        try {
+            // delegate to the cache implementation
+            return cache.get((ImmutableBytesPtr)key);            
+        } catch (ExecutionException e) {
+            // TODO What's the proper way to surface errors?
+            // FIXME using a non-checked exception for now...
+            throw new RuntimeException(e);
+        }
+    }    
+    
+    /**
+     * Return a map view of the cache, READ ONLY
+     */
+    public Map<ImmutableBytesPtr, Aggregator[]> getAsMap() {
+        // Useful for iterators
+        return cache.asMap();
+    }
+    
+    
+    /**
+     * This function creates a iterator over the cache and the spilled data structures.
+     * The key/value tuples are returned in non-deterministic order.
+     */
+    public EntryIterator newEntryIterator() {
+        return new EntryIterator();
+    }
+    
+    
+    // Iterator that returns CacheEntries.
+    // CacheEntries are either extracted from the LRU cache or from the spillable data
+    // structures.
+    private final class EntryIterator implements Iterator<CacheEntry> {
+        
+        final Map<ImmutableBytesPtr, Aggregator[]> cacheMap;
+        final Iterator<Map.Entry<ImmutableBytesPtr, Aggregator[]>> cacheIter;
+        final Iterator<byte[]> spilledCacheIter;
+
+        private EntryIterator() {
+            cacheMap = cache.asMap();
+            cacheIter = cacheMap.entrySet().iterator();
+            if(spillManager != null) {
+                spilledCacheIter = spillManager.newDataIterator();
+            }
+            else {
+                spilledCacheIter = null;
+            }
+        }
+        
+        @Override
+        public boolean hasNext() {
+            return cacheIter.hasNext();
+        }
+        
+        @Override
+        public CacheEntry next() {
+            if(spilledCacheIter != null && spilledCacheIter.hasNext())
+            {
+                try {
+                    byte[] value = spilledCacheIter.next();
+                    // Deserialize into a CacheEntry
+                    CacheEntry spilledEntry = spillManager.toCacheEntry(value);
+                    
+                    boolean notFound = false;
+                    // check against map and return only if not present
+                    while(cacheMap.containsKey(spilledEntry.getKey())) {
+                        // LRU Cache entries always take precedence, 
+                        // since they are more up to date
+                        if(spilledCacheIter.hasNext()) {
+                            value = spilledCacheIter.next();
+                            spilledEntry = spillManager.toCacheEntry(value);
+                        }
+                        else {
+                            notFound = true;
+                            break;
+                        }                        
+                    }
+                    if( !notFound ) {
+                        // Return a spilled entry, this only happens if the entry was not
+                        // found in the LRU cache
+                        return spilledEntry;
+                    }
+                } catch(IOException ioe) {
+                    // TODO rework error handling
+                    throw new RuntimeException(ioe);
+                }
+            }
+            // Spilled elements exhausted
+            // Finally return all elements from LRU cache
+            Map.Entry< ImmutableBytesPtr, Aggregator[] >entry = cacheIter.next();
+            CacheEntry ce = new SpillManager.CacheEntry(entry.getKey(), entry.getValue());
+            return ce;
+        }
+
+        /**
+         * Remove??? Denied!!!
+         */
+        @Override
+        public void remove() {
+            throw new IllegalAccessError("Remove is not supported for this type of iterator");            
+        }
+    }
+    
+    /**
+     * DO NOT USE, instead use the EntryIterator
+     */
+    @Override
+    public Set<java.util.Map.Entry<ImmutableBytesPtr, Aggregator[]>> entrySet() {
+        throw new IllegalAccessError("entrySet is not supported for this type of cache");
+    }
+    
+    
+    /**
+     * Closes cache and releases spill resources
+     * @throws IOException
+     */
+    public void close() throws IOException {
+        // Close spillable resources
+        Closeables.closeQuietly(spillManager);        
+    }
+}

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
@@ -1,5 +1,9 @@
 package com.salesforce.phoenix.cache.aggcache;
 
+import static com.salesforce.phoenix.query.QueryServices.SPGBY_MAX_CACHE_SIZE_ATTRIB;
+import static com.salesforce.phoenix.query.QueryServices.SPGBY_NUM_SPILLFILES_ATTRIB;
+import static com.salesforce.phoenix.query.QueryServicesOptions.DEFAULT_SPGBY_CACHE_MAX_SIZE;
+import static com.salesforce.phoenix.query.QueryServicesOptions.DEFAULT_SPGBY_NUM_SPILLFILES;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Iterator;
@@ -7,9 +11,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,143 +29,209 @@ import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.ServerAggregators;
 
 /**
- * Class that implements an LRU cache for key/Aggregator[] tuples.
- * Keys that do not yet exists are loaded into the cache automatically.
- * Eviction happens on a size limit basis. Evicted elements are spilled to disk.
+ * The main entry point is in GroupedAggregateRegionObserver. It instantiates a
+ * GroupByCache and invokes a get() method on it. There is no:
+ * "if key not exists -> put into map" case, since the cache is a Loading cache
+ * and therefore handles the put under the covers. I tried to implement the
+ * final cache element accesses (RegionScanner below) streaming, i.e. there is
+ * just an iterator on it and removed the existing result materialization.
+ * 
+ * GroupByCache implements a Guava LoadingCache, which an upper and lower
+ * configurable size limit. Optimally it is sized as estMapSize / valueSize,
+ * since the upper limit is number and not memory budget based. As long as no
+ * eviction happens no spillable data structures are allocated, this only
+ * happens as soon as the first element is evicted from the cache. We cannot
+ * really make any assumptions on which keys arrive at the map, but I thought
+ * the LRU would at least cover the cases where some keys have a slight skew and
+ * they should stay memory resident.
+ * 
+ * Once a key gets evicted, the spillManager is instantiated. It basically takes
+ * care of spilling an element to disk and does all the SERDE work. It creates a
+ * bunch of SpillFiles (spill partition) which are MemoryMappedFiles. Each
+ * MMFile only works with up to 2GB of spilled data, therefore the SpillManager
+ * keeps a list of these and hash distributes the keys within this list. Once an
+ * element gets spilled, it is serialized and will only get deserialized again,
+ * when it is requested from the client, i.e. loaded back into the LRU cache.
+ * The SpillManager holds a SpillMap for every spill partition (SpillFile). Each
+ * SpillMap has access to all the pages of its SpillFile, it also contains a
+ * list of bloomFilters, one for every page of the spillFile. Only a single
+ * page, the currently active page stays in memory. The in memory data structure
+ * of the page is a HashMap for easy key access purposes. An element evicted
+ * form the LRU cache is hashed into the correct SpillMap. the spillMap then
+ * determines via the list of BloomFilters on which page in the SpillFile the
+ * key resides and loads this page into a HashMap in memory. If the key was
+ * never spilled before, the SpillMap tries to fill up the current, in memory
+ * residing page with this new key. In case it doesn't fit, the current memory
+ * page is flushed to disk and a new page is requested. The key is then written
+ * to the new in-memory page. Lastly, the bloomFilter is updated so that this
+ * key can be discovered again. Loading a key works similarly, if not present in
+ * the LRU cache, the CacheLoader sets in. The key gets hashed into the correct
+ * SpillMap, the list of bloomFilters is walked to determined the SpillFile
+ * page, the key resides on and this page is loaded first into memory and
+ * eventually, into the LRU cache. Only for the last step the deserialization is
+ * triggered. The aggregators are returned from the LRU cache and the next value
+ * is computed. In case the key is not found on any page, the Loader create new
+ * aggregators for it.
  */
 public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
-    private static final Logger logger = LoggerFactory.getLogger(SpillManager.class);
-    
-    private static final int NUM_SPILLFILES = 5;
-    // TODO what are proper defaults?
-    private static final int CACHE_MIN_SIZE = 10;
-    private static final int CACHE_MAX_SIZE = 10000;
-    // TODO Generally better to use Collection API with generics instead of array types
+    private static final Logger logger = LoggerFactory
+            .getLogger(SpillManager.class);
+
+    // Min size of 1st level main memory cache in bytes --> lower bound
+    private static final int SPGBY_CACHE_MIN_SIZE = 4096; // 4K
+
+    // TODO Generally better to use Collection API with generics instead of
+    // array types
     public final LoadingCache<ImmutableBytesPtr, Aggregator[]> cache;
     private SpillManager spillManager = null;
     private final ObserverContext<RegionCoprocessorEnvironment> context;
     private int curNumCacheElements;
     private final int estValueSize;
     private final ServerAggregators aggregators;
-       
-    
+
     /**
      * Instantiates a Loading LRU Cache that stores key / aggregator[] tuples
      * used for group by queries
+     * 
      * @param estSize
      * @param estValueSize
      * @param aggs
      * @param ctxt
      */
-    public GroupByCache( long estSize, int estValueSize, ServerAggregators aggs,
-                         final ObserverContext<RegionCoprocessorEnvironment> ctxt ) {
-        context = ctxt; 
+    public GroupByCache(long estSize, int estValueSize, ServerAggregators aggs,
+            final ObserverContext<RegionCoprocessorEnvironment> ctxt) {
+        context = ctxt;
         this.estValueSize = estValueSize;
         curNumCacheElements = 0;
-        this.aggregators = aggs;
+        this.aggregators = aggs;        
         
-        // use upper and lower bounds for the cache size 
-        int maxCacheSize = Math.max(CACHE_MIN_SIZE, Math.min(CACHE_MAX_SIZE,((int)estSize / estValueSize )));
+        Configuration conf = ctxt.getEnvironment().getConfiguration();
+        final long maxCacheSizeConf = conf.getLong(SPGBY_MAX_CACHE_SIZE_ATTRIB, DEFAULT_SPGBY_CACHE_MAX_SIZE);
+        final int numSpillFilesConf = conf.getInt(SPGBY_NUM_SPILLFILES_ATTRIB, DEFAULT_SPGBY_NUM_SPILLFILES);
+        
+        logger.error("conf size" + maxCacheSizeConf);
+        int estSizeNum = (int) (estSize / estValueSize);
+        int maxSizeNum = (int) ( maxCacheSizeConf / estValueSize);
+        int minSizeNum = (int) (SPGBY_CACHE_MIN_SIZE / estValueSize);
+        logger.error("estSize: " + estSize);
+        logger.error("estValueSize: " + estValueSize);
+        logger.error("estValueSize: " + estValueSize);
+        logger.error("estSizeNum: " + estSizeNum);
+        logger.error("maxSizeNum: " + maxSizeNum);
+        logger.error("minSizeNum: " + minSizeNum);
+
+        // use upper and lower bounds for the cache size
+        int maxCacheSize = Math.max(minSizeNum,
+                Math.min(maxSizeNum, estSizeNum));
+
         if (logger.isDebugEnabled()) {
-            logger.debug("Instantiating LRU groupby cache of element size: " + maxCacheSize);
+            logger.debug("Instantiating LRU groupby cache of element size: "
+                    + maxCacheSize);
         }
-        // Cache is element number bounded. Using the max of CACHE_MIN_SIZE and the est MapSize
-        cache = CacheBuilder.newBuilder().maximumSize(maxCacheSize)
-                .removalListener( 
+        // Cache is element number bounded. Using the max of CACHE_MIN_SIZE and
+        // the est MapSize
+        cache = CacheBuilder                
+                .newBuilder()
+                .recordStats()
+                .maximumSize(maxCacheSize)
+                .removalListener(
                         new RemovalListener<ImmutableBytesPtr, Aggregator[]>() {
                             /*
                              * CacheRemoval listener implementation
                              */
                             @Override
-                            public void onRemoval(RemovalNotification<ImmutableBytesPtr, Aggregator[]> notification) {
+                            public void onRemoval(
+                                    RemovalNotification<ImmutableBytesPtr, Aggregator[]> notification) {
                                 try {
-                                    if(spillManager == null) {
-                                        // Lazy instantiation of spillable data structures
+                                    if (spillManager == null) {
+                                        // Lazy instantiation of spillable data
+                                        // structures
                                         //
-                                        // Only create spill data structs if LRU cache is too small
-                                        spillManager = new SpillManager(NUM_SPILLFILES, aggregators, context.getEnvironment().getConfiguration());
+                                        // Only create spill data structs if LRU
+                                        // cache is too small
+                                        spillManager = new SpillManager(
+                                                numSpillFilesConf,
+                                                aggregators, context
+                                                        .getEnvironment()
+                                                        .getConfiguration());
                                     }
-                                    spillManager.spill(notification.getKey(), notification.getValue());
-                                    // keep track of elements in cache       
+                                    spillManager.spill(notification.getKey(),
+                                            notification.getValue());
+                                    // keep track of elements in cache
                                     curNumCacheElements--;
-                                }
-                                catch(IOException ioe) {
+                                } catch (IOException ioe) {
                                     // TODO rework error handling
                                     throw new RuntimeException(ioe);
                                 }
-                            }                            
-                        })                
-                .build(
-                       new CacheLoader<ImmutableBytesPtr, Aggregator[]>() {
-                           /*
-                            * CacheLoader implementation
-                            */
-                           @Override
-                           public Aggregator[] load(ImmutableBytesPtr key) throws Exception {
-                               
-                               Aggregator[] aggs = null;
-                               if(spillManager == null) {
-                                   // No spill Manager, always assume this key is new!
-                                   aggs = aggregators.newAggregators(context.getEnvironment().getConfiguration());
-                               }
-                               else {
-                                   // Spill manager present, check if key has been spilled before
-                                   aggs = spillManager.loadEntry(key);
-                                    if(aggs == null) {
-                                        // No, key never spilled before, create a new tuple
-                                        if (logger.isDebugEnabled()) {
-                                            logger.debug("Adding new aggregate bucket for row key " + Bytes.toStringBinary( key.get(),
-                                                                                                                            key.getOffset(),
-                                                                                                                            key.getLength()) );
-                                        }                                                                                
-                                        aggs = aggregators.newAggregators(context.getEnvironment().getConfiguration());                                 
-                                    }
-                               }
-                               // keep track of elements in cache       
-                               curNumCacheElements++;
-                               return aggs;
-                           }
-                       });
+                            }
+                        })
+                .build(new CacheLoader<ImmutableBytesPtr, Aggregator[]>() {
+                    /*
+                     * CacheLoader implementation
+                     */
+                    @Override
+                    public Aggregator[] load(ImmutableBytesPtr key)
+                            throws Exception {
+
+                        Aggregator[] aggs = null;
+                        if (spillManager == null) {
+                            // No spill Manager, always assume this key is new!
+                            aggs = aggregators.newAggregators(context
+                                    .getEnvironment().getConfiguration());
+                        } else {
+                            // Spill manager present, check if key has been
+                            // spilled before
+                            aggs = spillManager.loadEntry(key);
+                            if (aggs == null) {
+                                // No, key never spilled before, create a new tuple
+                                aggs = aggregators.newAggregators(context
+                                        .getEnvironment().getConfiguration());
+                            }
+                        }
+                        // keep track of elements in cache
+                        curNumCacheElements++;
+                        return aggs;
+                    }
+                });
     }
-    
-    
+
     /**
      * Size function returns the estimate LRU cache size in bytes
      */
     @Override
     public int size() {
         return curNumCacheElements * estValueSize;
-    }       
-    
+    }
+
     /**
-     * put function of Map interface
-     * DO NOT USE
-     * Cache takes automatically care of loading non-existing elements
+     * put function of Map interface DO NOT USE Cache takes automatically care
+     * of loading non-existing elements
      */
     @Override
     public Aggregator[] put(ImmutableBytesPtr key, Aggregator[] value) {
-        // Loading cache implicitly implements a put when a cache hit has occurred
+        // Loading cache implicitly implements a put when a cache hit has
+        // occurred
         // Disable the map interface
         throw new IllegalAccessError("put is not supported for a loading cache");
     }
 
     /**
-     * Extract an element from the Cache
-     * If element is not present in in-memory cache / or in spill files
-     * cache implements an implicit put() of a new key/value tuple and loads it into the cache
+     * Extract an element from the Cache If element is not present in in-memory
+     * cache / or in spill files cache implements an implicit put() of a new
+     * key/value tuple and loads it into the cache
      */
     @Override
-    public Aggregator[] get(Object key) { 
+    public Aggregator[] get(Object key) {
         try {
             // delegate to the cache implementation
-            return cache.get((ImmutableBytesPtr)key);            
+            return cache.get((ImmutableBytesPtr) key);
         } catch (ExecutionException e) {
             // TODO What's the proper way to surface errors?
             // FIXME using a non-checked exception for now...
             throw new RuntimeException(e);
         }
-    }    
-    
+    }
+
     /**
      * Return a map view of the cache, READ ONLY
      */
@@ -169,22 +239,21 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
         // Useful for iterators
         return cache.asMap();
     }
-    
-    
+
     /**
-     * This function creates a iterator over the cache and the spilled data structures.
-     * The key/value tuples are returned in non-deterministic order.
+     * This function creates a iterator over the cache and the spilled data
+     * structures. The key/value tuples are returned in non-deterministic order.
      */
     public EntryIterator newEntryIterator() {
         return new EntryIterator();
     }
-    
-    
+
     // Iterator that returns CacheEntries.
-    // CacheEntries are either extracted from the LRU cache or from the spillable data
+    // CacheEntries are either extracted from the LRU cache or from the
+    // spillable data
     // structures.
     private final class EntryIterator implements Iterator<CacheEntry> {
-        
+
         final Map<ImmutableBytesPtr, Aggregator[]> cacheMap;
         final Iterator<Map.Entry<ImmutableBytesPtr, Aggregator[]>> cacheIter;
         final Iterator<byte[]> spilledCacheIter;
@@ -192,56 +261,55 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
         private EntryIterator() {
             cacheMap = cache.asMap();
             cacheIter = cacheMap.entrySet().iterator();
-            if(spillManager != null) {
+            if (spillManager != null) {
                 spilledCacheIter = spillManager.newDataIterator();
-            }
-            else {
+            } else {
                 spilledCacheIter = null;
             }
         }
-        
+
         @Override
         public boolean hasNext() {
             return cacheIter.hasNext();
         }
-        
+
         @Override
         public CacheEntry next() {
-            if(spilledCacheIter != null && spilledCacheIter.hasNext())
-            {
+            if (spilledCacheIter != null && spilledCacheIter.hasNext()) {
                 try {
                     byte[] value = spilledCacheIter.next();
                     // Deserialize into a CacheEntry
                     CacheEntry spilledEntry = spillManager.toCacheEntry(value);
-                    
+
                     boolean notFound = false;
                     // check against map and return only if not present
-                    while(cacheMap.containsKey(spilledEntry.getKey())) {
-                        // LRU Cache entries always take precedence, 
+                    while (cacheMap.containsKey(spilledEntry.getKey())) {
+                        // LRU Cache entries always take precedence,
                         // since they are more up to date
-                        if(spilledCacheIter.hasNext()) {
+                        if (spilledCacheIter.hasNext()) {
                             value = spilledCacheIter.next();
                             spilledEntry = spillManager.toCacheEntry(value);
-                        }
-                        else {
+                        } else {
                             notFound = true;
                             break;
-                        }                        
+                        }
                     }
-                    if( !notFound ) {
-                        // Return a spilled entry, this only happens if the entry was not
+                    if (!notFound) {
+                        // Return a spilled entry, this only happens if the
+                        // entry was not
                         // found in the LRU cache
                         return spilledEntry;
                     }
-                } catch(IOException ioe) {
+                } catch (IOException ioe) {
                     // TODO rework error handling
                     throw new RuntimeException(ioe);
                 }
             }
             // Spilled elements exhausted
             // Finally return all elements from LRU cache
-            Map.Entry< ImmutableBytesPtr, Aggregator[] >entry = cacheIter.next();
-            CacheEntry ce = new SpillManager.CacheEntry(entry.getKey(), entry.getValue());
+            Map.Entry<ImmutableBytesPtr, Aggregator[]> entry = cacheIter.next();
+            CacheEntry ce = new SpillManager.CacheEntry(entry.getKey(),
+                    entry.getValue());
             return ce;
         }
 
@@ -250,25 +318,27 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
          */
         @Override
         public void remove() {
-            throw new IllegalAccessError("Remove is not supported for this type of iterator");            
+            throw new IllegalAccessError(
+                    "Remove is not supported for this type of iterator");
         }
     }
-    
+
     /**
      * DO NOT USE, instead use the EntryIterator
      */
     @Override
     public Set<java.util.Map.Entry<ImmutableBytesPtr, Aggregator[]>> entrySet() {
-        throw new IllegalAccessError("entrySet is not supported for this type of cache");
+        throw new IllegalAccessError(
+                "entrySet is not supported for this type of cache");
     }
-    
-    
+
     /**
      * Closes cache and releases spill resources
+     * 
      * @throws IOException
      */
     public void close() throws IOException {
         // Close spillable resources
-        Closeables.closeQuietly(spillManager);        
+        Closeables.closeQuietly(spillManager);
     }
 }

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
@@ -102,6 +102,7 @@ public class SpillFile implements Closeable {
         return maxPageId;
     }
     
+    @Override
     public void close() throws IOException {
         Closeables.closeQuietly(fc);
         Closeables.closeQuietly(file);

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
@@ -1,0 +1,116 @@
+package com.salesforce.phoenix.cache.aggcache;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.Closeables;
+
+/**
+ * This class abstracts a SpillFile
+ * It is a accessible on a page basis
+ */
+public class SpillFile implements Closeable {
+    
+    private static final Logger logger = LoggerFactory.getLogger(SpillFile.class);
+    // Default size for a single spillFile 2GB
+    private static final int SPILL_FILE_SIZE = Integer.MAX_VALUE;
+    // Page size for a spill file 4K
+    public static final int DEFAULT_PAGE_SIZE = 4096;
+    
+    private File tempFile;    
+    private FileChannel fc;
+    private RandomAccessFile file;
+    private int maxPageId;
+
+    /**
+     * Create a new SpillFile using the Java TempFile creation function.
+     * SpillFile is access in pages.
+     */
+    public static SpillFile createSpillFile() {
+        File tempFile = null;
+        try {            
+            tempFile = File.createTempFile(UUID.randomUUID().toString(), null);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Creating new SpillFile: " + tempFile.getAbsolutePath());
+            }
+            RandomAccessFile file = new RandomAccessFile( tempFile, "rw" );            
+            file.setLength(SPILL_FILE_SIZE);
+            return new SpillFile( tempFile, file );
+            
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not create Spillfile");
+        }
+        finally {
+            if(tempFile != null) {
+                // Cleanup hook 
+                tempFile.deleteOnExit();
+            }
+        }
+    }
+            
+    private SpillFile(File tempFile, RandomAccessFile file ) throws IOException {
+        this.tempFile = tempFile;
+        this.file = file;
+        this.fc = file.getChannel();
+        maxPageId = -1;
+    }
+    
+    /**
+     * Returns the next free page within the current spill file
+     */
+    public MappedByteBuffer getNextFreePage() {
+        try {            
+            maxPageId++;                        
+            int offset = maxPageId * DEFAULT_PAGE_SIZE;
+            return fc.map(MapMode.READ_WRITE, offset, DEFAULT_PAGE_SIZE);
+        }
+        catch(IOException ioe) {
+            throw new RuntimeException("Could not get next free page at index: " + maxPageId);
+        }
+    }
+    
+    
+    /**
+     * Random access to a page of the current spill file
+     * @param index
+     */
+    public MappedByteBuffer getPage(int index) {
+        try {
+            Preconditions.checkArgument(index <= maxPageId);
+            int offset = index * DEFAULT_PAGE_SIZE;
+            return fc.map(MapMode.READ_WRITE, offset, DEFAULT_PAGE_SIZE);
+        }
+        catch(IOException ioe) {
+            throw new RuntimeException("Could not get page at index: " + index);
+        }
+    }
+    
+    /**
+     * Return the current highest allocaled page in spill file
+     */
+    public int getMaxPageId() {
+        return maxPageId;
+    }
+    
+    public void close() throws IOException {
+        Closeables.closeQuietly(fc);
+        Closeables.closeQuietly(file);
+        if(tempFile != null) {
+            if(logger.isDebugEnabled()) {
+                logger.debug("Deleting tempFIle: " + tempFile.getAbsolutePath());
+            }
+            tempFile.delete();
+            tempFile = null;
+        }
+    }
+}   

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillFile.java
@@ -16,18 +16,18 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.Closeables;
 
 /**
- * This class abstracts a SpillFile
- * It is a accessible on a page basis
+ * This class abstracts a SpillFile It is a accessible on a page basis
  */
 public class SpillFile implements Closeable {
-    
-    private static final Logger logger = LoggerFactory.getLogger(SpillFile.class);
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(SpillFile.class);
     // Default size for a single spillFile 2GB
     private static final int SPILL_FILE_SIZE = Integer.MAX_VALUE;
     // Page size for a spill file 4K
-    public static final int DEFAULT_PAGE_SIZE = 4096;
-    
-    private File tempFile;    
+    static final int DEFAULT_PAGE_SIZE = 4 * 1024;
+
+    private File tempFile;
     private FileChannel fc;
     private RandomAccessFile file;
     private int maxPageId;
@@ -38,50 +38,50 @@ public class SpillFile implements Closeable {
      */
     public static SpillFile createSpillFile() {
         File tempFile = null;
-        try {            
+        try {
             tempFile = File.createTempFile(UUID.randomUUID().toString(), null);
             if (logger.isDebugEnabled()) {
-                logger.debug("Creating new SpillFile: " + tempFile.getAbsolutePath());
+                logger.debug("Creating new SpillFile: "
+                        + tempFile.getAbsolutePath());
             }
-            RandomAccessFile file = new RandomAccessFile( tempFile, "rw" );            
+            RandomAccessFile file = new RandomAccessFile(tempFile, "rw");
             file.setLength(SPILL_FILE_SIZE);
-            return new SpillFile( tempFile, file );
-            
+            return new SpillFile(tempFile, file);
+
         } catch (IOException ioe) {
             throw new RuntimeException("Could not create Spillfile");
-        }
-        finally {
-            if(tempFile != null) {
-                // Cleanup hook 
+        } finally {
+            if (tempFile != null) {
+                // Cleanup hook
                 tempFile.deleteOnExit();
             }
         }
     }
-            
-    private SpillFile(File tempFile, RandomAccessFile file ) throws IOException {
+
+    private SpillFile(File tempFile, RandomAccessFile file) throws IOException {
         this.tempFile = tempFile;
         this.file = file;
         this.fc = file.getChannel();
         maxPageId = -1;
     }
-    
+
     /**
      * Returns the next free page within the current spill file
      */
     public MappedByteBuffer getNextFreePage() {
-        try {            
-            maxPageId++;                        
+        try {
+            maxPageId++;
             int offset = maxPageId * DEFAULT_PAGE_SIZE;
             return fc.map(MapMode.READ_WRITE, offset, DEFAULT_PAGE_SIZE);
-        }
-        catch(IOException ioe) {
-            throw new RuntimeException("Could not get next free page at index: " + maxPageId);
+        } catch (IOException ioe) {
+            throw new RuntimeException(
+                    "Could not get next free page at index: " + maxPageId);
         }
     }
-    
-    
+
     /**
      * Random access to a page of the current spill file
+     * 
      * @param index
      */
     public MappedByteBuffer getPage(int index) {
@@ -89,29 +89,28 @@ public class SpillFile implements Closeable {
             Preconditions.checkArgument(index <= maxPageId);
             int offset = index * DEFAULT_PAGE_SIZE;
             return fc.map(MapMode.READ_WRITE, offset, DEFAULT_PAGE_SIZE);
-        }
-        catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new RuntimeException("Could not get page at index: " + index);
         }
     }
-    
+
     /**
      * Return the current highest allocaled page in spill file
      */
     public int getMaxPageId() {
         return maxPageId;
     }
-    
+
     @Override
     public void close() throws IOException {
         Closeables.closeQuietly(fc);
         Closeables.closeQuietly(file);
-        if(tempFile != null) {
-            if(logger.isDebugEnabled()) {
+        if (tempFile != null) {
+            if (logger.isDebugEnabled()) {
                 logger.debug("Deleting tempFIle: " + tempFile.getAbsolutePath());
             }
             tempFile.delete();
             tempFile = null;
         }
     }
-}   
+}

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
@@ -28,25 +28,23 @@ import com.salesforce.phoenix.util.KeyValueUtil;
 import com.salesforce.phoenix.util.TupleUtil;
 
 /**
- * Class servers as an adapter between the in-memory LRU cache and the 
- * Spill data structures. 
- * It takes care of serializing / deserializing the key/value groupby tuples,
- * and spilling them to the correct spill partition
+ * Class servers as an adapter between the in-memory LRU cache and the Spill
+ * data structures. It takes care of serializing / deserializing the key/value
+ * groupby tuples, and spilling them to the correct spill partition
  */
 public class SpillManager implements Closeable {
-    
+
     // Wrapper class for DESERIALIZED groupby key/value tuples
     public static class CacheEntry {
-        
+
         protected final ImmutableBytesPtr key;
         protected final Aggregator[] aggs;
-        
-        public CacheEntry( ImmutableBytesPtr key, 
-                            Aggregator[] aggs ) {
+
+        public CacheEntry(ImmutableBytesPtr key, Aggregator[] aggs) {
             this.key = key;
             this.aggs = aggs;
         }
-                
+
         public ImmutableBytesPtr getKey() {
             return key;
         }
@@ -54,13 +52,12 @@ public class SpillManager implements Closeable {
         public Aggregator[] getValue(Configuration conf) {
             return aggs;
         }
-                
+
         public int getKeyLength() {
             return key.getLength();
-        }        
-    }    
+        }
+    }
 
-    
     private final ArrayList<SpillMap> spillMaps;
     private final int numSpillFiles;
 
@@ -68,33 +65,37 @@ public class SpillManager implements Closeable {
     private final Configuration conf;
 
     /**
-     * SpillManager takes care of spilling and loading tuples from spilled data structs
+     * SpillManager takes care of spilling and loading tuples from spilled data
+     * structs
+     * 
      * @param numSpillFiles
      * @param serverAggregators
      */
-    public SpillManager(int numSpillFiles, ServerAggregators serverAggregators, Configuration conf) {
-        try {           
+    public SpillManager(int numSpillFiles, ServerAggregators serverAggregators,
+            Configuration conf) {
+        try {
             spillMaps = Lists.newArrayList();
             this.numSpillFiles = numSpillFiles;
             this.aggregators = serverAggregators;
             this.conf = conf;
-            
+
             // Create a list of spillFiles
             // Each Spillfile only handles up to 2GB data
-            for( int i = 0; i < numSpillFiles; i++ ) {
+            for (int i = 0; i < numSpillFiles; i++) {
                 SpillFile file = SpillFile.createSpillFile();
-                spillMaps.add(new SpillMap( file, SpillFile.DEFAULT_PAGE_SIZE ));               
+                spillMaps.add(new SpillMap(file, SpillFile.DEFAULT_PAGE_SIZE));
             }
         } catch (IOException ioe) {
             throw new RuntimeException("Could not init the SpillManager");
         }
     }
-        
+
     // serialize a key/value tuple into a byte array
     // WARNING: expensive
-    private byte[] serialize(ImmutableBytesPtr key, Aggregator[] aggs, ServerAggregators serverAggs) throws IOException {
-                    
-        DataOutputStream output = null; 
+    private byte[] serialize(ImmutableBytesPtr key, Aggregator[] aggs,
+            ServerAggregators serverAggs) throws IOException {
+
+        DataOutputStream output = null;
         ByteArrayOutputStream bai = null;
         try {
             bai = new ByteArrayOutputStream();
@@ -103,22 +104,21 @@ public class SpillManager implements Closeable {
             WritableUtils.writeVInt(output, key.getLength());
             // key
             output.write(key.get(), key.getOffset(), key.getLength());
-            byte[] aggsByte = serverAggs.toBytes(aggs);                        
+            byte[] aggsByte = serverAggs.toBytes(aggs);
             // aggs length
             WritableUtils.writeVInt(output, aggsByte.length);
             // aggs
             output.write(aggsByte);
-            
-            byte[] data = bai.toByteArray();            
+
+            byte[] data = bai.toByteArray();
             return data;
-        }
-        finally {
-            
-            if(bai != null) {
+        } finally {
+
+            if (bai != null) {
                 bai.close();
                 bai = null;
-            }            
-            if(output != null) {
+            }
+            if (output != null) {
                 output.close();
                 output = null;
             }
@@ -127,49 +127,51 @@ public class SpillManager implements Closeable {
 
     /**
      * Helper method to deserialize the key part from a serialized byte array
+     * 
      * @param data
      * @return
      * @throws IOException
      */
-     static ImmutableBytesPtr getKey(byte[] data) throws IOException {
+    static ImmutableBytesPtr getKey(byte[] data) throws IOException {
         DataInputStream input = null;
         try {
             input = new DataInputStream(new ByteArrayInputStream(data));
-            // key length                
+            // key length
             int keyLength = WritableUtils.readVInt(input);
             byte[] keyBytes = new byte[keyLength];
             // key
             input.readFully(keyBytes, 0, keyLength);
             return new ImmutableBytesPtr(keyBytes, 0, keyLength);
-        }
-        finally {
-            if(input != null) {
+        } finally {
+            if (input != null) {
                 input.close();
             }
         }
     }
 
-    // Instantiate Aggregators form a serialized byte array 
-    private Aggregator[] getAggregators (byte[] data) throws IOException {
+    // Instantiate Aggregators form a serialized byte array
+    private Aggregator[] getAggregators(byte[] data) throws IOException {
         DataInputStream input = null;
         try {
             input = new DataInputStream(new ByteArrayInputStream(data));
-            // key length                
+            // key length
             int keyLength = WritableUtils.readVInt(input);
             byte[] keyBytes = new byte[keyLength];
             // key
             input.readFully(keyBytes, 0, keyLength);
-            ImmutableBytesPtr ptr = new ImmutableBytesPtr(keyBytes, 0, keyLength);
-            
+            ImmutableBytesPtr ptr = new ImmutableBytesPtr(keyBytes, 0,
+                    keyLength);
+
             // value length
             int valueLength = WritableUtils.readVInt(input);
             byte[] valueBytes = new byte[valueLength];
             // value bytes
             input.readFully(valueBytes, 0, valueLength);
-            KeyValue keyValue = KeyValueUtil.newKeyValue( ptr.get(),ptr.getOffset(), ptr.getLength(), 
-                                                          QueryConstants.SINGLE_COLUMN_FAMILY, 
-                                                          QueryConstants.SINGLE_COLUMN, QueryConstants.AGG_TIMESTAMP, 
-                                                          valueBytes, 0, valueBytes.length);
+            KeyValue keyValue = KeyValueUtil.newKeyValue(ptr.get(),
+                    ptr.getOffset(), ptr.getLength(),
+                    QueryConstants.SINGLE_COLUMN_FAMILY,
+                    QueryConstants.SINGLE_COLUMN, QueryConstants.AGG_TIMESTAMP,
+                    valueBytes, 0, valueBytes.length);
             Tuple result = new SingleKeyValueTuple(keyValue);
             TupleUtil.getAggregateValue(result, ptr);
             KeyValueSchema schema = aggregators.getValueSchema();
@@ -182,30 +184,31 @@ public class SpillManager implements Closeable {
             Aggregator[] sAggs = new Aggregator[funcArray.length];
             Boolean hasValue;
             schema.iterator(ptr);
-            while ((hasValue=schema.next(ptr, i, maxOffset, tempValueSet)) != null) {
+            while ((hasValue = schema.next(ptr, i, maxOffset, tempValueSet)) != null) {
                 SingleAggregateFunction func = funcArray[i];
-                sAggs[i++] = hasValue ? func.newServerAggregator(conf, ptr) : func.newServerAggregator(conf);
+                sAggs[i++] = hasValue ? func.newServerAggregator(conf, ptr)
+                        : func.newServerAggregator(conf);
             }
             return sAggs;
-            
+
         } finally {
             Closeables.closeQuietly(input);
         }
     }
-    
+
     /**
-     * Helper function to deserialize a byte array into
-     * a CacheEntry
+     * Helper function to deserialize a byte array into a CacheEntry
+     * 
      * @param bytes
      * @throws IOException
      */
-    public CacheEntry toCacheEntry( byte[] bytes ) throws IOException {
+    public CacheEntry toCacheEntry(byte[] bytes) throws IOException {
         ImmutableBytesPtr key = SpillManager.getKey(bytes);
         Aggregator[] aggs = getAggregators(bytes);
-        
+
         return new CacheEntry(key, aggs);
     }
-    
+
     // Determines the partition, i.e. spillFile the tuple should get spilled to.
     private int getPartition(ImmutableBytesPtr key) {
         // Simple implementation hash mod numFiles
@@ -213,43 +216,46 @@ public class SpillManager implements Closeable {
     }
 
     /**
-     * Function that spills a key/value groupby tuple into a partition
-     * Spilling always triggers a serialize call
+     * Function that spills a key/value groupby tuple into a partition Spilling
+     * always triggers a serialize call
+     * 
      * @param key
      * @param value
      * @throws IOException
      */
-    public void spill(ImmutableBytesPtr key, Aggregator[] value) throws IOException{        
-        SpillMap spillMap = spillMaps.get( getPartition(key) );
+    public void spill(ImmutableBytesPtr key, Aggregator[] value)
+            throws IOException {
+        SpillMap spillMap = spillMaps.get(getPartition(key));
         byte[] data = serialize(key, value, aggregators);
         spillMap.put(key, data);
     }
 
     /**
-     * Function that loads a spilled key/value groupby tuple from one of the spill partitions 
-     * into the LRU cache.
-     * Loading always involves deserialization
+     * Function that loads a spilled key/value groupby tuple from one of the
+     * spill partitions into the LRU cache. Loading always involves
+     * deserialization
+     * 
      * @throws IOException
      */
     public Aggregator[] loadEntry(ImmutableBytesPtr key) throws IOException {
-        SpillMap spillMap = spillMaps.get( getPartition(key) );
+        SpillMap spillMap = spillMaps.get(getPartition(key));
         byte[] data = spillMap.get(key);
-        if(data != null) {
+        if (data != null) {
             return getAggregators(data);
         }
         return null;
     }
-    
+
     /**
      * Close the attached spillMap
      */
     @Override
     public void close() {
-        for(int i = 0; i < spillMaps.size(); i++) {
+        for (int i = 0; i < spillMaps.size(); i++) {
             Closeables.closeQuietly(spillMaps.get(i).getSpillFile());
         }
     }
-    
+
     /**
      * Function returns an iterator over all spilled Tuples
      */
@@ -260,13 +266,12 @@ public class SpillManager implements Closeable {
     private final class SpillMapIterator implements Iterator<byte[]> {
 
         int index = 0;
-        Iterator< byte[] >spillIter = spillMaps.get(index).iterator();
-        
+        Iterator<byte[]> spillIter = spillMaps.get(index).iterator();
+
         @Override
         public boolean hasNext() {
-            if(!spillIter.hasNext())
-            {
-                if(index < (numSpillFiles - 1) ) {
+            if (!spillIter.hasNext()) {
+                if (index < (numSpillFiles - 1)) {
                     // Current spillFile exhausted get iterator over new one
                     spillIter = spillMaps.get(++index).iterator();
                 }
@@ -281,7 +286,8 @@ public class SpillManager implements Closeable {
 
         @Override
         public void remove() {
-            throw new IllegalAccessError("Remove is not supported for this type of iterator");            
-        }       
+            throw new IllegalAccessError(
+                    "Remove is not supported for this type of iterator");
+        }
     }
 }

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
@@ -1,0 +1,284 @@
+package com.salesforce.phoenix.cache.aggcache;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.io.WritableUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Closeables;
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.ClientAggregators;
+import com.salesforce.phoenix.expression.aggregator.ServerAggregators;
+import com.salesforce.phoenix.query.QueryConstants;
+import com.salesforce.phoenix.schema.tuple.SingleKeyValueTuple;
+import com.salesforce.phoenix.util.KeyValueUtil;
+
+/**
+ * Class servers as an adapter between the in-memory LRU cache and the 
+ * Spill data structures. 
+ * It takes care of serializing / deserializing the key/value groupby tuples,
+ * and spilling them to the correct spill partition
+ */
+public class SpillManager implements Closeable {
+    
+    // Wrapper class for DESERIALIZED groupby key/value tuples
+    public static class CacheEntry {
+        
+        protected final ImmutableBytesPtr key;
+        protected final Aggregator[] aggs;
+        
+        public CacheEntry( ImmutableBytesPtr key, 
+                            Aggregator[] aggs ) {
+            this.key = key;
+            this.aggs = aggs;
+        }
+                
+        public ImmutableBytesPtr getKey() {
+            return key;
+        }
+
+        public Aggregator[] getValue(Configuration conf) {
+            return aggs;
+        }
+                
+        public int getKeyLength() {
+            return key.getLength();
+        }        
+    }    
+
+    
+    private final ArrayList<SpillMap> spillMaps;
+    private final int numSpillFiles;
+
+    private ServerAggregators serverAggregators;
+    private ClientAggregators clientAggregators;
+    private Aggregator[] aggregators;
+
+    /**
+     * SpillManager takes care of spilling and loading tuples from spilled data structs
+     * @param numSpillFiles
+     * @param serverAggregators
+     */
+    public SpillManager(int numSpillFiles, ServerAggregators serverAggregators) {
+        try {           
+            spillMaps = Lists.newArrayList();
+            this.numSpillFiles = numSpillFiles;
+            this.serverAggregators = serverAggregators;
+            clientAggregators = new ClientAggregators( Lists.newArrayList( serverAggregators.getFunctions()), 
+                                                                           serverAggregators.getValueSchema().getMinNullable() );
+            aggregators = clientAggregators.newAggregators();
+            
+            // Create a list of spillFiles
+            // Each Spillfile only handles up to 2GB data
+            for( int i = 0; i < numSpillFiles; i++ ) {
+                SpillFile file = SpillFile.createSpillFile();
+                spillMaps.add(new SpillMap( file, SpillFile.DEFAULT_PAGE_SIZE ));               
+            }
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not init the SpillManager");
+        }
+    }
+        
+    // serialize a key/value tuple into a byte array
+    // WARNING: expensive
+    private byte[] serialize(ImmutableBytesPtr key, Aggregator[] aggs, ServerAggregators serverAggs) throws IOException {
+                    
+        DataOutputStream output = null; 
+        ByteArrayOutputStream bai = null;
+        try {
+            bai = new ByteArrayOutputStream();
+            output = new DataOutputStream(bai);
+            // key length
+            WritableUtils.writeVInt(output, key.getLength());
+            // key
+            output.write(key.get(), key.getOffset(), key.getLength());
+            byte[] aggsByte = serverAggs.toBytes(aggs);                        
+            // aggs length
+            WritableUtils.writeVInt(output, aggsByte.length);
+            // aggs
+            output.write(aggsByte);
+            
+            byte[] data = bai.toByteArray();            
+            return data;
+        }
+        finally {
+            
+            if(bai != null) {
+                bai.close();
+                bai = null;
+            }            
+            if(output != null) {
+                output.close();
+                output = null;
+            }
+        }
+    }
+
+    /**
+     * Helper method to deserialize the key part from a serialized byte array
+     * @param data
+     * @return
+     * @throws IOException
+     */
+     static ImmutableBytesPtr getKey(byte[] data) throws IOException {
+        DataInputStream input = null;
+        try {
+            input = new DataInputStream(new ByteArrayInputStream(data));
+            // key length                
+            int keyLength = WritableUtils.readVInt(input);
+            byte[] keyBytes = new byte[keyLength];
+            // key
+            input.readFully(keyBytes, 0, keyLength);
+            return new ImmutableBytesPtr(keyBytes, 0, keyLength);
+        }
+        finally {
+            if(input != null) {
+                input.close();
+            }
+        }
+    }
+
+    // Instantiate Aggregators form a serialized byte array 
+    private Aggregator[] getAggregators (byte[] data) throws IOException {
+        DataInputStream input = null;
+        try {
+            input = new DataInputStream(new ByteArrayInputStream(data));
+            // key length                
+            int keyLength = WritableUtils.readVInt(input);
+            byte[] keyBytes = new byte[keyLength];
+            // key
+            input.readFully(keyBytes, 0, keyLength);
+            ImmutableBytesPtr key = new ImmutableBytesPtr(keyBytes, 0, keyLength);
+        
+            // value length
+            int valueLength = WritableUtils.readVInt(input);
+            byte[] valueBytes = new byte[valueLength];
+            // value bytes
+            input.readFully(valueBytes, 0, valueLength);
+            KeyValue keyValue = KeyValueUtil.newKeyValue( key.get(),key.getOffset(), key.getLength(), 
+                                                          QueryConstants.SINGLE_COLUMN_FAMILY, 
+                                                          QueryConstants.SINGLE_COLUMN, QueryConstants.AGG_TIMESTAMP, 
+                                                          valueBytes, 0, valueBytes.length);
+            
+            SingleKeyValueTuple skv = new SingleKeyValueTuple(keyValue);
+            clientAggregators.reset( aggregators );
+            clientAggregators.aggregate( aggregators, skv );
+            
+            Aggregator[] sAggs = serverAggregators.newAggregators();
+            for(int i = 0; i < sAggs.length; i++) {
+                // Init the aggregators, re-sets the serialized state, 
+                // i.e. the aggregated value
+                // TODO might just be implemented as a new constructor that initializes
+                // itself with client aggregators
+                sAggs[i].init( aggregators[i] );
+            }
+
+            return sAggs;
+            
+        } finally {
+            Closeables.closeQuietly(input);
+        }
+    }
+    
+    /**
+     * Helper function to deserialize a byte array into
+     * a CacheEntry
+     * @param bytes
+     * @throws IOException
+     */
+    public CacheEntry toCacheEntry( byte[] bytes ) throws IOException {
+        ImmutableBytesPtr key = SpillManager.getKey(bytes);
+        Aggregator[] aggs = getAggregators(bytes);
+        
+        return new CacheEntry(key, aggs);
+    }
+    
+    // Determines the partition, i.e. spillFile the tuple should get spilled to.
+    private int getPartition(ImmutableBytesPtr key) {
+        // Simple implementation hash mod numFiles
+        return Math.abs(key.hashCode()) % numSpillFiles;
+    }
+
+    /**
+     * Function that spills a key/value groupby tuple into a partition
+     * Spilling always triggers a serialize call
+     * @param key
+     * @param value
+     * @throws IOException
+     */
+    public void spill(ImmutableBytesPtr key, Aggregator[] value) throws IOException{        
+        SpillMap spillMap = spillMaps.get( getPartition(key) );
+        byte[] data = serialize(key, value, serverAggregators);
+        spillMap.put(key, data);
+    }
+
+    /**
+     * Function that loads a spilled key/value groupby tuple from one of the spill partitions 
+     * into the LRU cache.
+     * Loading always involves deserialization
+     * @throws IOException
+     */
+    public Aggregator[] loadEntry(ImmutableBytesPtr key) throws IOException {
+        SpillMap spillMap = spillMaps.get( getPartition(key) );
+        byte[] data = spillMap.get(key);
+        if(data != null) {
+            return getAggregators(data);
+        }
+        return null;
+    }
+    
+    /**
+     * Close the attached spillMap
+     */
+    @Override
+    public void close() {
+        for(int i = 0; i < spillMaps.size(); i++) {
+            Closeables.closeQuietly(spillMaps.get(i).getSpillFile());
+        }
+    }
+    
+    /**
+     * Function returns an iterator over all spilled Tuples
+     */
+    public SpillMapIterator newDataIterator() {
+        return new SpillMapIterator();
+    }
+
+    private final class SpillMapIterator implements Iterator<byte[]> {
+
+        int index = 0;
+        Iterator< byte[] >spillIter = spillMaps.get(index).iterator();
+        
+        @Override
+        public boolean hasNext() {
+            if(!spillIter.hasNext())
+            {
+                if(index < (numSpillFiles - 1) ) {
+                    // Current spillFile exhausted get iterator over new one
+                    spillIter = spillMaps.get(++index).iterator();
+                }
+            }
+            return spillIter.hasNext();
+        }
+
+        @Override
+        public byte[] next() {
+            return spillIter.next();
+        }
+
+        @Override
+        public void remove() {
+            throw new IllegalAccessError("Remove is not supported for this type of iterator");            
+        }       
+    }
+}

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillMap.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillMap.java
@@ -13,7 +13,6 @@ import java.util.Set;
 
 import org.apache.hadoop.hbase.util.Bytes;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.hash.BloomFilter;
@@ -21,45 +20,47 @@ import com.google.common.hash.Funnels;
 import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 
 /**
- * Class implements an active spilled partition
- * serialized tuples are first written into an in-memory data structure that represents
- * a single page. As the page fills up, it is written to the current spillFile or spill partition
- * For fast tuple discovery, the class maintains a per page bloom-filter and never de-serializes elements 
+ * Class implements an active spilled partition serialized tuples are first
+ * written into an in-memory data structure that represents a single page. As
+ * the page fills up, it is written to the current spillFile or spill partition
+ * For fast tuple discovery, the class maintains a per page bloom-filter and
+ * never de-serializes elements
  */
-public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements Iterable<byte[]> {
+public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements
+        Iterable<byte[]> {
 
     // threshold is typically the page size
     private final int thresholdBytes;
     private MappedByteBufferMap byteMap = null;
-    // Keep a list of bloomfilters, one for every page to quickly determine 
+    // Keep a list of bloomfilters, one for every page to quickly determine
     // which page determines the requested key
     private ArrayList<BloomFilter<byte[]>> bFilters;
     private SpillFile spillFile;
-    
+
     public SpillMap(SpillFile file, int thresholdBytes) throws IOException {
         this.thresholdBytes = thresholdBytes;
-        this.spillFile = file;        
-        byteMap = MappedByteBufferMap.newMappedByteBufferMap(thresholdBytes, spillFile);
+        this.spillFile = file;
+        byteMap = MappedByteBufferMap.newMappedByteBufferMap(thresholdBytes,
+                spillFile);
         bFilters = Lists.newArrayList();
         bFilters.add(BloomFilter.create(Funnels.byteArrayFunnel(), 1000));
     }
 
-    
     /**
-     * Get a key from the spillable data structures
-     * This conducts a linear search through all active pages in the current SpillFile
-     * Before doing an actual IO on the page, we check its associated bloomFilter if
-     * the key is contained. False positives are possible but compensated for.
+     * Get a key from the spillable data structures This conducts a linear
+     * search through all active pages in the current SpillFile Before doing an
+     * actual IO on the page, we check its associated bloomFilter if the key is
+     * contained. False positives are possible but compensated for.
      */
     @Override
     public byte[] get(Object key) {
-        if(! (key instanceof ImmutableBytesPtr)) {
+        if (!(key instanceof ImmutableBytesPtr)) {
             // TODO ... work on type safety
-        }        
-        ImmutableBytesPtr ikey = (ImmutableBytesPtr)key;
+        }
+        ImmutableBytesPtr ikey = (ImmutableBytesPtr) key;
         byte[] value = null;
         int bucketIndex = 0;
-        
+
         // Iterate over all pages
         for (int i = 0; i <= spillFile.getMaxPageId(); i++) {
             // run in loop in case of false positives in bloom filter
@@ -77,49 +78,45 @@ public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements 
                     byteMap.flushBuffer();
                 }
                 // load page into memory
-                byteMap = MappedByteBufferMap.newMappedByteBufferMap(bucketIndex, thresholdBytes, spillFile);
+                byteMap = MappedByteBufferMap.newMappedByteBufferMap(
+                        bucketIndex, thresholdBytes, spillFile);
                 byteMap.pageIn();
             }
             // get KV from current queue
             value = byteMap.getPagedInElement(ikey);
-            if ( value != null ) {
+            if (value != null) {
                 return value;
             }
         }
         return value;
     }
-        
+
     /**
-     * Spill a key
-     * First we discover if the key has been spilled before and load it into memory:
-     * #ref get()
-     * if it was loaded before just replace the old value in the memory page
-     * if it was not loaded before try to store it in the current page
-     *    alternatively if not enough memory available, request new page.
+     * Spill a key First we discover if the key has been spilled before and load
+     * it into memory: #ref get() if it was loaded before just replace the old
+     * value in the memory page if it was not loaded before try to store it in
+     * the current page alternatively if not enough memory available, request
+     * new page.
      */
     @Override
     public byte[] put(ImmutableBytesPtr key, byte[] value) {
-
         // page in element and replace if present
         byte[] spilledValue = get(key);
-        if( spilledValue == null ) {
-            // Key does not exist yet            
-            // Check that currentPage is not full yet and optionally spill to disk
-            ensureSpace(value);
-            addKeyToBloomFilter(byteMap.getCurIndex(), key);
-        }
-        byteMap.putPagedInElement(key, value);        
+
+        MappedByteBufferMap byteMap = ensureSpace(spilledValue, value);        
+        byteMap.addElement(spilledValue, key, value);
+        addKeyToBloomFilter(byteMap.getCurIndex(), key);
+
         return value;
     }
-    
+
     /**
-     * Function returns the current spill file 
+     * Function returns the current spill file
      */
     public SpillFile getSpillFile() {
         return spillFile;
     }
-    
-    
+
     private int isKeyinPage(ImmutableBytesPtr key, int index) {
         // use BloomFilter to determine if key is contained in page
         // prevent expensive IO
@@ -128,84 +125,102 @@ public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements 
         }
         return -1;
     }
-    
-    // Funtion checks if current page has enough space to fit the new serialized tuple
+
+    // Funtion checks if current page has enough space to fit the new serialized
+    // tuple
     // If not it flushes the current buffer and gets a new page
-    // TODO: The code does not ensure that pages are optimally packed. 
-    //       It only tries to fill up the current page as much as possbile, if its 
-    //       exhausted it requests a new page. Instead it would be nice to load the next page
-    //       that could fit the new value.
-    private void ensureSpace(byte[] value) {
-        if (!byteMap.canFit(value)) {
+    // TODO: The code does not ensure that pages are optimally packed.
+    // It only tries to fill up the current page as much as possbile, if its
+    // exhausted it requests a new page. Instead it would be nice to load the
+    // next page
+    // that could fit the new value.
+    private MappedByteBufferMap ensureSpace(byte[] prevValue, byte[] newValue) {
+        if (!byteMap.canFit(prevValue, newValue)) {
+            if (prevValue != null) {
+                // Element grew in size and does not fit into buffer
+                // anymore.
+                // TODO InvalidateValue();
+                throw new RuntimeException("Element grew to large, not supported yet");
+            }
             // Flush current buffer
             byteMap.flushBuffer();
             // Get next page
-            byteMap = MappedByteBufferMap.newMappedByteBufferMap(thresholdBytes, spillFile);            
+            byteMap = MappedByteBufferMap.newMappedByteBufferMap(
+                    thresholdBytes, spillFile);
             // Create new bloomfilter
             bFilters.add(BloomFilter.create(Funnels.byteArrayFunnel(), 1000));
         }
+        return byteMap;
     }
 
     private void addKeyToBloomFilter(int index, ImmutableBytesPtr key) {
         BloomFilter<byte[]> bFilter = bFilters.get(index);
         bFilter.put(key.copyBytes());
     }
-    
-    
+
     /**
-     * This inner class represents the currently mapped file region.
-     *  It uses a Map to represent the current in memory page for easy get() and update()
-     *  calls on an individual key 
-     *  The class keeps track of the current size of the in memory page and handles 
-     *  flushing and paging in respectively
+     * This inner class represents the currently mapped file region. It uses a
+     * Map to represent the current in memory page for easy get() and update()
+     * calls on an individual key The class keeps track of the current size of
+     * the in memory page and handles flushing and paging in respectively
      */
     private static class MappedByteBufferMap {
         private final int thresholdBytes;
         private long totalResultSize = 0;
         private MappedByteBuffer buffer;
         private int bufferIndex;
-        // Use a map for in memory page representation        
+        // Use a map for in memory page representation
         Map<ImmutableBytesPtr, byte[]> pageMap = Maps.newConcurrentMap();
 
         private MappedByteBufferMap(int index, MappedByteBuffer buffer,
                 int thresholdBytes) {
-                //throws IOException {
+            // throws IOException {
             this.bufferIndex = index;
             this.buffer = buffer;
             // size threshold of a page
-            this.thresholdBytes = thresholdBytes - Bytes.SIZEOF_INT;            
+            this.thresholdBytes = thresholdBytes - Bytes.SIZEOF_INT;
             pageMap.clear();
         }
-        
-        // Get the next free new MappedMap 
-        static MappedByteBufferMap newMappedByteBufferMap(int thresholdBytes, SpillFile spillFile) {
+
+        // Get the next free new MappedMap
+        static MappedByteBufferMap newMappedByteBufferMap(int thresholdBytes,
+                SpillFile spillFile) {
             MappedByteBuffer buffer = spillFile.getNextFreePage();
-            return new MappedByteBufferMap(spillFile.getMaxPageId(), buffer, thresholdBytes);           
+            return new MappedByteBufferMap(spillFile.getMaxPageId(), buffer,
+                    thresholdBytes);
         }
-        
+
         // Random access to new MappedMap
-        static MappedByteBufferMap newMappedByteBufferMap(int index, int thresholdBytes, SpillFile spillFile) {
+        static MappedByteBufferMap newMappedByteBufferMap(int index,
+                int thresholdBytes, SpillFile spillFile) {
             MappedByteBuffer buffer = spillFile.getPage(index);
-            return new MappedByteBufferMap(index, buffer, thresholdBytes);           
+            return new MappedByteBufferMap(index, buffer, thresholdBytes);
         }
-        
-        
-        private boolean canFit(byte[] value) {
-            if (thresholdBytes < value.length) {
-                // TODO resize page size if single element is too big, 
+
+        private boolean canFit(byte[] curValue, byte[] newValue) {
+            if (thresholdBytes < newValue.length) {
+                // TODO resize page size if single element is too big,
                 // Can this ever happen?
-                throw new RuntimeException("page size too small to store a single KV element");
+                throw new RuntimeException(
+                        "page size too small to store a single KV element");
             }
-            int resultSize = value.length + Bytes.SIZEOF_INT;
-            if ((thresholdBytes - totalResultSize) < resultSize) {
+
+            int resultSize = newValue.length + Bytes.SIZEOF_INT;
+            if (curValue != null) {
+                // Key existed before
+                // Ensure to compensate for potential larger byte[] for agg
+                resultSize = Math.max(0, resultSize
+                        - (curValue.length + Bytes.SIZEOF_INT));
+            }
+
+            if ((thresholdBytes - totalResultSize) <= (resultSize)) {
                 // KV does not fit
                 return false;
             }
             // KV fits
-            totalResultSize += resultSize;
             return true;
         }
-        
+
         public int getCurIndex() {
             return bufferIndex;
         }
@@ -216,20 +231,19 @@ public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements 
 
         // Flush the current page to the memory mapped byte buffer
         private void flushBuffer() throws BufferOverflowException {
-            Collection<byte[]> values = ImmutableMap.copyOf(pageMap).values();
-            buffer.clear();                
+            Collection<byte[]> values = pageMap.values();
+            buffer.clear();
             // number of elements
-            buffer.putInt(values.size());                
+            buffer.putInt(values.size());
             for (byte[] value : values) {
                 // element length
                 buffer.putInt(value.length);
                 // element
                 buffer.put(value, 0, value.length);
             }
-            
             // Reset page stats
             pageMap.clear();
-            totalResultSize = 0;            
+            totalResultSize = 0;
         }
 
         // load memory mapped region into a map for fast element access
@@ -241,7 +255,7 @@ public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements 
                 buffer.get(data, 0, kvSize);
                 try {
                     pageMap.put(SpillManager.getKey(data), data);
-                    totalResultSize += data.length + Bytes.SIZEOF_INT;
+                    totalResultSize += (data.length + Bytes.SIZEOF_INT);
                 } catch (IOException ioe) {
                     // Error during key access on spilled resource
                     // TODO rework error handling
@@ -249,110 +263,128 @@ public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements 
                 }
             }
         }
-        
+
         /**
-         * Return a cache element currently page into memory
-         * Direct access via mapped page map
+         * Return a cache element currently page into memory Direct access via
+         * mapped page map
+         * 
          * @param key
          * @return
          */
-        public byte[] getPagedInElement(ImmutableBytesPtr key) {            
-            return pageMap.get(key);            
+        public byte[] getPagedInElement(ImmutableBytesPtr key) {
+            return pageMap.get(key);
         }
 
-
         /**
-         * Inserts / Replaces cache element in the currently loaded page.
-         * Direct access via mapped page map
+         * Inserts / Replaces cache element in the currently loaded page. Direct
+         * access via mapped page map
+         * 
          * @param key
          * @param value
          */
-        public void putPagedInElement(ImmutableBytesPtr key, byte[] value) {
+        public void addElement(byte[] spilledValue, ImmutableBytesPtr key,
+                byte[] value) {
+
+            // put Element into map
             pageMap.put(key, value);
+            // track current Map size to prevent Buffer overflows
+            if (spilledValue != null) {
+                // if previous key was present, just add the size difference
+                totalResultSize += Math.max(0, value.length
+                        - (spilledValue.length));
+            } else {
+                // Add new size information
+                totalResultSize += (value.length + Bytes.SIZEOF_INT);
+            }
         }
-        
-        
+
         /**
-         * Returns a value iterator over the pageMap 
+         * Returns a value iterator over the pageMap
          */
         public Iterator<byte[]> getPageMapEntries() {
             return pageMap.values().iterator();
         }
-        
+
         /**
-         * Direct access to the current memory mapped buffer
-         * Used by Iterator to prevent loading the pageMap first
+         * Direct access to the current memory mapped buffer Used by Iterator to
+         * prevent loading the pageMap first
          * 
          * @return List of all serialized aggregate objects in arbitrary order
          * @throws IndexOutOfBoundsException
          */
-        public List<byte[]> getMemBufferElements() throws IndexOutOfBoundsException {
+        public List<byte[]> getMemBufferElements()
+                throws IndexOutOfBoundsException {
             ArrayList<byte[]> elements = Lists.newArrayList();
             int numElements = buffer.getInt();
 
             for (int i = 0; i < numElements; i++) {
                 int kvSize = buffer.getInt();
                 byte[] data = new byte[kvSize];
-                buffer.get(data, 0, kvSize);            
+                buffer.get(data, 0, kvSize);
                 elements.add(data);
             }
             return elements;
         }
     }
-       
+
     @Override
     public Iterator<byte[]> iterator() {
-        
+
         return new Iterator<byte[]>() {
             List<byte[]> bufferEntries;
             int pageIndex = 0;
+            int inMemPageIndex = byteMap.getCurIndex();
             int curBufferIndex = 0;
             int curBufferSize = 0;
             long highestPageId = spillFile.getMaxPageId();
-            Iterator<byte[]>entriesIter = byteMap.getPageMapEntries();
+            Iterator<byte[]> entriesIter = byteMap.getPageMapEntries();
 
             @Override
             public boolean hasNext() {
-                if(highestPageId == 0) {
+                if (highestPageId == 0) {
                     // single page only, no need to do more IO
                     return entriesIter.hasNext();
                 }
-                if ( pageIndex >= highestPageId && curBufferIndex >= curBufferSize) {
+                if (inMemPageIndex == pageIndex) {
+                    // skip current page, since covered by in memory map already
+                    pageIndex++;
+                }
+                if (pageIndex > highestPageId
+                        && curBufferIndex >= curBufferSize) {
                     return false;
+                }
+                if (curBufferIndex >= curBufferSize) {
+                    // get keys from all spilled pages
+                    MappedByteBuffer buffer = spillFile.getPage(pageIndex++);
+                    byteMap = new MappedByteBufferMap(pageIndex, buffer,
+                            thresholdBytes);
+                    bufferEntries = byteMap.getMemBufferElements();
+                    curBufferSize = bufferEntries.size();
+                    curBufferIndex = 0;
                 }
                 return true;
             }
 
             @Override
             public byte[] next() {
-                if( entriesIter.hasNext() ) {
+                if (entriesIter.hasNext()) {
                     // get elements from in memory map first
                     return entriesIter.next();
-                }
-                if(pageIndex == byteMap.getCurIndex()) {
-                    // skip current page, since covered by in memory map already
-                    pageIndex++;                    
-                }
-                if (curBufferIndex >= curBufferSize) {
-                    // get keys from all spilled pages
-                    MappedByteBuffer buffer = spillFile.getPage(pageIndex++);
-                    byteMap = new MappedByteBufferMap(pageIndex, buffer, thresholdBytes);
-                    bufferEntries = byteMap.getMemBufferElements();
-                    curBufferSize = bufferEntries.size();
-                    curBufferIndex = 0;
                 }
                 return bufferEntries.get(curBufferIndex++);
             }
 
             @Override
             public void remove() {
-                throw new IllegalAccessError("Iterator does not support removal operation");
+                throw new IllegalAccessError(
+                        "Iterator does not support removal operation");
             }
         };
     }
 
     @Override
     public Set<java.util.Map.Entry<ImmutableBytesPtr, byte[]>> entrySet() {
-        throw new IllegalAccessError("entrySet is not supported for this type of cache");
+        throw new IllegalAccessError(
+                "entrySet is not supported for this type of cache");
     }
 }

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillMap.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillMap.java
@@ -1,0 +1,358 @@
+package com.salesforce.phoenix.cache.aggcache;
+
+import java.io.IOException;
+import java.nio.BufferOverflowException;
+import java.nio.MappedByteBuffer;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
+
+/**
+ * Class implements an active spilled partition
+ * serialized tuples are first written into an in-memory data structure that represents
+ * a single page. As the page fills up, it is written to the current spillFile or spill partition
+ * For fast tuple discovery, the class maintains a per page bloom-filter and never de-serializes elements 
+ */
+public class SpillMap extends AbstractMap<ImmutableBytesPtr, byte[]> implements Iterable<byte[]> {
+
+    // threshold is typically the page size
+    private final int thresholdBytes;
+    private MappedByteBufferMap byteMap = null;
+    // Keep a list of bloomfilters, one for every page to quickly determine 
+    // which page determines the requested key
+    private ArrayList<BloomFilter<byte[]>> bFilters;
+    private SpillFile spillFile;
+    
+    public SpillMap(SpillFile file, int thresholdBytes) throws IOException {
+        this.thresholdBytes = thresholdBytes;
+        this.spillFile = file;        
+        byteMap = MappedByteBufferMap.newMappedByteBufferMap(thresholdBytes, spillFile);
+        bFilters = Lists.newArrayList();
+        bFilters.add(BloomFilter.create(Funnels.byteArrayFunnel(), 1000));
+    }
+
+    
+    /**
+     * Get a key from the spillable data structures
+     * This conducts a linear search through all active pages in the current SpillFile
+     * Before doing an actual IO on the page, we check its associated bloomFilter if
+     * the key is contained. False positives are possible but compensated for.
+     */
+    @Override
+    public byte[] get(Object key) {
+        if(! (key instanceof ImmutableBytesPtr)) {
+            // TODO ... work on type safety
+        }        
+        ImmutableBytesPtr ikey = (ImmutableBytesPtr)key;
+        byte[] value = null;
+        int bucketIndex = 0;
+        
+        // Iterate over all pages
+        for (int i = 0; i <= spillFile.getMaxPageId(); i++) {
+            // run in loop in case of false positives in bloom filter
+            bucketIndex = isKeyinPage(ikey, i);
+            if (bucketIndex == -1) {
+                // key not contained in current bloom filter
+                continue;
+            }
+
+            if (bucketIndex != byteMap.getCurIndex()) {
+                // key contained in page which is not in memory
+                // page it in
+                if (byteMap.getSize() > 0) {
+                    // ensure consistency and flush current memory page to disk
+                    byteMap.flushBuffer();
+                }
+                // load page into memory
+                byteMap = MappedByteBufferMap.newMappedByteBufferMap(bucketIndex, thresholdBytes, spillFile);
+                byteMap.pageIn();
+            }
+            // get KV from current queue
+            value = byteMap.getPagedInElement(ikey);
+            if ( value != null ) {
+                return value;
+            }
+        }
+        return value;
+    }
+        
+    /**
+     * Spill a key
+     * First we discover if the key has been spilled before and load it into memory:
+     * #ref get()
+     * if it was loaded before just replace the old value in the memory page
+     * if it was not loaded before try to store it in the current page
+     *    alternatively if not enough memory available, request new page.
+     */
+    @Override
+    public byte[] put(ImmutableBytesPtr key, byte[] value) {
+
+        // page in element and replace if present
+        byte[] spilledValue = get(key);
+        if( spilledValue == null ) {
+            // Key does not exist yet            
+            // Check that currentPage is not full yet and optionally spill to disk
+            ensureSpace(value);
+            addKeyToBloomFilter(byteMap.getCurIndex(), key);
+        }
+        byteMap.putPagedInElement(key, value);        
+        return value;
+    }
+    
+    /**
+     * Function returns the current spill file 
+     */
+    public SpillFile getSpillFile() {
+        return spillFile;
+    }
+    
+    
+    private int isKeyinPage(ImmutableBytesPtr key, int index) {
+        // use BloomFilter to determine if key is contained in page
+        // prevent expensive IO
+        if (bFilters.get(index).mightContain(key.copyBytes())) {
+            return index;
+        }
+        return -1;
+    }
+    
+    // Funtion checks if current page has enough space to fit the new serialized tuple
+    // If not it flushes the current buffer and gets a new page
+    // TODO: The code does not ensure that pages are optimally packed. 
+    //       It only tries to fill up the current page as much as possbile, if its 
+    //       exhausted it requests a new page. Instead it would be nice to load the next page
+    //       that could fit the new value.
+    private void ensureSpace(byte[] value) {
+        if (!byteMap.canFit(value)) {
+            // Flush current buffer
+            byteMap.flushBuffer();
+            // Get next page
+            byteMap = MappedByteBufferMap.newMappedByteBufferMap(thresholdBytes, spillFile);            
+            // Create new bloomfilter
+            bFilters.add(BloomFilter.create(Funnels.byteArrayFunnel(), 1000));
+        }
+    }
+
+    private void addKeyToBloomFilter(int index, ImmutableBytesPtr key) {
+        BloomFilter<byte[]> bFilter = bFilters.get(index);
+        bFilter.put(key.copyBytes());
+    }
+    
+    
+    /**
+     * This inner class represents the currently mapped file region.
+     *  It uses a Map to represent the current in memory page for easy get() and update()
+     *  calls on an individual key 
+     *  The class keeps track of the current size of the in memory page and handles 
+     *  flushing and paging in respectively
+     */
+    private static class MappedByteBufferMap {
+        private final int thresholdBytes;
+        private long totalResultSize = 0;
+        private MappedByteBuffer buffer;
+        private int bufferIndex;
+        // Use a map for in memory page representation        
+        Map<ImmutableBytesPtr, byte[]> pageMap = Maps.newConcurrentMap();
+
+        private MappedByteBufferMap(int index, MappedByteBuffer buffer,
+                int thresholdBytes) {
+                //throws IOException {
+            this.bufferIndex = index;
+            this.buffer = buffer;
+            // size threshold of a page
+            this.thresholdBytes = thresholdBytes - Bytes.SIZEOF_INT;            
+            pageMap.clear();
+        }
+        
+        // Get the next free new MappedMap 
+        static MappedByteBufferMap newMappedByteBufferMap(int thresholdBytes, SpillFile spillFile) {
+            MappedByteBuffer buffer = spillFile.getNextFreePage();
+            return new MappedByteBufferMap(spillFile.getMaxPageId(), buffer, thresholdBytes);           
+        }
+        
+        // Random access to new MappedMap
+        static MappedByteBufferMap newMappedByteBufferMap(int index, int thresholdBytes, SpillFile spillFile) {
+            MappedByteBuffer buffer = spillFile.getPage(index);
+            return new MappedByteBufferMap(index, buffer, thresholdBytes);           
+        }
+        
+        
+        private boolean canFit(byte[] value) {
+            if (thresholdBytes < value.length) {
+                // TODO resize page size if single element is too big, 
+                // Can this ever happen?
+                throw new RuntimeException("page size too small to store a single KV element");
+            }
+            int resultSize = value.length + Bytes.SIZEOF_INT;
+            if ((thresholdBytes - totalResultSize) < resultSize) {
+                // KV does not fit
+                return false;
+            }
+            // KV fits
+            totalResultSize += resultSize;
+            return true;
+        }
+        
+        public int getCurIndex() {
+            return bufferIndex;
+        }
+
+        public int getSize() {
+            return pageMap.size();
+        }
+
+        // Flush the current page to the memory mapped byte buffer
+        private void flushBuffer() throws BufferOverflowException {
+            Collection<byte[]> values = ImmutableMap.copyOf(pageMap).values();
+            buffer.clear();                
+            // number of elements
+            buffer.putInt(values.size());                
+            for (byte[] value : values) {
+                // element length
+                buffer.putInt(value.length);
+                // element
+                buffer.put(value, 0, value.length);
+            }
+            
+            // Reset page stats
+            pageMap.clear();
+            totalResultSize = 0;            
+        }
+
+        // load memory mapped region into a map for fast element access
+        private void pageIn() throws IndexOutOfBoundsException {
+            int numElements = buffer.getInt();
+            for (int i = 0; i < numElements; i++) {
+                int kvSize = buffer.getInt();
+                byte[] data = new byte[kvSize];
+                buffer.get(data, 0, kvSize);
+                try {
+                    pageMap.put(SpillManager.getKey(data), data);
+                    totalResultSize += data.length + Bytes.SIZEOF_INT;
+                } catch (IOException ioe) {
+                    // Error during key access on spilled resource
+                    // TODO rework error handling
+                    throw new RuntimeException(ioe);
+                }
+            }
+        }
+        
+        /**
+         * Return a cache element currently page into memory
+         * Direct access via mapped page map
+         * @param key
+         * @return
+         */
+        public byte[] getPagedInElement(ImmutableBytesPtr key) {            
+            return pageMap.get(key);            
+        }
+
+
+        /**
+         * Inserts / Replaces cache element in the currently loaded page.
+         * Direct access via mapped page map
+         * @param key
+         * @param value
+         */
+        public void putPagedInElement(ImmutableBytesPtr key, byte[] value) {
+            pageMap.put(key, value);
+        }
+        
+        
+        /**
+         * Returns a value iterator over the pageMap 
+         */
+        public Iterator<byte[]> getPageMapEntries() {
+            return pageMap.values().iterator();
+        }
+        
+        /**
+         * Direct access to the current memory mapped buffer
+         * Used by Iterator to prevent loading the pageMap first
+         * 
+         * @return List of all serialized aggregate objects in arbitrary order
+         * @throws IndexOutOfBoundsException
+         */
+        public List<byte[]> getMemBufferElements() throws IndexOutOfBoundsException {
+            ArrayList<byte[]> elements = Lists.newArrayList();
+            int numElements = buffer.getInt();
+
+            for (int i = 0; i < numElements; i++) {
+                int kvSize = buffer.getInt();
+                byte[] data = new byte[kvSize];
+                buffer.get(data, 0, kvSize);            
+                elements.add(data);
+            }
+            return elements;
+        }
+    }
+       
+    @Override
+    public Iterator<byte[]> iterator() {
+        
+        return new Iterator<byte[]>() {
+            List<byte[]> bufferEntries;
+            int pageIndex = 0;
+            int curBufferIndex = 0;
+            int curBufferSize = 0;
+            long highestPageId = spillFile.getMaxPageId();
+            Iterator<byte[]>entriesIter = byteMap.getPageMapEntries();
+
+            @Override
+            public boolean hasNext() {
+                if(highestPageId == 0) {
+                    // single page only, no need to do more IO
+                    return entriesIter.hasNext();
+                }
+                if ( pageIndex >= highestPageId && curBufferIndex >= curBufferSize) {
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public byte[] next() {
+                if( entriesIter.hasNext() ) {
+                    // get elements from in memory map first
+                    return entriesIter.next();
+                }
+                if(pageIndex == byteMap.getCurIndex()) {
+                    // skip current page, since covered by in memory map already
+                    pageIndex++;                    
+                }
+                if (curBufferIndex >= curBufferSize) {
+                    // get keys from all spilled pages
+                    MappedByteBuffer buffer = spillFile.getPage(pageIndex++);
+                    byteMap = new MappedByteBufferMap(pageIndex, buffer, thresholdBytes);
+                    bufferEntries = byteMap.getMemBufferElements();
+                    curBufferSize = bufferEntries.size();
+                    curBufferIndex = 0;
+                }
+                return bufferEntries.get(curBufferIndex++);
+            }
+
+            @Override
+            public void remove() {
+                throw new IllegalAccessError("Iterator does not support removal operation");
+            }
+        };
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<ImmutableBytesPtr, byte[]>> entrySet() {
+        throw new IllegalAccessError("entrySet is not supported for this type of cache");
+    }
+}

--- a/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
@@ -30,6 +30,8 @@ package com.salesforce.phoenix.coprocessor;
 import static com.salesforce.phoenix.query.QueryConstants.AGG_TIMESTAMP;
 import static com.salesforce.phoenix.query.QueryConstants.SINGLE_COLUMN;
 import static com.salesforce.phoenix.query.QueryConstants.SINGLE_COLUMN_FAMILY;
+import static com.salesforce.phoenix.query.QueryServices.SPGBY_ENABLED_ATTRIB;
+import static com.salesforce.phoenix.query.QueryServicesOptions.DEFAULT_SPGBY_ENABLED;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -44,6 +46,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Scan;
@@ -58,6 +61,7 @@ import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.cache.CacheStats;
 import com.salesforce.phoenix.cache.GlobalCache;
 import com.salesforce.phoenix.cache.TenantCache;
 import com.salesforce.phoenix.cache.aggcache.GroupByCache;
@@ -76,17 +80,17 @@ import com.salesforce.phoenix.util.ScanUtil;
 import com.salesforce.phoenix.util.SizedUtil;
 import com.salesforce.phoenix.util.TupleUtil;
 
-
-
 /**
- * Region observer that aggregates grouped rows (i.e. SQL query with GROUP BY clause)
+ * Region observer that aggregates grouped rows (i.e. SQL query with GROUP BY
+ * clause)
  * 
  * @author jtaylor
  * @since 0.1
  */
 public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
-    private static final Logger logger = LoggerFactory.getLogger(GroupedAggregateRegionObserver.class);
-    
+    private static final Logger logger = LoggerFactory
+            .getLogger(GroupedAggregateRegionObserver.class);
+
     public static final String AGGREGATORS = "Aggs";
     public static final String UNORDERED_GROUP_BY_EXPRESSIONS = "UnorderedGroupByExpressions";
     public static final String KEY_ORDERED_GROUP_BY_EXPRESSIONS = "OrderedGroupByExpressions";
@@ -94,69 +98,75 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
     public static final String ESTIMATED_DISTINCT_VALUES = "EstDistinctValues";
     public static final int DEFAULT_ESTIMATED_DISTINCT_VALUES = 10000;
     public static final int MIN_DISTINCT_VALUES = 100;
-    // Enable / disable spillable group by
-    public static boolean SPILLABLE_GROUPBY = true;
 
     /**
-     * Replaces the RegionScanner s with a RegionScanner that groups by the key formed by the list of expressions from the scan
-     * and returns the aggregated rows of each group.  For example, given the following original rows in the RegionScanner:
-     * KEY    COL1
-     * row1   a
-     * row2   b
-     * row3   a
-     * row4   a
+     * Replaces the RegionScanner s with a RegionScanner that groups by the key
+     * formed by the list of expressions from the scan and returns the
+     * aggregated rows of each group. For example, given the following original
+     * rows in the RegionScanner: KEY COL1 row1 a row2 b row3 a row4 a
      * 
-     * the following rows will be returned for COUNT(*):
-     * KEY    COUNT
-     * a      3
-     * b      1
-     *
-     * The client is required to do a sort and a final aggregation, since multiple rows with the same key may be returned from different regions.
+     * the following rows will be returned for COUNT(*): KEY COUNT a 3 b 1
+     * 
+     * The client is required to do a sort and a final aggregation, since
+     * multiple rows with the same key may be returned from different regions.
      */
     @Override
-    protected RegionScanner doPostScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Scan scan, RegionScanner s) throws IOException {
+    protected RegionScanner doPostScannerOpen(
+            ObserverContext<RegionCoprocessorEnvironment> c, Scan scan,
+            RegionScanner s) throws IOException {
         boolean keyOrdered = false;
-        byte[] expressionBytes = scan.getAttribute(UNORDERED_GROUP_BY_EXPRESSIONS);
+        byte[] expressionBytes = scan
+                .getAttribute(UNORDERED_GROUP_BY_EXPRESSIONS);
 
         if (expressionBytes == null) {
-            expressionBytes = scan.getAttribute(KEY_ORDERED_GROUP_BY_EXPRESSIONS);
+            expressionBytes = scan
+                    .getAttribute(KEY_ORDERED_GROUP_BY_EXPRESSIONS);
             if (expressionBytes == null) {
                 return s;
             }
             keyOrdered = true;
         }
         List<Expression> expressions = deserializeGroupByExpressions(expressionBytes);
-        
-        ServerAggregators aggregators = ServerAggregators.deserialize(
-                scan.getAttribute(GroupedAggregateRegionObserver.AGGREGATORS), c.getEnvironment().getConfiguration());
 
-        final ScanProjector p = ScanProjector.deserializeProjectorFromScan(scan);
-        final HashJoinInfo j = HashJoinInfo.deserializeHashJoinFromScan(scan);        
+        ServerAggregators aggregators = ServerAggregators.deserialize(
+                scan.getAttribute(GroupedAggregateRegionObserver.AGGREGATORS),
+                c.getEnvironment().getConfiguration());
+
+        final ScanProjector p = ScanProjector
+                .deserializeProjectorFromScan(scan);
+        final HashJoinInfo j = HashJoinInfo.deserializeHashJoinFromScan(scan);
         RegionScanner innerScanner = s;
         if (p != null || j != null) {
-            innerScanner = new HashJoinRegionScanner(s, p, j, ScanUtil.getTenantId(scan), c.getEnvironment());
+            innerScanner = new HashJoinRegionScanner(s, p, j,
+                    ScanUtil.getTenantId(scan), c.getEnvironment());
         }
-        
-        if (keyOrdered) { // Optimize by taking advantage that the rows are already in the required group by key order
+
+        if (keyOrdered) { // Optimize by taking advantage that the rows are
+                          // already in the required group by key order
             return scanOrdered(c, scan, innerScanner, expressions, aggregators);
         } else { // Otherwse, collect them all up in an in memory map
-            return scanUnordered(c, scan, innerScanner, expressions, aggregators);
+            return scanUnordered(c, scan, innerScanner, expressions,
+                    aggregators);
         }
     }
 
     private static int sizeOfUnorderedGroupByMap(int nRows, int valueSize) {
-        return SizedUtil.sizeOfMap(nRows, SizedUtil.IMMUTABLE_BYTES_WRITABLE_SIZE, valueSize);
+        return SizedUtil.sizeOfMap(nRows,
+                SizedUtil.IMMUTABLE_BYTES_WRITABLE_SIZE, valueSize);
     }
 
-    public static void serializeIntoScan(Scan scan, String attribName, List<Expression> groupByExpressions) {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(Math.max(1, groupByExpressions.size() * 10));
+    public static void serializeIntoScan(Scan scan, String attribName,
+            List<Expression> groupByExpressions) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(Math.max(1,
+                groupByExpressions.size() * 10));
         try {
             if (groupByExpressions.isEmpty()) { // FIXME ?
                 stream.write(QueryConstants.TRUE);
             } else {
                 DataOutputStream output = new DataOutputStream(stream);
                 for (Expression expression : groupByExpressions) {
-                    WritableUtils.writeVInt(output, ExpressionType.valueOf(expression).ordinal());
+                    WritableUtils.writeVInt(output,
+                            ExpressionType.valueOf(expression).ordinal());
                     expression.write(output);
                 }
             }
@@ -173,7 +183,8 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
 
     }
 
-    private List<Expression> deserializeGroupByExpressions(byte[] expressionBytes) throws IOException {
+    private List<Expression> deserializeGroupByExpressions(
+            byte[] expressionBytes) throws IOException {
         List<Expression> expressions = new ArrayList<Expression>(3);
         ByteArrayInputStream stream = new ByteArrayInputStream(expressionBytes);
         try {
@@ -181,7 +192,8 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
             while (true) {
                 try {
                     int expressionOrdinal = WritableUtils.readVInt(input);
-                    Expression expression = ExpressionType.values()[expressionOrdinal].newInstance();
+                    Expression expression = ExpressionType.values()[expressionOrdinal]
+                            .newInstance();
                     expression.readFields(input);
                     expressions.add(expression);
                 } catch (EOFException e) {
@@ -193,156 +205,212 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
         }
         return expressions;
     }
-    
+
     /**
-     * Used for an aggregate query in which the key order does not necessarily match the group by key order. In this case,
-     * we must collect all distinct groups within a region into a map, aggregating as we go.
+     * Used for an aggregate query in which the key order does not necessarily
+     * match the group by key order. In this case, we must collect all distinct
+     * groups within a region into a map, aggregating as we go.
      */
-    private RegionScanner scanUnordered(ObserverContext<RegionCoprocessorEnvironment> c, Scan scan, final RegionScanner s, final List<Expression> expressions, final ServerAggregators aggregators) throws IOException {
+    private RegionScanner scanUnordered(
+            ObserverContext<RegionCoprocessorEnvironment> c, Scan scan,
+            final RegionScanner s, final List<Expression> expressions,
+            final ServerAggregators aggregators) throws IOException {
         if (logger.isDebugEnabled()) {
-            logger.debug("Grouped aggregation over unordered rows with scan " + scan + ", group by " + expressions + ", aggregators " + aggregators);
+            logger.debug("Grouped aggregation over unordered rows with scan "
+                    + scan + ", group by " + expressions + ", aggregators "
+                    + aggregators);
         }
         int estDistVals = DEFAULT_ESTIMATED_DISTINCT_VALUES;
         byte[] estDistValsBytes = scan.getAttribute(ESTIMATED_DISTINCT_VALUES);
         if (estDistValsBytes != null) {
-            estDistVals = Math.min(MIN_DISTINCT_VALUES, (int)(Bytes.toInt(estDistValsBytes) * 1.5f));  // Allocate 1.5x estimation
+            estDistVals = Math.min(MIN_DISTINCT_VALUES,
+                    (int) (Bytes.toInt(estDistValsBytes) * 1.5f)); // Allocate
+                                                                   // 1.5x
+                                                                   // estimation
         }
-        
-        TenantCache tenantCache = GlobalCache.getTenantCache(c.getEnvironment(), ScanUtil.getTenantId(scan));
-        int estSize = sizeOfUnorderedGroupByMap(estDistVals, aggregators.getSize());
-        final MemoryChunk chunk = tenantCache.getMemoryManager().allocate(estSize);
+
+        TenantCache tenantCache = GlobalCache.getTenantCache(
+                c.getEnvironment(), ScanUtil.getTenantId(scan));
+        int estSize = sizeOfUnorderedGroupByMap(estDistVals,
+                aggregators.getSize());
+        final MemoryChunk chunk = tenantCache.getMemoryManager().allocate(
+                estSize);
         boolean success = false;
+        
+        Configuration conf = c.getEnvironment().getConfiguration();
+        final boolean spillableEnabled = conf.getBoolean(SPGBY_ENABLED_ATTRIB, DEFAULT_SPGBY_ENABLED);
         try {
             // TODO: spool map to disk if map becomes too big
             boolean hasMore;
             int estValueSize = aggregators.getSize();
             MultiKeyValueTuple result = new MultiKeyValueTuple();
             if (logger.isDebugEnabled()) {
-                logger.debug("Spillable groupby enabled: " + SPILLABLE_GROUPBY);
+                logger.debug("Spillable groupby enabled: "
+                        + spillableEnabled);
             }
-            final GroupByCache gbCache = new GroupByCache(chunk.getSize(), estValueSize, aggregators, c);
-            Map<ImmutableBytesWritable, Aggregator[]> aggregateMap = new HashMap<ImmutableBytesWritable, Aggregator[]>(estDistVals);
+            final GroupByCache gbCache = new GroupByCache(chunk.getSize(),
+                    estValueSize, aggregators, c);
+            Map<ImmutableBytesWritable, Aggregator[]> aggregateMap = new HashMap<ImmutableBytesWritable, Aggregator[]>(
+                    estDistVals);
             HRegion region = c.getEnvironment().getRegion();
-            MultiVersionConsistencyControl.setThreadReadPoint(s.getMvccReadPoint());
+            MultiVersionConsistencyControl.setThreadReadPoint(s
+                    .getMvccReadPoint());
             region.startRegionOperation();
             try {
                 do {
                     List<KeyValue> results = new ArrayList<KeyValue>();
-                    // Results are potentially returned even when the return value of s.next is false
-                    // since this is an indication of whether or not there are more values after the
+                    // Results are potentially returned even when the return
+                    // value of s.next is false
+                    // since this is an indication of whether or not there are
+                    // more values after the
                     // ones returned
                     hasMore = s.nextRaw(results, null);
                     if (!results.isEmpty()) {
                         result.setKeyValues(results);
-                        ImmutableBytesWritable key = TupleUtil.getConcatenatedValue(result, expressions);
+                        ImmutableBytesWritable key = TupleUtil
+                                .getConcatenatedValue(result, expressions);
                         Aggregator[] rowAggregators = null;
-                        if(SPILLABLE_GROUPBY) {
-                            // Loading cache, key not exists, put into map handled by Loader implementation
+                        if (spillableEnabled) {
+                            // Loading cache, key not exists, put into map
+                            // handled by Loader implementation
                             rowAggregators = gbCache.get(key);
-                        }
-                        else {
+                        } else {
                             rowAggregators = aggregateMap.get(key);
                             if (rowAggregators == null) {
-                                // If Aggregators not found for this distinct value, clone our original one (we need one per distinct value)
+                                // If Aggregators not found for this distinct
+                                // value, clone our original one (we need one
+                                // per distinct value)
                                 if (logger.isDebugEnabled()) {
-                                    logger.debug("Adding new aggregate bucket for row key " + Bytes.toStringBinary(key.get(),key.getOffset(),key.getLength()));
+                                    logger.debug("Adding new aggregate bucket for row key "
+                                            + Bytes.toStringBinary(key.get(),
+                                                    key.getOffset(),
+                                                    key.getLength()));
                                 }
-                                rowAggregators = aggregators.newAggregators(c.getEnvironment().getConfiguration());
+                                rowAggregators = aggregators.newAggregators(c
+                                        .getEnvironment().getConfiguration());
                                 aggregateMap.put(key, rowAggregators);
                             }
                         }
                         // Aggregate values here
                         aggregators.aggregate(rowAggregators, result);
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Row passed filters: " + results + ", aggregated values: " + Arrays.asList(rowAggregators));
+                            // logger.debug("Row passed filters: " + results +
+                            // ", aggregated values: " +
+                            // Arrays.asList(rowAggregators));
                         }
-                            
-                        if (aggregateMap.size() > estDistVals) { // increase allocation
+
+                        if (aggregateMap.size() > estDistVals) { // increase
+                                                                 // allocation
                             estDistVals *= 1.5f;
-                            estSize = sizeOfUnorderedGroupByMap(estDistVals, estValueSize);
+                            estSize = sizeOfUnorderedGroupByMap(estDistVals,
+                                    estValueSize);
                             chunk.resize(estSize);
                         }
                     }
                 } while (hasMore);
+
+                // check on cache stats
+                 CacheStats stats = gbCache.cache.stats();
+                 logger.error("Load time: " + stats.totalLoadTime());
+                 logger.error("Load Penalty: " + stats.averageLoadPenalty());
+                 logger.error("Load Count: " + stats.loadCount());
+                 logger.error("Eviction Count: " + stats.evictionCount());
+                 logger.error("HitRate: " + stats.hitRate());
             } finally {
                 region.closeRegionOperation();
             }
-    
+
             // Compute final allocation
-            estSize = sizeOfUnorderedGroupByMap(aggregateMap.size(), estValueSize);
+            estSize = sizeOfUnorderedGroupByMap(aggregateMap.size(),
+                    estValueSize);
             chunk.resize(estSize);
-            
-            // TODO: spool list to disk if too big and free memory?
-            final List<KeyValue> aggResults = new ArrayList<KeyValue>(aggregateMap.size());
-            final Iterator<CacheEntry>cacheIter = gbCache.newEntryIterator();
-            
-            if(!SPILLABLE_GROUPBY) {
-                for (Map.Entry<ImmutableBytesWritable, Aggregator[]> entry : aggregateMap.entrySet()) {
+
+            final List<KeyValue> aggResults = new ArrayList<KeyValue>(
+                    aggregateMap.size());
+            final Iterator<CacheEntry> cacheIter = gbCache.newEntryIterator();
+
+            if (!spillableEnabled) {
+                for (Map.Entry<ImmutableBytesWritable, Aggregator[]> entry : aggregateMap
+                        .entrySet()) {
                     ImmutableBytesWritable key = entry.getKey();
                     Aggregator[] rowAggregators = entry.getValue();
-                    // Generate byte array of Aggregators and set as value of row
+                    // Generate byte array of Aggregators and set as value of
+                    // row
                     byte[] value = aggregators.toBytes(rowAggregators);
-                    
+
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Adding new distinct group: " + Bytes.toStringBinary(key.get(),key.getOffset(), key.getLength()) + 
-                                " with aggregators " + Arrays.asList(rowAggregators).toString() + 
-                                " value = " + Bytes.toStringBinary(value));
+                        logger.debug("Adding new distinct group: "
+                                + Bytes.toStringBinary(key.get(),
+                                        key.getOffset(), key.getLength())
+                                + " with aggregators "
+                                + Arrays.asList(rowAggregators).toString()
+                                + " value = " + Bytes.toStringBinary(value));
                     }
-                    KeyValue keyValue = KeyValueUtil.newKeyValue(key.get(),key.getOffset(), key.getLength(),SINGLE_COLUMN_FAMILY, SINGLE_COLUMN, AGG_TIMESTAMP, value, 0, value.length);
+                    KeyValue keyValue = KeyValueUtil.newKeyValue(key.get(),
+                            key.getOffset(), key.getLength(),
+                            SINGLE_COLUMN_FAMILY, SINGLE_COLUMN, AGG_TIMESTAMP,
+                            value, 0, value.length);
                     aggResults.add(keyValue);
                 }
             }
 
             // Do not sort here, but sort back on the client instead
-            // The reason is that if the scan ever extends beyond a region (which can happen
-            // if we're basing our parallelization split points on old metadata), we'll get
+            // The reason is that if the scan ever extends beyond a region
+            // (which can happen
+            // if we're basing our parallelization split points on old
+            // metadata), we'll get
             // incorrect query results.
-            
-            // scanner using the spillable implementation 
+
+            // scanner using the spillable implementation
             RegionScanner scannerSpillable = new BaseRegionScanner() {
-              @Override
-              public HRegionInfo getRegionInfo() {
-                  return s.getRegionInfo();
-              }
-  
-              @Override
-              public void close() throws IOException {
-                  try {
-                      s.close();
-                      gbCache.close();
-                  } finally {                        
-                      chunk.close();
-                  }
-              }
-  
-              @Override
-              public boolean next(List<KeyValue> results) throws IOException {
-                  if(! cacheIter.hasNext() ) {
-                      return false;
-                  }
-                  CacheEntry ce = cacheIter.next();
-                  ImmutableBytesWritable key = ce.getKey();
-                  Aggregator[] aggs = ce.getValue(null);
-                  byte[] value = aggregators.toBytes(aggs);
-                  if (logger.isDebugEnabled()) {
-                      logger.debug("Adding new distinct group: " + Bytes.toStringBinary(key.get(),key.getOffset(), key.getLength()) + 
-                            " with aggregators " + aggs.toString() + 
-                            " value = " + Bytes.toStringBinary(value));
-                  }
-                  results.add( KeyValueUtil.newKeyValue(key.get(),key.getOffset(), key.getLength(),SINGLE_COLUMN_FAMILY, SINGLE_COLUMN, AGG_TIMESTAMP, value, 0, value.length) );
-                  return cacheIter.hasNext();
-              }
-          };
-            
-          // scanner using the non spillable, memory-only implementation 
-          RegionScanner scanner = new BaseRegionScanner() {
-                private int index = 0;
-    
                 @Override
                 public HRegionInfo getRegionInfo() {
                     return s.getRegionInfo();
                 }
-    
+
+                @Override
+                public void close() throws IOException {
+                    try {
+                        s.close();
+                        gbCache.close();
+                    } finally {
+                        chunk.close();
+                    }
+                }
+
+                @Override
+                public boolean next(List<KeyValue> results) throws IOException {
+                    if (!cacheIter.hasNext()) {
+                        return false;
+                    }
+                    CacheEntry ce = cacheIter.next();
+                    ImmutableBytesWritable key = ce.getKey();
+                    Aggregator[] aggs = ce.getValue(null);
+                    byte[] value = aggregators.toBytes(aggs);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Adding new distinct group: "
+                                + Bytes.toStringBinary(key.get(),
+                                        key.getOffset(), key.getLength())
+                                + " with aggregators " + aggs.toString()
+                                + " value = " + Bytes.toStringBinary(value));
+                    }
+                    results.add(KeyValueUtil.newKeyValue(key.get(),
+                            key.getOffset(), key.getLength(),
+                            SINGLE_COLUMN_FAMILY, SINGLE_COLUMN, AGG_TIMESTAMP,
+                            value, 0, value.length));
+                    return cacheIter.hasNext();
+                }
+            };
+
+            // scanner using the non spillable, memory-only implementation
+            RegionScanner scanner = new BaseRegionScanner() {
+                private int index = 0;
+
+                @Override
+                public HRegionInfo getRegionInfo() {
+                    return s.getRegionInfo();
+                }
+
                 @Override
                 public void close() throws IOException {
                     try {
@@ -351,23 +419,25 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                         chunk.close();
                     }
                 }
-    
+
                 @Override
                 public boolean next(List<KeyValue> results) throws IOException {
-                    if (index >= aggResults.size()) return false;
+                    if (index >= aggResults.size())
+                        return false;
                     results.add(aggResults.get(index));
                     index++;
                     return index < aggResults.size();
                 }
-          };
-          success = true;
-        
-          if(!SPILLABLE_GROUPBY) {
-              return scanner;
-          }
-          return scannerSpillable;
-        } 
-        finally {
+            };
+            success = true;
+
+            if (!spillableEnabled) {
+                logger.error("returning non spill iter");
+                return scanner;
+            }
+            logger.error("returning spill iter");
+            return scannerSpillable;
+        } finally {
             if (!success) {
                 chunk.close();
             }
@@ -375,13 +445,19 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
     }
 
     /**
-     * Used for an aggregate query in which the key order match the group by key order. In this case, we can do the
-     * aggregation as we scan, by detecting when the group by key changes.
+     * Used for an aggregate query in which the key order match the group by key
+     * order. In this case, we can do the aggregation as we scan, by detecting
+     * when the group by key changes.
      */
-    private RegionScanner scanOrdered(final ObserverContext<RegionCoprocessorEnvironment> c, Scan scan, final RegionScanner s, final List<Expression> expressions, final ServerAggregators aggregators) {
-        
+    private RegionScanner scanOrdered(
+            final ObserverContext<RegionCoprocessorEnvironment> c, Scan scan,
+            final RegionScanner s, final List<Expression> expressions,
+            final ServerAggregators aggregators) {
+
         if (logger.isDebugEnabled()) {
-            logger.debug("Grouped aggregation over ordered rows with scan " + scan + ", group by " + expressions + ", aggregators " + aggregators);
+            logger.debug("Grouped aggregation over ordered rows with scan "
+                    + scan + ", group by " + expressions + ", aggregators "
+                    + aggregators);
         }
         return new BaseRegionScanner() {
             private ImmutableBytesWritable currentKey = null;
@@ -404,23 +480,30 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                 ImmutableBytesWritable key = null;
                 Aggregator[] rowAggregators = aggregators.getAggregators();
                 HRegion region = c.getEnvironment().getRegion();
-                MultiVersionConsistencyControl.setThreadReadPoint(s.getMvccReadPoint());
+                MultiVersionConsistencyControl.setThreadReadPoint(s
+                        .getMvccReadPoint());
                 region.startRegionOperation();
                 try {
                     do {
                         List<KeyValue> kvs = new ArrayList<KeyValue>();
-                        // Results are potentially returned even when the return value of s.next is false
-                        // since this is an indication of whether or not there are more values after the
+                        // Results are potentially returned even when the return
+                        // value of s.next is false
+                        // since this is an indication of whether or not there
+                        // are more values after the
                         // ones returned
                         hasMore = s.nextRaw(kvs, null);
                         if (!kvs.isEmpty()) {
                             result.setKeyValues(kvs);
-                            key = TupleUtil.getConcatenatedValue(result, expressions);
-                            aggBoundary = currentKey != null && currentKey.compareTo(key) != 0;
+                            key = TupleUtil.getConcatenatedValue(result,
+                                    expressions);
+                            aggBoundary = currentKey != null
+                                    && currentKey.compareTo(key) != 0;
                             if (!aggBoundary) {
                                 aggregators.aggregate(rowAggregators, result);
                                 if (logger.isDebugEnabled()) {
-                                    logger.debug("Row passed filters: " + kvs + ", aggregated values: " + Arrays.asList(rowAggregators));
+                                    logger.debug("Row passed filters: " + kvs
+                                            + ", aggregated values: "
+                                            + Arrays.asList(rowAggregators));
                                 }
                                 currentKey = key;
                             }
@@ -429,16 +512,29 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                 } finally {
                     region.closeRegionOperation();
                 }
-                
+
                 if (currentKey != null) {
                     byte[] value = aggregators.toBytes(rowAggregators);
-                    KeyValue keyValue = KeyValueUtil.newKeyValue(currentKey.get(),currentKey.getOffset(), currentKey.getLength(),SINGLE_COLUMN_FAMILY, SINGLE_COLUMN, AGG_TIMESTAMP, value, 0, value.length);
+                    KeyValue keyValue = KeyValueUtil.newKeyValue(
+                            currentKey.get(), currentKey.getOffset(),
+                            currentKey.getLength(), SINGLE_COLUMN_FAMILY,
+                            SINGLE_COLUMN, AGG_TIMESTAMP, value, 0,
+                            value.length);
                     results.add(keyValue);
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Adding new aggregate row: " + keyValue + ",for current key " + Bytes.toStringBinary(currentKey.get(),currentKey.getOffset(), currentKey.getLength()) + ", aggregated values: " + Arrays.asList(rowAggregators));
+                        logger.debug("Adding new aggregate row: "
+                                + keyValue
+                                + ",for current key "
+                                + Bytes.toStringBinary(currentKey.get(),
+                                        currentKey.getOffset(),
+                                        currentKey.getLength())
+                                + ", aggregated values: "
+                                + Arrays.asList(rowAggregators));
                     }
-                    // If we're at an aggregation boundary, reset the aggregators and
-                    // aggregate with the current result (which is not a part of the returned result).
+                    // If we're at an aggregation boundary, reset the
+                    // aggregators and
+                    // aggregate with the current result (which is not a part of
+                    // the returned result).
                     if (aggBoundary) {
                         aggregators.reset(rowAggregators);
                         aggregators.aggregate(rowAggregators, result);

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/Aggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/Aggregator.java
@@ -53,4 +53,9 @@ public interface Aggregator extends Expression {
      * Get the size in bytes
      */
     public int getSize();
+    
+    /**
+     * Initialize the current aggregate using a clientAggregator 
+     */
+    public void init(Aggregator clientAgg);
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/Aggregators.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/Aggregators.java
@@ -77,6 +77,14 @@ abstract public class Aggregators {
         }
         return buf.toString();
     }
+    
+    /**
+     * Return the aggregate functions
+     */
+    public SingleAggregateFunction[] getFunctions() {
+        return functions;
+    }
+    
     /**
      * Aggregate over aggregators
      * @param result the single row Result from scan iteration

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/BaseAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/BaseAggregator.java
@@ -28,6 +28,8 @@
 package com.salesforce.phoenix.expression.aggregator;
 
 
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+
 import com.salesforce.phoenix.expression.BaseTerminalExpression;
 import com.salesforce.phoenix.schema.ColumnModifier;
 import com.salesforce.phoenix.util.SizedUtil;
@@ -54,5 +56,17 @@ public abstract class BaseAggregator extends BaseTerminalExpression implements A
     @Override
     public int getSize() {
         return SizedUtil.OBJECT_SIZE;
+    }
+    
+    @Override
+    public void init(Aggregator clientAgg) {
+        throw new RuntimeException("not supported");
+    }
+    
+    ImmutableBytesWritable evalClientAggs(Aggregator clientAgg) {
+        CountAggregator ca = (CountAggregator)clientAgg;
+        ImmutableBytesWritable ptr = new ImmutableBytesWritable();
+        ca.evaluate(null, ptr);
+        return ptr;
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
@@ -33,21 +33,22 @@ import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 import com.salesforce.phoenix.util.SizedUtil;
 
-
 /**
  * 
  * Aggregator for COUNT aggregations
+ * 
  * @author jtaylor
  * @since 0.1
  */
 public class CountAggregator extends BaseAggregator {
+
     private long count = 0;
     private byte[] buffer = null;
-    
+
     public CountAggregator() {
         super(null);
     }
-    
+
     public CountAggregator(LongSumAggregator clientAgg) {
         this();
         count = clientAgg.getSum();
@@ -57,12 +58,12 @@ public class CountAggregator extends BaseAggregator {
     public void aggregate(Tuple tuple, ImmutableBytesWritable ptr) {
         count++;
     }
-    
+
     @Override
     public boolean isNullable() {
         return false;
     }
-    
+
     @Override
     public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
         if (buffer == null) {
@@ -72,7 +73,7 @@ public class CountAggregator extends BaseAggregator {
         ptr.set(buffer);
         return true;
     }
-    
+
     @Override
     public final PDataType getDataType() {
         return PDataType.LONG;
@@ -83,8 +84,8 @@ public class CountAggregator extends BaseAggregator {
         count = 0;
         buffer = null;
         super.reset();
-    }      
-    
+    }
+
     @Override
     public String toString() {
         return "COUNT [count=" + count + "]";
@@ -92,17 +93,8 @@ public class CountAggregator extends BaseAggregator {
 
     @Override
     public int getSize() {
-        return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE + getDataType().getByteSize();
+        return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE
+                + getDataType().getByteSize();
     }
-    
-    @Override
-    public void init(Aggregator clientAgg) {
-        // FIXME move into a new constructor
-        // FIXME type safety for clientAgg, casting to LongSumAggregator doesnt look right here...
-        ImmutableBytesWritable ptr = evalClientAggs(clientAgg);
-        count = getDataType().getCodec().decodeLong(ptr, columnModifier);
-        if (buffer == null) {
-            buffer = new byte[getDataType().getByteSize()];
-        }
-    }
+
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
@@ -78,7 +78,7 @@ public class CountAggregator extends BaseAggregator {
         count = 0;
         buffer = null;
         super.reset();
-    }
+    }      
     
     @Override
     public String toString() {
@@ -88,5 +88,16 @@ public class CountAggregator extends BaseAggregator {
     @Override
     public int getSize() {
         return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE + getDataType().getByteSize();
+    }
+    
+    @Override
+    public void init(Aggregator clientAgg) {
+        // FIXME move into a new constructor
+        // FIXME type safety for clientAgg, casting to LongSumAggregator doesnt look right here...
+        ImmutableBytesWritable ptr = evalClientAggs(clientAgg);
+        count = getDataType().getCodec().decodeLong(ptr, columnModifier);
+        if (buffer == null) {
+            buffer = new byte[getDataType().getByteSize()];
+        }
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/CountAggregator.java
@@ -48,6 +48,11 @@ public class CountAggregator extends BaseAggregator {
         super(null);
     }
     
+    public CountAggregator(LongSumAggregator clientAgg) {
+        this();
+        count = clientAgg.getSum();
+    }
+
     @Override
     public void aggregate(Tuple tuple, ImmutableBytesWritable ptr) {
         count++;

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DecimalSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DecimalSumAggregator.java
@@ -48,8 +48,11 @@ public class DecimalSumAggregator extends BaseAggregator {
     private BigDecimal sum = BigDecimal.ZERO;
     private byte[] sumBuffer;
     
-    public DecimalSumAggregator(ColumnModifier columnModifier) {
+    public DecimalSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
         super(columnModifier);
+        if (ptr != null) {
+            sum = (BigDecimal)PDataType.DECIMAL.toObject(ptr);
+        }
     }
     
     private PDataType getInputDataType() {

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DecimalSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DecimalSumAggregator.java
@@ -51,12 +51,21 @@ public class DecimalSumAggregator extends BaseAggregator {
     public DecimalSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
         super(columnModifier);
         if (ptr != null) {
+            initBuffer();
             sum = (BigDecimal)PDataType.DECIMAL.toObject(ptr);
         }
     }
     
     private PDataType getInputDataType() {
         return PDataType.DECIMAL;
+    }
+    
+    private int getBufferLength() {
+        return getDataType().getByteSize();
+    }
+
+    private void initBuffer() {
+        sumBuffer = new byte[getBufferLength()];
     }
     
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DistinctValueWithCountServerAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DistinctValueWithCountServerAggregator.java
@@ -29,7 +29,8 @@ package com.salesforce.phoenix.expression.aggregator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.Configuration;
@@ -45,7 +46,8 @@ import com.salesforce.phoenix.query.QueryServices;
 import com.salesforce.phoenix.query.QueryServicesOptions;
 import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
-import com.salesforce.phoenix.util.*;
+import com.salesforce.phoenix.util.ByteUtil;
+import com.salesforce.phoenix.util.SizedUtil;
 
 /**
  * Server side Aggregator which will aggregate data and find distinct values with number of occurrences for each.
@@ -67,6 +69,11 @@ public class DistinctValueWithCountServerAggregator extends BaseAggregator {
         super(null);
         compressThreshold = conf.getInt(QueryServices.DISTINCT_VALUE_COMPRESS_THRESHOLD_ATTRIB,
                 QueryServicesOptions.DEFAULT_DISTINCT_VALUE_COMPRESS_THRESHOLD);
+    }
+
+    public DistinctValueWithCountServerAggregator(Configuration conf, DistinctValueWithCountClientAggregator clientAgg) {
+        this(conf);
+        valueVsCount = clientAgg.valueVsCount;
     }
 
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DoubleSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DoubleSumAggregator.java
@@ -39,8 +39,11 @@ public class DoubleSumAggregator extends BaseAggregator {
     private double sum = 0;
     private byte[] buffer;
 
-    public DoubleSumAggregator(ColumnModifier columnModifier) {
+    public DoubleSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
         super(columnModifier);
+        if (ptr != null) {
+            sum = PDataType.DOUBLE.getCodec().decodeDouble(ptr, columnModifier);
+        }
     }
     
     protected PDataType getInputDataType() {

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/DoubleSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/DoubleSumAggregator.java
@@ -42,6 +42,7 @@ public class DoubleSumAggregator extends BaseAggregator {
     public DoubleSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
         super(columnModifier);
         if (ptr != null) {
+            initBuffer();
             sum = PDataType.DOUBLE.getCodec().decodeDouble(ptr, columnModifier);
         }
     }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
@@ -50,6 +50,10 @@ abstract public class NumberSumAggregator extends BaseAggregator {
         super(columnModifier);
     }
 
+    public long getSum() {
+        return sum;
+    }
+    
     abstract protected PDataType getInputDataType();
     
     private int getBufferLength() {

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
@@ -34,25 +34,26 @@ import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
 import com.salesforce.phoenix.util.SizedUtil;
 
-
 /**
  * 
  * Aggregator that sums integral number values
- *
+ * 
  * @author jtaylor
  * @since 0.1
  */
 abstract public class NumberSumAggregator extends BaseAggregator {
     private long sum = 0;
     private byte[] buffer;
-    
+
     public NumberSumAggregator(ColumnModifier columnModifier) {
         super(columnModifier);
     }
 
-    public NumberSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
+    public NumberSumAggregator(ColumnModifier columnModifier,
+            ImmutableBytesWritable ptr) {
         this(columnModifier);
         if (ptr != null) {
+            initBuffer();
             sum = PDataType.LONG.getCodec().decodeLong(ptr, columnModifier);
         }
     }
@@ -60,27 +61,28 @@ abstract public class NumberSumAggregator extends BaseAggregator {
     public long getSum() {
         return sum;
     }
-    
+
     abstract protected PDataType getInputDataType();
-    
+
     private int getBufferLength() {
         return getDataType().getByteSize();
     }
-    
+
     private void initBuffer() {
         buffer = new byte[getBufferLength()];
     }
-        
+
     @Override
     public void aggregate(Tuple tuple, ImmutableBytesWritable ptr) {
         // Get either IntNative or LongNative depending on input type
-        long value = getInputDataType().getCodec().decodeLong(ptr, columnModifier);
+        long value = getInputDataType().getCodec().decodeLong(ptr,
+                columnModifier);
         sum += value;
         if (buffer == null) {
             initBuffer();
         }
     }
-    
+
     @Override
     public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
         if (buffer == null) {
@@ -93,12 +95,12 @@ abstract public class NumberSumAggregator extends BaseAggregator {
         getDataType().getCodec().encodeLong(sum, ptr);
         return true;
     }
-    
+
     @Override
     public final PDataType getDataType() {
         return PDataType.LONG;
     }
-    
+
     @Override
     public void reset() {
         sum = 0;
@@ -113,17 +115,8 @@ abstract public class NumberSumAggregator extends BaseAggregator {
 
     @Override
     public int getSize() {
-        return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE + getBufferLength();
+        return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE
+                + getBufferLength();
     }
-    
-    @Override
-    public void init(Aggregator clientAgg) {
-        // TODO move into a new constrcutor
-        // type safety on clientAgg
-        ImmutableBytesWritable ptr = evalClientAggs(clientAgg);
-        sum = getDataType().getCodec().decodeLong(ptr, columnModifier);
-        if(buffer == null) {
-            initBuffer();
-        }       
-    }
+
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
@@ -104,4 +104,15 @@ abstract public class NumberSumAggregator extends BaseAggregator {
     public int getSize() {
         return super.getSize() + SizedUtil.LONG_SIZE + SizedUtil.ARRAY_SIZE + getBufferLength();
     }
+    
+    @Override
+    public void init(Aggregator clientAgg) {
+        // TODO move into a new constrcutor
+        // type safety on clientAgg
+        ImmutableBytesWritable ptr = evalClientAggs(clientAgg);
+        sum = getDataType().getCodec().decodeLong(ptr, columnModifier);
+        if(buffer == null) {
+            initBuffer();
+        }       
+    }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
+++ b/src/main/java/com/salesforce/phoenix/expression/aggregator/NumberSumAggregator.java
@@ -50,6 +50,13 @@ abstract public class NumberSumAggregator extends BaseAggregator {
         super(columnModifier);
     }
 
+    public NumberSumAggregator(ColumnModifier columnModifier, ImmutableBytesWritable ptr) {
+        this(columnModifier);
+        if (ptr != null) {
+            sum = PDataType.LONG.getCodec().decodeLong(ptr, columnModifier);
+        }
+    }
+
     public long getSum() {
         return sum;
     }

--- a/src/main/java/com/salesforce/phoenix/expression/function/CountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/CountAggregateFunction.java
@@ -32,9 +32,12 @@ import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.CountAggregator;
+import com.salesforce.phoenix.expression.aggregator.LongSumAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -90,7 +93,7 @@ public class CountAggregateFunction extends SingleAggregateFunction {
     }
 
     @Override 
-    public Aggregator newClientAggregator() {
+    public LongSumAggregator newClientAggregator() {
         // Since COUNT can never be null, ensure the aggregator is not nullable.
         // This allows COUNT(*) to return 0 with the initial state of ClientAggregators
         // when no rows are returned. 
@@ -110,5 +113,12 @@ public class CountAggregateFunction extends SingleAggregateFunction {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+        LongSumAggregator sumAgg = newClientAggregator();
+        sumAgg.aggregate(null, ptr);
+        return new CountAggregator(sumAgg);
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/function/CountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/CountAggregateFunction.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
-import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
 import com.salesforce.phoenix.expression.aggregator.Aggregator;
@@ -116,7 +116,7 @@ public class CountAggregateFunction extends SingleAggregateFunction {
     }
 
     @Override
-    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesWritable ptr) {
         LongSumAggregator sumAgg = newClientAggregator();
         sumAgg.aggregate(null, ptr);
         return new CountAggregator(sumAgg);

--- a/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
@@ -32,7 +32,6 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
-import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.DistinctCountClientAggregator;
@@ -125,7 +124,7 @@ public class DistinctCountAggregateFunction extends DelegateConstantToCountAggre
     }
 
     @Override
-    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesWritable ptr) {
         DistinctCountClientAggregator clientAgg = newClientAggregator();
         clientAgg.aggregate(null, ptr);
         return new DistinctValueWithCountServerAggregator(config, clientAgg);

--- a/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/DistinctCountAggregateFunction.java
@@ -32,8 +32,11 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctCountClientAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -96,7 +99,7 @@ public class DistinctCountAggregateFunction extends DelegateConstantToCountAggre
     }
 
     @Override 
-    public Aggregator newClientAggregator() {
+    public DistinctCountClientAggregator newClientAggregator() {
         return new DistinctCountClientAggregator(getAggregatorExpression().getColumnModifier());
     }
     
@@ -119,5 +122,12 @@ public class DistinctCountAggregateFunction extends DelegateConstantToCountAggre
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+        DistinctCountClientAggregator clientAgg = newClientAggregator();
+        clientAgg.aggregate(null, ptr);
+        return new DistinctValueWithCountServerAggregator(config, clientAgg);
     }
 }

--- a/src/main/java/com/salesforce/phoenix/expression/function/DistinctValueWithCountAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/DistinctValueWithCountAggregateFunction.java
@@ -30,8 +30,8 @@ package com.salesforce.phoenix.expression.function;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
-import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountClientAggregator;
@@ -50,7 +50,7 @@ public abstract class DistinctValueWithCountAggregateFunction extends SingleAggr
     abstract public DistinctValueWithCountClientAggregator newClientAggregator();
     
     @Override
-    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesWritable ptr) {
         DistinctValueWithCountClientAggregator clientAgg = newClientAggregator();
         clientAgg.aggregate(null, ptr);
         return new DistinctValueWithCountServerAggregator(config, clientAgg);

--- a/src/main/java/com/salesforce/phoenix/expression/function/MaxAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/MaxAggregateFunction.java
@@ -36,7 +36,7 @@ import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.MaxAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
-import com.salesforce.phoenix.parse.*;
+import com.salesforce.phoenix.parse.MaxAggregateParseNode;
 import com.salesforce.phoenix.schema.ColumnModifier;
 import com.salesforce.phoenix.schema.PDataType;
 

--- a/src/main/java/com/salesforce/phoenix/expression/function/MinAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/MinAggregateFunction.java
@@ -37,7 +37,7 @@ import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.MinAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
-import com.salesforce.phoenix.parse.*;
+import com.salesforce.phoenix.parse.MinAggregateParseNode;
 import com.salesforce.phoenix.schema.ColumnModifier;
 import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;

--- a/src/main/java/com/salesforce/phoenix/expression/function/PercentRankAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/PercentRankAggregateFunction.java
@@ -32,7 +32,10 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountClientAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
+import com.salesforce.phoenix.expression.aggregator.PercentRankClientAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -46,7 +49,7 @@ import com.salesforce.phoenix.schema.PDataType;
  */
 @BuiltInFunction(name = PercentRankAggregateFunction.NAME, args = { @Argument(),
         @Argument(allowedTypes = { PDataType.BOOLEAN }, isConstant = true), @Argument(isConstant = true) })
-public class PercentRankAggregateFunction extends SingleAggregateFunction {
+public class PercentRankAggregateFunction extends DistinctValueWithCountAggregateFunction {
     public static final String NAME = "PERCENT_RANK";
 
     public PercentRankAggregateFunction() {
@@ -63,7 +66,7 @@ public class PercentRankAggregateFunction extends SingleAggregateFunction {
     }
 
     @Override
-    public Aggregator newClientAggregator() {
+    public DistinctValueWithCountClientAggregator newClientAggregator() {
         return new PercentRankClientAggregator(children, getAggregatorExpression().getColumnModifier());
     }
 

--- a/src/main/java/com/salesforce/phoenix/expression/function/PercentileContAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/PercentileContAggregateFunction.java
@@ -32,7 +32,10 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountClientAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
+import com.salesforce.phoenix.expression.aggregator.PercentileClientAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -47,7 +50,7 @@ import com.salesforce.phoenix.schema.PDataType;
 @BuiltInFunction(name = PercentileContAggregateFunction.NAME, args = { @Argument(allowedTypes = { PDataType.DECIMAL }),
         @Argument(allowedTypes = { PDataType.BOOLEAN }, isConstant = true),
         @Argument(allowedTypes = { PDataType.DECIMAL }, isConstant = true, minValue = "0", maxValue = "1") })
-public class PercentileContAggregateFunction extends SingleAggregateFunction {
+public class PercentileContAggregateFunction extends DistinctValueWithCountAggregateFunction {
     public static final String NAME = "PERCENTILE_CONT";
 
     public PercentileContAggregateFunction() {
@@ -64,7 +67,7 @@ public class PercentileContAggregateFunction extends SingleAggregateFunction {
     }
 
     @Override
-    public Aggregator newClientAggregator() {
+    public DistinctValueWithCountClientAggregator newClientAggregator() {
         return new PercentileClientAggregator(children, getAggregatorExpression().getColumnModifier());
     }
 

--- a/src/main/java/com/salesforce/phoenix/expression/function/SingleAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/SingleAggregateFunction.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
+import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
 import com.salesforce.phoenix.expression.aggregator.Aggregator;
@@ -146,6 +147,12 @@ abstract public class SingleAggregateFunction extends AggregateFunction {
     public Aggregator newClientAggregator() {
         return newServerAggregator(null);
     }
+
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+        Aggregator agg = newServerAggregator(config);
+        agg.aggregate(null, ptr);
+        return agg;
+    }
     
     public void readFields(DataInput input, Configuration conf) throws IOException {
         super.readFields(input);
@@ -171,4 +178,5 @@ abstract public class SingleAggregateFunction extends AggregateFunction {
         }
         return t;
     }
+
 }

--- a/src/main/java/com/salesforce/phoenix/expression/function/SingleAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/SingleAggregateFunction.java
@@ -36,7 +36,6 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
-import com.salesforce.hbase.index.util.ImmutableBytesPtr;
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
 import com.salesforce.phoenix.expression.aggregator.Aggregator;
@@ -148,7 +147,7 @@ abstract public class SingleAggregateFunction extends AggregateFunction {
         return newServerAggregator(null);
     }
 
-    public Aggregator newServerAggregator(Configuration config, ImmutableBytesPtr ptr) {
+    public Aggregator newServerAggregator(Configuration config, ImmutableBytesWritable ptr) {
         Aggregator agg = newServerAggregator(config);
         agg.aggregate(null, ptr);
         return agg;

--- a/src/main/java/com/salesforce/phoenix/expression/function/StddevPopFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/StddevPopFunction.java
@@ -32,7 +32,11 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DecimalStddevPopAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountClientAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
+import com.salesforce.phoenix.expression.aggregator.StddevPopAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -45,7 +49,7 @@ import com.salesforce.phoenix.schema.PDataType;
  * @since 1.2.1
  */
 @BuiltInFunction(name = StddevPopFunction.NAME, args = { @Argument(allowedTypes={PDataType.DECIMAL})})
-public class StddevPopFunction extends SingleAggregateFunction {
+public class StddevPopFunction extends DistinctValueWithCountAggregateFunction {
     public static final String NAME = "STDDEV_POP";
 
     public StddevPopFunction() {
@@ -62,7 +66,7 @@ public class StddevPopFunction extends SingleAggregateFunction {
     }
 
     @Override
-    public Aggregator newClientAggregator() {
+    public DistinctValueWithCountClientAggregator newClientAggregator() {
         if (children.get(0).getDataType() == PDataType.DECIMAL) {
             // Special Aggregators for DECIMAL datatype for more precision than double
             return new DecimalStddevPopAggregator(children, getAggregatorExpression().getColumnModifier());

--- a/src/main/java/com/salesforce/phoenix/expression/function/StddevSampFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/StddevSampFunction.java
@@ -32,7 +32,11 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 
 import com.salesforce.phoenix.expression.Expression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DecimalStddevSampAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountClientAggregator;
+import com.salesforce.phoenix.expression.aggregator.DistinctValueWithCountServerAggregator;
+import com.salesforce.phoenix.expression.aggregator.StddevSampAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
 import com.salesforce.phoenix.schema.PDataType;
@@ -45,7 +49,7 @@ import com.salesforce.phoenix.schema.PDataType;
  * @since 1.2.1
  */
 @BuiltInFunction(name = StddevSampFunction.NAME, args = { @Argument(allowedTypes={PDataType.DECIMAL})})
-public class StddevSampFunction extends SingleAggregateFunction {
+public class StddevSampFunction extends DistinctValueWithCountAggregateFunction {
     public static final String NAME = "STDDEV_SAMP";
 
     public StddevSampFunction() {
@@ -62,7 +66,7 @@ public class StddevSampFunction extends SingleAggregateFunction {
     }
 
     @Override
-    public Aggregator newClientAggregator() {
+    public DistinctValueWithCountClientAggregator newClientAggregator() {
         if (children.get(0).getDataType() == PDataType.DECIMAL) {
             // Special Aggregators for DECIMAL datatype for more precision than double
             return new DecimalStddevSampAggregator(children, getAggregatorExpression().getColumnModifier());

--- a/src/main/java/com/salesforce/phoenix/expression/function/SumAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/SumAggregateFunction.java
@@ -107,7 +107,8 @@ public class SumAggregateFunction extends DelegateConstantToCountAggregateFuncti
     
     @Override
     public Aggregator newServerAggregator(Configuration conf, ImmutableBytesWritable ptr) {
-        return newAggregator(getDataType(), null, ptr);
+        Expression child = getAggregatorExpression();
+        return newAggregator(child.getDataType(), child.getColumnModifier(), ptr);
     }
     
     @Override

--- a/src/main/java/com/salesforce/phoenix/expression/function/SumAggregateFunction.java
+++ b/src/main/java/com/salesforce/phoenix/expression/function/SumAggregateFunction.java
@@ -35,10 +35,13 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 
 import com.salesforce.phoenix.expression.Expression;
 import com.salesforce.phoenix.expression.LiteralExpression;
-import com.salesforce.phoenix.expression.aggregator.*;
+import com.salesforce.phoenix.expression.aggregator.Aggregator;
+import com.salesforce.phoenix.expression.aggregator.DecimalSumAggregator;
+import com.salesforce.phoenix.expression.aggregator.DoubleSumAggregator;
+import com.salesforce.phoenix.expression.aggregator.NumberSumAggregator;
 import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
 import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
-import com.salesforce.phoenix.parse.*;
+import com.salesforce.phoenix.parse.SumAggregateParseNode;
 import com.salesforce.phoenix.schema.ColumnModifier;
 import com.salesforce.phoenix.schema.PDataType;
 import com.salesforce.phoenix.schema.tuple.Tuple;
@@ -94,23 +97,6 @@ public class SumAggregateFunction extends DelegateConstantToCountAggregateFuncti
         }
     }
     
-    @Override
-    public Aggregator newClientAggregator() {
-        switch( getDataType() ) {
-            case DECIMAL:
-                // On the client, we'll always aggregate over non modified column values,
-                // because we always get them back from the server in their non modified
-                // form.
-                return new DecimalSumAggregator(null);
-            case LONG:
-                return new LongSumAggregator(null);
-            case DOUBLE:
-                return new DoubleSumAggregator(null);
-            default:
-                throw new IllegalStateException("Unexpected SUM type: " + getDataType());
-        }
-    }
-
     @Override
     public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
         if (!super.evaluate(tuple, ptr)) {

--- a/src/main/java/com/salesforce/phoenix/query/QueryServices.java
+++ b/src/main/java/com/salesforce/phoenix/query/QueryServices.java
@@ -88,6 +88,9 @@ public interface QueryServices extends SQLCloseable {
     public static final String IMMUTABLE_ROWS_ATTRIB  = "phoenix.mutate.immutableRows";
     public static final String INDEX_MUTATE_BATCH_SIZE_THRESHOLD_ATTRIB  = "phoenix.index.mutableBatchSizeThreshold";
     public static final String DROP_METADATA_ATTRIB  = "phoenix.schema.dropMetaData";
+    public static final String SPGBY_ENABLED_ATTRIB  = "phoenix.spgby.enabled";
+    public static final String SPGBY_NUM_SPILLFILES_ATTRIB = "phoenix.spgby.num.spillfiles";
+    public static final String SPGBY_MAX_CACHE_SIZE_ATTRIB = "phoenix.spgby.max.cache.size";
 
     public static final String CALL_QUEUE_PRODUCER_ATTRIB_NAME = "CALL_QUEUE_PRODUCER";
     

--- a/src/test/java/com/salesforce/phoenix/end2end/SpillableGroupByTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/SpillableGroupByTest.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.end2end;
+
+import static com.salesforce.phoenix.util.TestUtil.GROUPBYTEST_NAME;
+import static com.salesforce.phoenix.util.TestUtil.PHOENIX_JDBC_URL;
+import static com.salesforce.phoenix.util.TestUtil.TEST_PROPERTIES;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.salesforce.phoenix.query.QueryServices;
+import com.salesforce.phoenix.util.PhoenixRuntime;
+import com.salesforce.phoenix.util.ReadOnlyProps;
+
+public class SpillableGroupByTest extends BaseConnectedQueryTest {
+
+    private static final int NUM_ROWS_INSERTED = 200000;
+    private static String GROUPBY1 = "select "
+            + "count(*), sum(appcpu), avg(appcpu) from "
+            + GROUPBYTEST_NAME + " group by uri";
+    private int id;
+
+    @BeforeClass
+    public static void doSetup() throws Exception {
+        Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
+        // Set a very small cache size to force plenty of spilling
+        props.put(QueryServices.SPGBY_MAX_CACHE_SIZE_ATTRIB,
+                Integer.toString(8192));
+        props.put(QueryServices.SPGBY_ENABLED_ATTRIB, String.valueOf(true));
+        // Must update config before starting server
+        startServer(getUrl(), new ReadOnlyProps(props.entrySet().iterator()));
+    }
+
+    private long createTable() throws Exception {
+        long ts = nextTimestamp();
+        ensureTableCreated(getUrl(), GROUPBYTEST_NAME, null, ts - 2);
+        return ts;
+    }
+
+    private void loadData(long ts) throws SQLException {
+        Properties props = new Properties(TEST_PROPERTIES);
+        props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB, Long.toString(ts));
+        Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+        int groupFactor = NUM_ROWS_INSERTED / 2;
+        for (int i = 0; i < NUM_ROWS_INSERTED; i++) {
+            insertRow(conn, Integer.toString(i % (groupFactor)), 10);
+
+            if ((i % 1000) == 0) {
+                conn.commit();
+            }
+        }
+        conn.commit();
+        conn.close();
+    }
+
+    private void insertRow(Connection conn, String uri, int appcpu)
+            throws SQLException {
+        PreparedStatement statement = conn.prepareStatement("UPSERT INTO "
+                + GROUPBYTEST_NAME + "(id, uri, appcpu) values (?,?,?)");
+        statement.setString(1, "id" + id);
+        statement.setString(2, uri);
+        statement.setInt(3, appcpu);
+        statement.executeUpdate();
+        id++;
+    }
+
+    
+    @Test
+    public void testScanUri() throws Exception {
+        SpillableGroupByTest spGpByT = new SpillableGroupByTest();
+        long ts = spGpByT.createTable();
+        spGpByT.loadData(ts);
+        Properties props = new Properties(TEST_PROPERTIES);
+        props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB,
+                Long.toString(ts + 1));
+        Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+        try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(GROUPBY1);
+
+            int count = 0;
+            while (rs.next()) {
+                assertEquals(rs.getInt(1), 2);
+                assertEquals(rs.getInt(2), 20);
+                assertEquals(rs.getInt(3), 10);
+                count++;
+            }
+            assertEquals(NUM_ROWS_INSERTED / 2, count);
+            
+        } finally {
+            conn.close();
+        }
+    }
+
+}


### PR DESCRIPTION
Spillable GroupBy:

The main entry point is in GroupedAggregateRegionObserver. It instantiates a GroupByCache and invokes a get() method on it. There is no: "if key not exists -> put into map" case, since the cache is a Loading cache and therefore handles the put under the covers. I tried to implement the final cache element accesses (RegionScanner below) streaming, i.e. there is just an iterator on it and removed the existing result materialization.

GroupByCache implements a Guava LoadingCache, which an upper and lower configurable size limit. Optimally it is sized as  estMapSize / valueSize, since the upper limit is number and not memory budget based. As long as no eviction happens no spillable data structures are allocated, this only happens as soon as the first element is evicted from the cache. We cannot really make any assumptions on which keys arrive at the map, but I thought the LRU would at least cover the cases where some keys have a slight skew and they should stay memory resident.

Once a key gets evicted, the spillManager is instantiated. It basically takes care of spilling an element to disk and does all the SERDE work. It creates a bunch of SpillFiles (spill partition) which are MemoryMappedFiles. Each MMFile only works with up to 2GB of spilled data, therefore the SpillManager keeps a list of these and hash distributes the keys within this list. Once an element gets spilled, it is serialized and will only get deserialized again, when it is requested from the client, i.e. loaded back into the LRU cache. 
The SpillManager holds a SpillMap for every spill partition (SpillFile). Each SpillMap has access to all the pages of its SpillFile, it also contains a list of bloomFilters, one for every page of the spillFile. Only a single page, the currently active page stays in memory. The in memory data structure of the page is a HashMap for easy key access purposes. 
An element evicted form the LRU cache is hashed into the correct SpillMap. the spillMap then determines via the list of BloomFilters on which page in the SpillFile the key resides and loads this page into a HashMap in memory. 
If the key was never spilled before, the SpillMap tries to fill up the current, in memory residing page with this new key. In case it doesn't fit, the current memory page is flushed to disk and a new page is requested. The key is then written to the new in-memory page. Lastly, the bloomFilter is updated so that this key can be discovered again.
Loading a key works similarly, if not present in the LRU cache, the CacheLoader sets in. The key gets hashed into the correct SpillMap, the list of bloomFilters is walked to determined the SpillFile page, the key resides on and this page is loaded first into memory and eventually, into the LRU cache. Only for the last step the deserialization is triggered. 
The aggregators are returned from the LRU cache and the next value is computed. In case the key is not found on any page, the Loader create new aggregators for it.

TODOs: 
--> Init a newly deserialized Aggregator with its previous value. I added an init function to the interface and receives the client aggs and init itself form this. This could go into a constructor. Also I just did this for two aggregators so far, not sure if this is the way you want it to be.

--> Error handling, right now I mostly re-throw local errors as unchecked  RuntimeExceptions. From my experience, even these are not always surfaced, this needs some rework I think.

--> Page defragmentation might happen as spilling occurs. The code tries to fill up the current in memory page. If space is exhausted it simply asks for a new page. Maybe a model that searches for a page that could store this additional element instead of requesting a complete new one, would be better. This would just increase the memory footprint a bit.

-> Tuning knobs that impact performance and memory footprint:
- Number of spillFiles
- Size of LRU cache
- Page size.

marcel
