### PR TITLE
Disallow array type to be used in primary key constraint

### DIFF
--- a/phoenix-core/src/main/java/com/salesforce/phoenix/exception/SQLExceptionCode.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/exception/SQLExceptionCode.java
@@ -94,6 +94,7 @@ public enum SQLExceptionCode {
     PRIMARY_KEY_ALREADY_EXISTS(510, "42889", "The table already has a primary key."),
     ORDER_BY_NOT_IN_SELECT_DISTINCT(511, "42890", "All ORDER BY expressions must appear in SELECT DISTINCT:"),
     INVALID_PRIMARY_KEY_CONSTRAINT(512, "42891", "Invalid column reference in primary key constraint"),
+    INVALID_ARRAY_TYPE_AS_PRIMARY_KEY_CONSTRAINT(513, "42892", "Array type not allowed as primary key constraint"),
     
     /** 
      * HBase and Phoenix specific implementation defined sub-classes.

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/schema/MetaDataClient.java
@@ -718,6 +718,11 @@ public class MetaDataClient {
                         throw new SQLExceptionInfo.Builder(SQLExceptionCode.CREATE_TENANT_TABLE_NO_PK)
                             .setColumnName(colDef.getColumnDefName().getColumnName()).build().buildException();
                     }
+                    // disallow array type usage in primary key constraint
+                    if (colDef.isArray()) {
+                        throw new SQLExceptionInfo.Builder(SQLExceptionCode.INVALID_ARRAY_TYPE_AS_PRIMARY_KEY_CONSTRAINT)
+                        .setColumnName(colDef.getColumnDefName().getColumnName()).build().buildException();
+                    }
                     if (!pkColumns.add(column)) {
                         throw new ColumnAlreadyExistsException(schemaName, tableName, column.getName().getString());
                     }

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/compile/QueryCompileTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/compile/QueryCompileTest.java
@@ -1193,4 +1193,31 @@ public class QueryCompileTest extends BaseConnectionlessQueryTest {
             assertEquals(SQLExceptionCode.TYPE_MISMATCH.getErrorCode(), e.getErrorCode());
         }
     }
+    @Test
+    public void testInvalidArrayTypeAsPK () throws Exception {
+        Connection conn = DriverManager.getConnection(getUrl());
+        try {
+            String query = "CREATE TABLE foo (col1 INTEGER[10] NOT NULL PRIMARY KEY)";
+            PreparedStatement statement = conn.prepareStatement(query);
+            statement.execute();
+            fail();
+        } catch (SQLException e) {
+                assertTrue(e.getMessage(), e.getMessage().contains("ERROR 513 (42892): Array type not allowed as primary key constraint"));
+        } finally {
+                conn.close();
+        }
+
+        conn = DriverManager.getConnection(getUrl());
+        try {
+            String query = "CREATE TABLE foo (col1 VARCHAR, col2 INTEGER ARRAY[10] CONSTRAINT pk PRIMARY KEY (col1, col2))";
+            PreparedStatement statement = conn.prepareStatement(query);
+            statement.execute();
+            fail();
+        } catch (SQLException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("ERROR 513 (42892): Array type not allowed as primary key constraint"));
+        } finally {
+            conn.close();
+        }
+    }
+
  }


### PR DESCRIPTION
https://github.com/forcedotcom/phoenix/issues/649
