### PR TITLE
ArrayLength function

### DIFF
--- a/phoenix-core/src/main/java/com/salesforce/phoenix/expression/ExpressionType.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/expression/ExpressionType.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import com.salesforce.phoenix.expression.function.ArrayIndexFunction;
+import com.salesforce.phoenix.expression.function.ArrayLengthFunction;
 import com.salesforce.phoenix.expression.function.CeilDateExpression;
 import com.salesforce.phoenix.expression.function.CeilDecimalExpression;
 import com.salesforce.phoenix.expression.function.CeilFunction;
@@ -156,7 +157,8 @@ public enum ExpressionType {
     ProjectedColumnExpression(ProjectedColumnExpression.class),
     TimestampAddExpression(TimestampAddExpression.class),
     TimestampSubtractExpression(TimestampSubtractExpression.class),
-    ArrayIndexFunction(ArrayIndexFunction.class);
+    ArrayIndexFunction(ArrayIndexFunction.class),
+    ArrayLengthFunction(ArrayLengthFunction.class);
     
     ExpressionType(Class<? extends Expression> clazz) {
         this.clazz = clazz;

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/expression/function/ArrayLengthFunction.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/expression/function/ArrayLengthFunction.java
@@ -62,14 +62,17 @@ public class ArrayLengthFunction extends ScalarFunction {
 		PDataType baseType = PDataType.fromTypeId(children.get(0).getDataType()
 				.getSqlType()
 				- Types.ARRAY);
-		PArrayDataType.getArrayElement(ptr, baseType);
+		int length = PArrayDataType.getArrayLength(ptr, baseType);
+		byte[] lengthBuf = new byte[PDataType.INTEGER.getByteSize()];
+		PDataType.INTEGER.getCodec().encodeInt(length, lengthBuf, 0);
+		ptr.set(lengthBuf);
 		return true;
 	}
 
 	@Override
 	public PDataType getDataType() {
 		// Array length will return an Integer
-		return PDataType.VARBINARY;
+		return PDataType.INTEGER;
 	}
 
 	@Override

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/expression/function/ArrayLengthFunction.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/expression/function/ArrayLengthFunction.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2013, Salesforce.com, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *     Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *     Neither the name of Salesforce.com nor the names of its contributors may 
+ *     be used to endorse or promote products derived from this software without 
+ *     specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+package com.salesforce.phoenix.expression.function;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+
+import com.salesforce.phoenix.expression.Expression;
+import com.salesforce.phoenix.parse.FunctionParseNode.Argument;
+import com.salesforce.phoenix.parse.FunctionParseNode.BuiltInFunction;
+import com.salesforce.phoenix.schema.PArrayDataType;
+import com.salesforce.phoenix.schema.PDataType;
+import com.salesforce.phoenix.schema.tuple.Tuple;
+
+@BuiltInFunction(name = ArrayLengthFunction.NAME, args = { @Argument(allowedTypes = {
+		PDataType.BINARY_ARRAY, PDataType.VARBINARY_ARRAY }) })
+public class ArrayLengthFunction extends ScalarFunction {
+	public static final String NAME = "ARRAY_LENGTH";
+
+	public ArrayLengthFunction() {
+	}
+
+	public ArrayLengthFunction(List<Expression> children) {
+		super(children);
+	}
+
+	@Override
+	public boolean evaluate(Tuple tuple, ImmutableBytesWritable ptr) {
+		Expression arrayExpr = children.get(0);
+		if (!arrayExpr.evaluate(tuple, ptr)) {
+			return false;
+		} else if (ptr.getLength() == 0) {
+			return true;
+		}
+		PDataType baseType = PDataType.fromTypeId(children.get(0).getDataType()
+				.getSqlType()
+				- Types.ARRAY);
+		PArrayDataType.getArrayElement(ptr, baseType);
+		return true;
+	}
+
+	@Override
+	public PDataType getDataType() {
+		// Array length will return an Integer
+		return PDataType.VARBINARY;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+}

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/schema/PArrayDataType.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/schema/PArrayDataType.java
@@ -151,15 +151,7 @@ public class PArrayDataType {
 		byte[] bytes = ptr.get();
 		int initPos = ptr.getOffset();
 		int noOfElements = 0;
-		// As no of elements is written as Vint we need to know how many bytes does this occupy
-/*		try {
-			// One byte for version
-			noOfElements = (int)Bytes.readVLong(bytes, initPos + Bytes.SIZEOF_BYTE);
-		} catch(IOException ioe) {
-			throw new RuntimeException(ioe);
-		}*/
 		noOfElements = Bytes.toInt(bytes, ptr.getOffset() + Bytes.SIZEOF_BYTE, Bytes.SIZEOF_INT);
-		//int noOFElementsSize = WritableUtils.getVIntSize(noOfElements);
 		int noOFElementsSize = Bytes.SIZEOF_INT;
 		if(arrayIndex >= noOfElements) {
 			throw new IndexOutOfBoundsException(
@@ -274,7 +266,6 @@ public class PArrayDataType {
         if (buffer == null) return null;
         buffer.put(ARRAY_SERIALIZATION_VERSION);
         buffer.putInt(noOfElements);
-        //ByteBufferUtils.writeVLong(buffer, noOfElements);
         if (byteSize == null) {
             int fillerForOffsetByteArray = buffer.position();
             buffer.position(fillerForOffsetByteArray + Bytes.SIZEOF_INT);
@@ -319,7 +310,6 @@ public class PArrayDataType {
 		ByteBuffer buffer = ByteBuffer.wrap(bytes, offset, length);
 		int initPos = buffer.position();
 		buffer.get();
-		//int noOfElements = (int) ByteBufferUtils.readVLong(buffer);
 		int noOfElements = buffer.getInt();
 		boolean useShort = true;
 		int baseSize = Bytes.SIZEOF_SHORT;
@@ -414,22 +404,13 @@ public class PArrayDataType {
 		return 1;
 	}
 
-	public static void getArrayElement(ImmutableBytesWritable ptr,
+	public static int getArrayLength(ImmutableBytesWritable ptr,
 			PDataType baseType) {
 		byte[] bytes = ptr.get();
-		int initPos = ptr.getOffset();
-		/* int noOfElements = 0;
-		// As no of elements is written as Vint we need to know how many bytes does this occupy
-		try {
-			// One byte for version
-			noOfElements = (int)Bytes.readVLong(bytes, initPos + Bytes.SIZEOF_BYTE);
-		} catch(IOException ioe) {
-			throw new RuntimeException(ioe);
+		if(baseType.isFixedWidth()) {
+			return ((ptr.getLength() - (Bytes.SIZEOF_BYTE + Bytes.SIZEOF_INT))/baseType.getByteSize());
 		}
-		int noOFElementsSize = WritableUtils.getVIntSize(noOfElements);*/
-		int noOfElements = Bytes.toInt(bytes, ptr.getOffset() + Bytes.SIZEOF_BYTE);
-		//int noOFElementsSize = WritableUtils.getVIntSize(noOfElements);
-		ptr.set(bytes, initPos + Bytes.SIZEOF_BYTE, Bytes.SIZEOF_INT);
+		return Bytes.toInt(bytes, ptr.getOffset() + Bytes.SIZEOF_BYTE);
 	}
 
 }

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/schema/PDataType.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/schema/PDataType.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Base64;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.io.WritableUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.math.LongMath;
@@ -5312,7 +5311,8 @@ public enum PDataType {
         if(isArrayType()) {
             PhoenixArray array = (PhoenixArray)o;
             int noOfElements = array.numElements;
-            int vIntSize = WritableUtils.getVIntSize(noOfElements);
+            //int vIntSize = WritableUtils.getVIntSize(noOfElements);
+            int vIntSize = Bytes.SIZEOF_INT;
 
             int totalVarSize = 0;
             for (int i = 0; i < noOfElements; i++) {

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/ArrayTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/ArrayTest.java
@@ -427,13 +427,38 @@ public class ArrayTest extends BaseClientMangedTimeTest {
 	}
 
 	@Test
-	public void testArrayLengthFunction() throws Exception {
+	public void testArrayLengthFunctionForVariableLength() throws Exception {
 		long ts = nextTimestamp();
 		String tenantId = getOrganizationId();
 		createTableWithArray(BaseConnectedQueryTest.getUrl(),
 				getDefaultSplits(tenantId), null, ts - 2);
 		initTablesWithArrays(tenantId, null, ts, false);
 		String query = "SELECT ARRAY_LENGTH(a_string_array) FROM table_with_array";
+		Properties props = new Properties(TEST_PROPERTIES);
+		props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB,
+				Long.toString(ts + 2)); // Execute at timestamp 2
+		Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+		try {
+			PreparedStatement statement = conn.prepareStatement(query);
+			ResultSet rs = statement.executeQuery();
+			assertTrue(rs.next());			
+			int result = rs.getInt(1);
+			assertEquals(result, 4);
+			assertFalse(rs.next());
+		} finally {
+			conn.close();
+		}
+	}
+	
+
+	@Test
+	public void testArrayLengthFunctionForFixedLength() throws Exception {
+		long ts = nextTimestamp();
+		String tenantId = getOrganizationId();
+		createTableWithArray(BaseConnectedQueryTest.getUrl(),
+				getDefaultSplits(tenantId), null, ts - 2);
+		initTablesWithArrays(tenantId, null, ts, false);
+		String query = "SELECT ARRAY_LENGTH(a_double_array) FROM table_with_array";
 		Properties props = new Properties(TEST_PROPERTIES);
 		props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB,
 				Long.toString(ts + 2)); // Execute at timestamp 2

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/ArrayTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/ArrayTest.java
@@ -426,6 +426,29 @@ public class ArrayTest extends BaseClientMangedTimeTest {
 		}
 	}
 
+	@Test
+	public void testArrayLengthFunction() throws Exception {
+		long ts = nextTimestamp();
+		String tenantId = getOrganizationId();
+		createTableWithArray(BaseConnectedQueryTest.getUrl(),
+				getDefaultSplits(tenantId), null, ts - 2);
+		initTablesWithArrays(tenantId, null, ts, false);
+		String query = "SELECT ARRAY_LENGTH(a_string_array) FROM table_with_array";
+		Properties props = new Properties(TEST_PROPERTIES);
+		props.setProperty(PhoenixRuntime.CURRENT_SCN_ATTRIB,
+				Long.toString(ts + 2)); // Execute at timestamp 2
+		Connection conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+		try {
+			PreparedStatement statement = conn.prepareStatement(query);
+			ResultSet rs = statement.executeQuery();
+			assertTrue(rs.next());			
+			int result = rs.getInt(1);
+			assertEquals(result, 4);
+			assertFalse(rs.next());
+		} finally {
+			conn.close();
+		}
+	}
 	static void createTableWithArray(String url, byte[][] bs, Object object,
 			long ts) throws SQLException {
 		String ddlStmt = "create table "

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/schema/PDataTypeForArraysTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/schema/PDataTypeForArraysTest.java
@@ -155,6 +155,28 @@ public class PDataTypeForArraysTest {
 		System.arraycopy(bs, offset, res, 0, length);
 		assertEquals("ranzzz", Bytes.toString(res));
 	}
+	
+	@Test
+	public void testGetArrayLength() {
+		String[] strArr = new String[5];
+		strArr[0] = "abx";
+		strArr[1] = "ereref";
+		strArr[2] = "random";
+		strArr[3] = "random12";
+		strArr[4] = "ranzzz";
+		PhoenixArray arr = PArrayDataType.instantiatePhoenixArray(
+				PDataType.VARCHAR, strArr);
+		byte[] bytes = PDataType.VARCHAR_ARRAY.toBytes(arr);
+		ImmutableBytesWritable ptr = new ImmutableBytesWritable(bytes);
+		PArrayDataType.getArrayElement(ptr, PDataType.VARCHAR);
+		int offset = ptr.getOffset();
+		int length = ptr.getLength();
+		byte[] bs = ptr.get();
+		byte[] res = new byte[length];
+		System.arraycopy(bs, offset, res, 0, length);
+		int result = Bytes.toInt(res, 0, 4);
+		assertEquals(5, result);
+	}
 
 	@Test
 	public void testForVarCharArrayForOddNumberWithIndex() {

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/schema/PDataTypeForArraysTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/schema/PDataTypeForArraysTest.java
@@ -157,7 +157,7 @@ public class PDataTypeForArraysTest {
 	}
 	
 	@Test
-	public void testGetArrayLength() {
+	public void testGetArrayLengthForVariableLengthArray() {
 		String[] strArr = new String[5];
 		strArr[0] = "abx";
 		strArr[1] = "ereref";
@@ -168,13 +168,7 @@ public class PDataTypeForArraysTest {
 				PDataType.VARCHAR, strArr);
 		byte[] bytes = PDataType.VARCHAR_ARRAY.toBytes(arr);
 		ImmutableBytesWritable ptr = new ImmutableBytesWritable(bytes);
-		PArrayDataType.getArrayElement(ptr, PDataType.VARCHAR);
-		int offset = ptr.getOffset();
-		int length = ptr.getLength();
-		byte[] bs = ptr.get();
-		byte[] res = new byte[length];
-		System.arraycopy(bs, offset, res, 0, length);
-		int result = Bytes.toInt(res, 0, 4);
+		int result = PArrayDataType.getArrayLength(ptr, PDataType.VARCHAR);
 		assertEquals(5, result);
 	}
 
@@ -254,6 +248,22 @@ public class PDataTypeForArraysTest {
 		System.arraycopy(bs, offset, res, 0, length);
 		long result = (Long) PDataType.LONG.toObject(res);
 		assertEquals(4l, result);
+	}
+	
+	@Test
+	public void testGetArrayLengthForFixedLengthArray() {
+		Long[] longArr = new Long[4];
+		longArr[0] = 1l;
+		longArr[1] = 2l;
+		longArr[2] = 4l;
+		longArr[3] = 5l;
+		PhoenixArray arr = PArrayDataType.instantiatePhoenixArray(
+				PDataType.LONG, longArr);
+		PDataType.LONG_ARRAY.toObject(arr, PDataType.LONG_ARRAY);
+		byte[] bytes = PDataType.LONG_ARRAY.toBytes(arr);
+		ImmutableBytesWritable ptr = new ImmutableBytesWritable(bytes);
+		int length = PArrayDataType.getArrayLength(ptr, PDataType.LONG);
+		assertEquals(4, length);
 	}
 
 	@Test


### PR DESCRIPTION
I have made changes to change the Vint for array elements to Integer.  If I have the return type as VARBINARY for the vint still it is not able to decode the integer stored in a single byte.
Now after changing it to Integer still for the ArrayLengthFunction am not able to use PDataType.INTEGER as the return type but using PDataType.VARBINARY works.
This may not be the final version if you feel some changes on the above are required.
