### PR TITLE
Allow for comma at the end of a column_def in a create table statement . Fix for https://github.com/forcedotcom/phoenix/issues/566

### DIFF
--- a/src/main/antlr3/PhoenixSQL.g
+++ b/src/main/antlr3/PhoenixSQL.g
@@ -387,7 +387,7 @@ create_index_node returns [CreateIndexStatement ret]
     ;
 
 pk_constraint returns [PrimaryKeyConstraint ret]
-    :   CONSTRAINT n=identifier PRIMARY KEY LPAREN cols=col_name_with_mod_list RPAREN { $ret = factory.primaryKey(n,cols); }
+    :   COMMA? CONSTRAINT n=identifier PRIMARY KEY LPAREN cols=col_name_with_mod_list RPAREN { $ret = factory.primaryKey(n,cols); }
     ;
 
 col_name_with_mod_list returns [List<Pair<ColumnName, ColumnModifier>> ret]

--- a/src/test/java/com/salesforce/phoenix/parse/QueryParserTest.java
+++ b/src/test/java/com/salesforce/phoenix/parse/QueryParserTest.java
@@ -27,6 +27,7 @@
  ******************************************************************************/
 package com.salesforce.phoenix.parse;
 
+import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -423,7 +424,7 @@ public class QueryParserTest {
     @Test
     public void testParseCreateTablePrimaryKeyConstraintWithOrder() throws Exception {
     	for (String order : new String[]{"asc", "desc", ""}) {
-    		String s = "create table core.entity_history_archive (id CHAR(15), name VARCHAR(150) constraint pk primary key (id ${o}, name ${o}))".replace("${o}", order);
+    		String s = "create table core.entity_history_archive (id CHAR(15), name VARCHAR(150), constraint pk primary key (id ${o}, name ${o}))".replace("${o}", order);
     		CreateTableStatement stmt = (CreateTableStatement)new SQLParser(new StringReader(s)).parseStatement();
     		PrimaryKeyConstraint pkConstraint = stmt.getPrimaryKeyConstraint();
     		List<Pair<ColumnName,ColumnModifier>> columns = pkConstraint.getColumnNames();
@@ -432,6 +433,18 @@ public class QueryParserTest {
     			assertEquals(ColumnModifier.fromDDLValue(order), pkConstraint.getColumn(pair.getFirst()).getSecond());
     		}    		
     	}
+    }
+
+    @Test
+    public void testParseCreateTableCommaBeforePrimaryKeyConstraint() throws Exception {
+        for (String leadingComma : new String[]{",", ""}) {
+            String s = "create table core.entity_history_archive (id CHAR(15), name VARCHAR(150)${o} constraint pk primary key (id))".replace("${o}", leadingComma);
+
+            CreateTableStatement stmt = (CreateTableStatement)new SQLParser(new StringReader(s)).parseStatement();
+
+            assertEquals(2, stmt.getColumnDefs().size());
+            assertNotNull(stmt.getPrimaryKeyConstraint());
+        }
     }
 
     public void testBadCharDef() throws Exception {

--- a/src/test/java/com/salesforce/phoenix/query/BaseTest.java
+++ b/src/test/java/com/salesforce/phoenix/query/BaseTest.java
@@ -85,7 +85,7 @@ public abstract class BaseTest {
                 "    created_date date not null,\n" +
                 "    entity_history_id char(15) not null,\n" +
                 "    old_value varchar,\n" +
-                "    new_value varchar\n" +
+                "    new_value varchar,\n" + //create table shouldn't blow up if the last column definition ends with a comma.
                 "    CONSTRAINT pk PRIMARY KEY (organization_id, parent_id, created_date, entity_history_id)\n" +
                 ")");
         builder.put(ENTITY_HISTORY_SALTED_TABLE_NAME,"create table " + ENTITY_HISTORY_SALTED_TABLE_NAME +


### PR DESCRIPTION
https://github.com/forcedotcom/phoenix/issues/566
