### PR TITLE
Fixed: #638, #640, and misc cleanup fixes

### DIFF
--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/GroupByCache.java
@@ -5,6 +5,7 @@ import static com.salesforce.phoenix.query.QueryServices.SPGBY_NUM_SPILLFILES_AT
 import static com.salesforce.phoenix.query.QueryServicesOptions.DEFAULT_SPGBY_CACHE_MAX_SIZE;
 import static com.salesforce.phoenix.query.QueryServicesOptions.DEFAULT_SPGBY_NUM_SPILLFILES;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Iterator;
@@ -30,53 +31,42 @@ import com.salesforce.phoenix.expression.aggregator.Aggregator;
 import com.salesforce.phoenix.expression.aggregator.ServerAggregators;
 
 /**
- * The main entry point is in GroupedAggregateRegionObserver. It instantiates a
- * GroupByCache and invokes a get() method on it. There is no:
- * "if key not exists -> put into map" case, since the cache is a Loading cache
- * and therefore handles the put under the covers. I tried to implement the
- * final cache element accesses (RegionScanner below) streaming, i.e. there is
- * just an iterator on it and removed the existing result materialization.
- * 
- * GroupByCache implements a Guava LoadingCache, which an upper and lower
- * configurable size limit. Optimally it is sized as estMapSize / valueSize,
- * since the upper limit is number and not memory budget based. As long as no
- * eviction happens no spillable data structures are allocated, this only
- * happens as soon as the first element is evicted from the cache. We cannot
- * really make any assumptions on which keys arrive at the map, but I thought
- * the LRU would at least cover the cases where some keys have a slight skew and
- * they should stay memory resident.
- * 
- * Once a key gets evicted, the spillManager is instantiated. It basically takes
- * care of spilling an element to disk and does all the SERDE work. It creates a
- * bunch of SpillFiles (spill partition) which are MemoryMappedFiles. Each
- * MMFile only works with up to 2GB of spilled data, therefore the SpillManager
- * keeps a list of these and hash distributes the keys within this list. Once an
- * element gets spilled, it is serialized and will only get deserialized again,
- * when it is requested from the client, i.e. loaded back into the LRU cache.
- * The SpillManager holds a SpillMap for every spill partition (SpillFile). Each
- * SpillMap has access to all the pages of its SpillFile, it also contains a
- * list of bloomFilters, one for every page of the spillFile. Only a single
- * page, the currently active page stays in memory. The in memory data structure
- * of the page is a HashMap for easy key access purposes. An element evicted
- * form the LRU cache is hashed into the correct SpillMap. the spillMap then
- * determines via the list of BloomFilters on which page in the SpillFile the
- * key resides and loads this page into a HashMap in memory. If the key was
- * never spilled before, the SpillMap tries to fill up the current, in memory
- * residing page with this new key. In case it doesn't fit, the current memory
- * page is flushed to disk and a new page is requested. The key is then written
- * to the new in-memory page. Lastly, the bloomFilter is updated so that this
- * key can be discovered again. Loading a key works similarly, if not present in
- * the LRU cache, the CacheLoader sets in. The key gets hashed into the correct
- * SpillMap, the list of bloomFilters is walked to determined the SpillFile
- * page, the key resides on and this page is loaded first into memory and
- * eventually, into the LRU cache. Only for the last step the deserialization is
- * triggered. The aggregators are returned from the LRU cache and the next value
- * is computed. In case the key is not found on any page, the Loader create new
+ * The main entry point is in GroupedAggregateRegionObserver. It instantiates a GroupByCache and
+ * invokes a get() method on it. There is no: "if key not exists -> put into map" case, since the
+ * cache is a Loading cache and therefore handles the put under the covers. I tried to implement the
+ * final cache element accesses (RegionScanner below) streaming, i.e. there is just an iterator on
+ * it and removed the existing result materialization. GroupByCache implements a Guava LoadingCache,
+ * which an upper and lower configurable size limit. Optimally it is sized as estMapSize /
+ * valueSize, since the upper limit is number and not memory budget based. As long as no eviction
+ * happens no spillable data structures are allocated, this only happens as soon as the first
+ * element is evicted from the cache. We cannot really make any assumptions on which keys arrive at
+ * the map, but I thought the LRU would at least cover the cases where some keys have a slight skew
+ * and they should stay memory resident. Once a key gets evicted, the spillManager is instantiated.
+ * It basically takes care of spilling an element to disk and does all the SERDE work. It creates a
+ * bunch of SpillFiles (spill partition) which are MemoryMappedFiles. Each MMFile only works with up
+ * to 2GB of spilled data, therefore the SpillManager keeps a list of these and hash distributes the
+ * keys within this list. Once an element gets spilled, it is serialized and will only get
+ * deserialized again, when it is requested from the client, i.e. loaded back into the LRU cache.
+ * The SpillManager holds a SpillMap for every spill partition (SpillFile). Each SpillMap has access
+ * to all the pages of its SpillFile, it also contains a list of bloomFilters, one for every page of
+ * the spillFile. Only a single page, the currently active page stays in memory. The in memory data
+ * structure of the page is a HashMap for easy key access purposes. An element evicted form the LRU
+ * cache is hashed into the correct SpillMap. the spillMap then determines via the list of
+ * BloomFilters on which page in the SpillFile the key resides and loads this page into a HashMap in
+ * memory. If the key was never spilled before, the SpillMap tries to fill up the current, in memory
+ * residing page with this new key. In case it doesn't fit, the current memory page is flushed to
+ * disk and a new page is requested. The key is then written to the new in-memory page. Lastly, the
+ * bloomFilter is updated so that this key can be discovered again. Loading a key works similarly,
+ * if not present in the LRU cache, the CacheLoader sets in. The key gets hashed into the correct
+ * SpillMap, the list of bloomFilters is walked to determined the SpillFile page, the key resides on
+ * and this page is loaded first into memory and eventually, into the LRU cache. Only for the last
+ * step the deserialization is triggered. The aggregators are returned from the LRU cache and the
+ * next value is computed. In case the key is not found on any page, the Loader create new
  * aggregators for it.
  */
-public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
-    private static final Logger logger = LoggerFactory
-            .getLogger(GroupByCache.class);
+public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> implements Closeable {
+
+    private static final Logger logger = LoggerFactory.getLogger(GroupByCache.class);
 
     // Min size of 1st level main memory cache in bytes --> lower bound
     private static final int SPGBY_CACHE_MIN_SIZE = 4096; // 4K
@@ -91,9 +81,8 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
     private final ServerAggregators aggregators;
 
     /**
-     * Instantiates a Loading LRU Cache that stores key / aggregator[] tuples
-     * used for group by queries
-     * 
+     * Instantiates a Loading LRU Cache that stores key / aggregator[] tuples used for group by
+     * queries
      * @param estSize
      * @param estValueSize
      * @param aggs
@@ -104,37 +93,37 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
         context = ctxt;
         this.estValueSize = estValueSize;
         curNumCacheElements = 0;
-        this.aggregators = aggs;        
-        
+        this.aggregators = aggs;
+
         Configuration conf = ctxt.getEnvironment().getConfiguration();
-        final long maxCacheSizeConf = conf.getLong(SPGBY_MAX_CACHE_SIZE_ATTRIB, DEFAULT_SPGBY_CACHE_MAX_SIZE);
-        final int numSpillFilesConf = conf.getInt(SPGBY_NUM_SPILLFILES_ATTRIB, DEFAULT_SPGBY_NUM_SPILLFILES);
-        
+        final long maxCacheSizeConf =
+                conf.getLong(SPGBY_MAX_CACHE_SIZE_ATTRIB, DEFAULT_SPGBY_CACHE_MAX_SIZE);
+        final int numSpillFilesConf =
+                conf.getInt(SPGBY_NUM_SPILLFILES_ATTRIB, DEFAULT_SPGBY_NUM_SPILLFILES);
+
         final int estSizeNum = (int) (estSize / estValueSize);
-        final int maxSizeNum = (int) ( maxCacheSizeConf / estValueSize);
+        final int maxSizeNum = (int) (maxCacheSizeConf / estValueSize);
         final int minSizeNum = (SPGBY_CACHE_MIN_SIZE / estValueSize);
 
         // use upper and lower bounds for the cache size
-        int maxCacheSize = Math.max(minSizeNum,
-                Math.min(maxSizeNum, estSizeNum));
+        int maxCacheSize = Math.max(minSizeNum, Math.min(maxSizeNum, estSizeNum));
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Instantiating LRU groupby cache of element size: "
-                    + maxCacheSize);
+            logger.debug("Instantiating LRU groupby cache of element size: " + maxCacheSize);
         }
         // Cache is element number bounded. Using the max of CACHE_MIN_SIZE and
         // the est MapSize
-        cache = CacheBuilder                
-                .newBuilder()
-                .maximumSize(maxCacheSize)
-                .removalListener(
-                        new RemovalListener<ImmutableBytesPtr, Aggregator[]>() {
+        cache =
+                CacheBuilder.newBuilder().maximumSize(maxCacheSize)
+                        .removalListener(new RemovalListener<ImmutableBytesPtr, Aggregator[]>() {
                             /*
                              * CacheRemoval listener implementation
                              */
                             @Override
-                            public void onRemoval(
-                                    RemovalNotification<ImmutableBytesPtr, Aggregator[]> notification) {
+                            public
+                                    void
+                                    onRemoval(
+                                            RemovalNotification<ImmutableBytesPtr, Aggregator[]> notification) {
                                 try {
                                     if (spillManager == null) {
                                         // Lazy instantiation of spillable data
@@ -142,15 +131,13 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
                                         //
                                         // Only create spill data structs if LRU
                                         // cache is too small
-                                        spillManager = new SpillManager(
-                                                numSpillFilesConf,
-                                                estValueSize,
-                                                aggregators, context
-                                                        .getEnvironment()
-                                                        .getConfiguration());
+                                        spillManager =
+                                                new SpillManager(numSpillFilesConf, estValueSize,
+                                                        aggregators, context.getEnvironment()
+                                                                .getConfiguration());
                                     }
                                     spillManager.spill(notification.getKey(),
-                                            notification.getValue());
+                                        notification.getValue());
                                     // keep track of elements in cache
                                     curNumCacheElements--;
                                 } catch (IOException ioe) {
@@ -158,35 +145,35 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
                                     throw new RuntimeException(ioe);
                                 }
                             }
-                        })
-                .build(new CacheLoader<ImmutableBytesPtr, Aggregator[]>() {
-                    /*
-                     * CacheLoader implementation
-                     */
-                    @Override
-                    public Aggregator[] load(ImmutableBytesPtr key)
-                            throws Exception {
+                        }).build(new CacheLoader<ImmutableBytesPtr, Aggregator[]>() {
+                            /*
+                             * CacheLoader implementation
+                             */
+                            @Override
+                            public Aggregator[] load(ImmutableBytesPtr key) throws Exception {
 
-                        Aggregator[] aggs = null;
-                        if (spillManager == null) {
-                            // No spill Manager, always assume this key is new!
-                            aggs = aggregators.newAggregators(context
-                                    .getEnvironment().getConfiguration());
-                        } else {
-                            // Spill manager present, check if key has been
-                            // spilled before
-                            aggs = spillManager.loadEntry(key);
-                            if (aggs == null) {
-                                // No, key never spilled before, create a new tuple
-                                aggs = aggregators.newAggregators(context
-                                        .getEnvironment().getConfiguration());
+                                Aggregator[] aggs = null;
+                                if (spillManager == null) {
+                                    // No spill Manager, always assume this key is new!
+                                    aggs =
+                                            aggregators.newAggregators(context.getEnvironment()
+                                                    .getConfiguration());
+                                } else {
+                                    // Spill manager present, check if key has been
+                                    // spilled before
+                                    aggs = spillManager.loadEntry(key);
+                                    if (aggs == null) {
+                                        // No, key never spilled before, create a new tuple
+                                        aggs =
+                                                aggregators.newAggregators(context.getEnvironment()
+                                                        .getConfiguration());
+                                    }
+                                }
+                                // keep track of elements in cache
+                                curNumCacheElements++;
+                                return aggs;
                             }
-                        }
-                        // keep track of elements in cache
-                        curNumCacheElements++;
-                        return aggs;
-                    }
-                });
+                        });
     }
 
     /**
@@ -198,8 +185,8 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
     }
 
     /**
-     * put function of Map interface DO NOT USE Cache takes automatically care
-     * of loading non-existing elements
+     * put function of Map interface DO NOT USE Cache takes automatically care of loading
+     * non-existing elements
      */
     @Override
     public Aggregator[] put(ImmutableBytesPtr key, Aggregator[] value) {
@@ -210,9 +197,8 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
     }
 
     /**
-     * Extract an element from the Cache If element is not present in in-memory
-     * cache / or in spill files cache implements an implicit put() of a new
-     * key/value tuple and loads it into the cache
+     * Extract an element from the Cache If element is not present in in-memory cache / or in spill
+     * files cache implements an implicit put() of a new key/value tuple and loads it into the cache
      */
     @Override
     public Aggregator[] get(Object key) {
@@ -235,8 +221,8 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
     }
 
     /**
-     * This function creates a iterator over the cache and the spilled data
-     * structures. The key/value tuples are returned in non-deterministic order.
+     * This function creates a iterator over the cache and the spilled data structures. The
+     * key/value tuples are returned in non-deterministic order.
      */
     public EntryIterator newEntryIterator() {
         return new EntryIterator();
@@ -302,8 +288,7 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
             // Spilled elements exhausted
             // Finally return all elements from LRU cache
             Map.Entry<ImmutableBytesPtr, Aggregator[]> entry = cacheIter.next();
-            CacheEntry ce = new SpillManager.CacheEntry(entry.getKey(),
-                    entry.getValue());
+            CacheEntry ce = new SpillManager.CacheEntry(entry.getKey(), entry.getValue());
             return ce;
         }
 
@@ -312,8 +297,7 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
          */
         @Override
         public void remove() {
-            throw new IllegalAccessError(
-                    "Remove is not supported for this type of iterator");
+            throw new IllegalAccessError("Remove is not supported for this type of iterator");
         }
     }
 
@@ -322,15 +306,14 @@ public class GroupByCache extends AbstractMap<ImmutableBytesPtr, Aggregator[]> {
      */
     @Override
     public Set<java.util.Map.Entry<ImmutableBytesPtr, Aggregator[]>> entrySet() {
-        throw new IllegalAccessError(
-                "entrySet is not supported for this type of cache");
+        throw new IllegalAccessError("entrySet is not supported for this type of cache");
     }
 
     /**
      * Closes cache and releases spill resources
-     * 
      * @throws IOException
      */
+    @Override
     public void close() throws IOException {
         // Close spillable resources
         Closeables.closeQuietly(spillManager);

--- a/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
+++ b/src/main/java/com/salesforce/phoenix/cache/aggcache/SpillManager.java
@@ -71,7 +71,7 @@ public class SpillManager implements Closeable {
      * @param numSpillFiles
      * @param serverAggregators
      */
-    public SpillManager(int numSpillFiles, ServerAggregators serverAggregators,
+    public SpillManager(int numSpillFiles, int estValueSize, ServerAggregators serverAggregators,
             Configuration conf) {
         try {
             spillMaps = Lists.newArrayList();
@@ -83,7 +83,7 @@ public class SpillManager implements Closeable {
             // Each Spillfile only handles up to 2GB data
             for (int i = 0; i < numSpillFiles; i++) {
                 SpillFile file = SpillFile.createSpillFile();
-                spillMaps.add(new SpillMap(file, SpillFile.DEFAULT_PAGE_SIZE));
+                spillMaps.add(new SpillMap(file, SpillFile.DEFAULT_PAGE_SIZE, estValueSize));
             }
         } catch (IOException ioe) {
             throw new RuntimeException("Could not init the SpillManager");

--- a/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
+++ b/src/main/java/com/salesforce/phoenix/coprocessor/GroupedAggregateRegionObserver.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheStats;
 import com.google.common.collect.Iterators;
 import com.salesforce.phoenix.cache.GlobalCache;
 import com.salesforce.phoenix.cache.TenantCache;
@@ -305,17 +304,6 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
                     }
                 } while (hasMore);
 
-                // check on cache stats
-                if (spillableEnabled) {
-                    CacheStats stats = gbCache.cache.stats();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Load time: " + stats.totalLoadTime());
-                        logger.debug("Load Penalty: " + stats.averageLoadPenalty());
-                        logger.debug("Load Count: " + stats.loadCount());
-                        logger.debug("Eviction Count: " + stats.evictionCount());
-                        logger.debug("HitRate: " + stats.hitRate());
-                    }
-                }
             } finally {
                 region.closeRegionOperation();
             }
@@ -430,14 +418,9 @@ public class GroupedAggregateRegionObserver extends BaseScannerRegionObserver {
             success = true;
 
             if (!spillableEnabled) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("returning non spill iter");
-                }
                 return scanner;
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("returning spill iter");
-            }
+
             return scannerSpillable;
         } finally {
             if (!success) {

--- a/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
+++ b/src/main/java/com/salesforce/phoenix/iterate/MappedByteBufferSortedQueue.java
@@ -27,11 +27,18 @@
  ******************************************************************************/
 package com.salesforce.phoenix.iterate;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
-import java.util.*;
+import java.util.AbstractQueue;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
@@ -271,7 +278,8 @@ public class MappedByteBufferSortedQueue extends AbstractQueue<ResultEntry> {
                     mappingSize = Math.min(Math.max(maxResultSize, DEFAULT_MAPPING_SIZE), totalResultSize);
                     writeBuffer = fc.map(MapMode.READ_WRITE, writeIndex, mappingSize);
                 
-                    for (int i = 0; i < results.size(); i++) {                
+                    int resSize = results.size();
+                    for (int i = 0; i < resSize; i++) {                
                         int totalLen = 0;
                         ResultEntry re = results.pollFirst();
                         List<KeyValue> keyValues = toKeyValues(re);

--- a/src/test/java/com/salesforce/phoenix/end2end/SpillableGroupByTest.java
+++ b/src/test/java/com/salesforce/phoenix/end2end/SpillableGroupByTest.java
@@ -51,7 +51,9 @@ import com.salesforce.phoenix.util.ReadOnlyProps;
 
 public class SpillableGroupByTest extends BaseConnectedQueryTest {
 
-    private static final int NUM_ROWS_INSERTED = 20000;
+    private static final int NUM_ROWS_INSERTED = 1000;
+    
+    // TODO add testcases for other aggregates
     private static String GROUPBY1 = "select "
             + "count(*), sum(appcpu), avg(appcpu) from "
             + GROUPBYTEST_NAME + " group by uri";
@@ -62,7 +64,7 @@ public class SpillableGroupByTest extends BaseConnectedQueryTest {
         Map<String, String> props = Maps.newHashMapWithExpectedSize(1);
         // Set a very small cache size to force plenty of spilling
         props.put(QueryServices.SPGBY_MAX_CACHE_SIZE_ATTRIB,
-                Integer.toString(2048));
+                Integer.toString(300));
         props.put(QueryServices.SPGBY_ENABLED_ATTRIB, String.valueOf(true));
         // Must update config before starting server
         startServer(getUrl(), new ReadOnlyProps(props.entrySet().iterator()));


### PR DESCRIPTION
This pull request includes the following fixes:
- Investigate test failure when number of rows inserted for SpillableGroupByTest is above 50K (#640)
- Explicitly remove memory mapped files instead of using deleteOnExit (#638)

Multiple consistency changes, and cleanUp fixes.
SpillableGroupByTestcase only inserts 1000 rows to improve performance.
