### PR TITLE
Support running end2end tests against 'real' hbase cluster

### DIFF
--- a/phoenix-core/src/main/java/com/salesforce/phoenix/jdbc/PhoenixDriver.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/jdbc/PhoenixDriver.java
@@ -70,7 +70,7 @@ public final class PhoenixDriver extends PhoenixEmbeddedDriver {
     @Override
     public boolean acceptsURL(String url) throws SQLException {
         // Accept the url only if test=true attribute not set
-        return super.acceptsURL(url) && !(url.endsWith(";test=true") || url.contains(";test=true;"));
+        return super.acceptsURL(url) && !isTestUrl(url);
     }
 
     @Override

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/jdbc/PhoenixEmbeddedDriver.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/jdbc/PhoenixEmbeddedDriver.java
@@ -326,4 +326,8 @@ public abstract class PhoenixEmbeddedDriver implements Driver, com.salesforce.ph
             return zookeeperQuorum + (port == null ? "" : ":" + port) + (rootNode == null ? "" : ":" + rootNode);
         }
     }
+
+    public static boolean isTestUrl(String url) {
+        return url.endsWith(";test=true") || url.contains(";test=true;");
+    }
 }

--- a/phoenix-core/src/main/java/com/salesforce/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/com/salesforce/phoenix/query/ConnectionQueryServicesImpl.java
@@ -62,6 +62,9 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.util.VersionInfo;
+import org.apache.hadoop.hbase.zookeeper.ZKAssign;
+import org.apache.hadoop.hbase.zookeeper.ZKConfig;
+import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -603,6 +606,7 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
         boolean isMetaTable = SchemaUtil.isMetaTable(tableName);
         boolean tableExist = true;
         try {
+            System.out.println("Found quorum: " + ZKConfig.getZKQuorumServersString(config));
             admin = new HBaseAdmin(config);
             try {
                 existingDesc = admin.getTableDescriptor(tableName);

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/BaseConnectedQueryTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/end2end/BaseConnectedQueryTest.java
@@ -96,6 +96,13 @@ import com.salesforce.phoenix.util.TestUtil;
  * @since 0.1
  */
 public abstract class BaseConnectedQueryTest extends BaseTest {
+
+    private static String TEST_URL = TestUtil.PHOENIX_JDBC_URL;
+
+    public static void setUrl(String url) {
+        BaseConnectedQueryTest.TEST_URL = url;
+    }
+
     protected static byte[][] getDefaultSplits(String tenantId) {
         return new byte[][] { 
             Bytes.toBytes(tenantId + "00A"),
@@ -105,7 +112,7 @@ public abstract class BaseConnectedQueryTest extends BaseTest {
     }
     
     protected static String getUrl() {
-        return TestUtil.PHOENIX_JDBC_URL;
+        return TEST_URL;
     }
 
     @BeforeClass
@@ -126,7 +133,7 @@ public abstract class BaseConnectedQueryTest extends BaseTest {
         if (tenantId != null) {
             props.setProperty(TENANT_ID_ATTRIB, tenantId);
             try {
-                conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+                conn = DriverManager.getConnection(getUrl(), props);
                 deletePriorTables(ts, conn);
                 deletePriorSequences(ts, conn);
             }
@@ -135,7 +142,7 @@ public abstract class BaseConnectedQueryTest extends BaseTest {
             }
             props.remove(TENANT_ID_ATTRIB);
         }
-        conn = DriverManager.getConnection(PHOENIX_JDBC_URL, props);
+        conn = DriverManager.getConnection(getUrl(), props);
         try {
             deletePriorTables(ts, conn);
             deletePriorSequences(ts, conn);

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/jdbc/PhoenixTestDriver.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/jdbc/PhoenixTestDriver.java
@@ -60,7 +60,7 @@ public class PhoenixTestDriver extends PhoenixEmbeddedDriver {
     @Override
     public boolean acceptsURL(String url) throws SQLException {
         // Accept the url only if test=true attribute set
-        return super.acceptsURL(url) && (url.endsWith(";test=true") || url.contains(";test=true;"));
+        return super.acceptsURL(url) && isTestUrl(url);
     }
 
     @Override // public for testing

--- a/phoenix-core/src/test/java/com/salesforce/phoenix/query/BaseTest.java
+++ b/phoenix-core/src/test/java/com/salesforce/phoenix/query/BaseTest.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.junit.AfterClass;
 
 import com.google.common.collect.ImmutableMap;
+import com.salesforce.phoenix.jdbc.PhoenixEmbeddedDriver;
 import com.salesforce.phoenix.jdbc.PhoenixTestDriver;
 import com.salesforce.phoenix.schema.TableAlreadyExistsException;
 import com.salesforce.phoenix.util.PhoenixRuntime;
@@ -415,8 +416,12 @@ public abstract class BaseTest {
 
     protected static void startServer(String url, ReadOnlyProps props) throws Exception {
         assertNull(BaseTest.driver);
-        PhoenixTestDriver driver = initDriver(new QueryServicesTestImpl(props));
-        assertTrue(DriverManager.getDriver(url) == driver);
+        // only load the test driver if we are testing locally - for integration tests, we want to
+        // test on a wider scale
+        if (PhoenixEmbeddedDriver.isTestUrl(url)) {
+            PhoenixTestDriver driver = initDriver(new QueryServicesTestImpl(props));
+            assertTrue(DriverManager.getDriver(url) == driver);
+        }
     }
     
     protected static void startServer(String url) throws Exception {


### PR DESCRIPTION
By setting the test url in the BaseConnectedQueryTest, you can then point any test at the cluster of your choice.
